### PR TITLE
fix: production hardening — auth on, no public MinIO, resource limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate docker-compose.yml
+        env:
+          DAKERA_ROOT_API_KEY: ci-validation-placeholder
         run: docker compose -f docker/docker-compose.yml config --quiet
 
       - name: Validate docker-compose.dev.yml

--- a/README.md
+++ b/README.md
@@ -47,8 +47,16 @@ docker compose -f docker-compose.dev.yml up -d
 
 Production-grade single-node deployment with MinIO, caching, and health checks.
 
+**First-time setup — configure credentials before starting:**
+
 ```bash
 cd docker
+cp .env.example .env
+# Edit .env — set DAKERA_ROOT_API_KEY and MinIO credentials
+# Generate a strong key: openssl rand -hex 32
+```
+
+```bash
 docker compose up -d
 ```
 
@@ -259,6 +267,20 @@ docker compose -f docker-compose.ha.yml start dakera-3
 ```bash
 docker compose -f docker-compose.dev.yml up -d --build
 ```
+
+## Security
+
+Before deploying to a production or internet-facing environment:
+
+| Requirement | How |
+|-------------|-----|
+| Enable authentication | `DAKERA_AUTH_ENABLED=true` (default in production compose) |
+| Set a strong root API key | `DAKERA_ROOT_API_KEY=$(openssl rand -hex 32)` |
+| Change MinIO credentials | Set `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` in `.env` |
+| Network isolation | Do **not** expose MinIO ports (9000, 9001) publicly |
+| TLS termination | Use a reverse proxy (nginx, Traefik, Caddy) with HTTPS |
+
+See [CONFIGURATION.md](https://github.com/dakera-ai/dakera-docs/blob/main/CONFIGURATION.md) for the full authentication reference.
 
 ## Related Repositories
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,37 +1,61 @@
 # =============================================================================
 # Dakera Deploy — Environment Configuration
 # =============================================================================
-# Copy this file to .env and customize as needed:
+# Copy this file to .env and fill in REQUIRED values before starting:
 #   cp .env.example .env
+#   # Edit .env, then:
+#   docker compose up -d
 #
-# All values have sensible defaults — you only need to set what you change.
+# IMPORTANT: Never commit .env to version control.
 # =============================================================================
 
-# --- Dakera Images ---
-# DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:latest
-# DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:latest
+# =============================================================================
+# Authentication (REQUIRED for production)
+# =============================================================================
 
-# --- Dakera Settings ---
-# DAKERA_AUTH_ENABLED=false
-# DAKERA_ROOT_API_KEY=dk_dev_root_key_change_in_production
-# RUST_LOG=info,dakera=debug
+# Enable API key authentication — required for any internet-facing deployment
+DAKERA_AUTH_ENABLED=true
 
-# --- Port Mapping ---
+# Root API key — generate a strong random key before deploying:
+#   openssl rand -hex 32
+DAKERA_ROOT_API_KEY=
+
+# =============================================================================
+# MinIO Credentials (REQUIRED — change from defaults)
+# =============================================================================
+
+# Change these from the defaults before deploying:
+#   openssl rand -hex 16
+MINIO_ROOT_USER=
+MINIO_ROOT_PASSWORD=
+
+# =============================================================================
+# Port Mapping (optional — uncomment to override defaults)
+# =============================================================================
+
+# DAKERA_PORT=3000
+# DAKERA_GRPC_PORT=50051
 # LB_HTTP_PORT=3000
 # LB_GRPC_PORT=50051
 # TRAEFIK_DASHBOARD_PORT=8080
 # DASHBOARD_PORT=3002
 # MINIO_API_PORT=9000
 # MINIO_CONSOLE_PORT=9001
-# REDIS_PORT=6379
 # PROMETHEUS_PORT=9090
 # GRAFANA_PORT=3003
 # JAEGER_UI_PORT=16686
 
-# --- MinIO Credentials ---
-# MINIO_ROOT_USER=minioadmin
-# MINIO_ROOT_PASSWORD=minioadmin
+# =============================================================================
+# Docker Images (optional — defaults to latest published images)
+# =============================================================================
 
-# --- Grafana Credentials ---
+# DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:latest
+# DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:latest
+
+# =============================================================================
+# Observability (optional)
+# =============================================================================
+
+# RUST_LOG=info
 # GRAFANA_USER=admin
 # GRAFANA_PASSWORD=dakera

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,11 +40,19 @@ services:
       - DAKERA_AUTO_TIER=true
       - DAKERA_TIER_CHECK_INTERVAL_SECS=300
       - DAKERA_MAX_BODY_SIZE=524288000
-      - DAKERA_AUTH_ENABLED=${DAKERA_AUTH_ENABLED:-false}
-      - DAKERA_ROOT_API_KEY=${DAKERA_ROOT_API_KEY:-dk_dev_root_key_change_in_production}
+      - DAKERA_AUTH_ENABLED=${DAKERA_AUTH_ENABLED:-true}
+      - DAKERA_ROOT_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.example)}
     volumes:
       - dakera-cache:/data/cache
       - dakera-rocksdb:/data/rocksdb
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+        reservations:
+          memory: 512M
+          cpus: "0.5"
     depends_on:
       minio-setup:
         condition: service_completed_successfully
@@ -73,6 +81,14 @@ services:
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
     volumes:
       - minio-data:/data
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1.0"
+        reservations:
+          memory: 256M
+          cpus: "0.25"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 10s
@@ -95,7 +111,6 @@ services:
       /bin/sh -c "
       mc alias set myminio http://minio:9000 $${MINIO_ROOT_USER:-minioadmin} $${MINIO_ROOT_PASSWORD:-minioadmin};
       mc mb myminio/dakera --ignore-existing;
-      mc anonymous set download myminio/dakera;
       echo 'Dakera bucket ready';
       exit 0;
       "
@@ -113,7 +128,7 @@ services:
       - "${DASHBOARD_PORT:-3002}:3000"
     environment:
       - DAKERA_API_UPSTREAM=http://dakera:3000
-      - DAKERA_API_KEY=${DAKERA_ROOT_API_KEY:-dk_dev_root_key_change_in_production}
+      - DAKERA_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.example)}
     depends_on:
       dakera:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Production readiness fixes for the default `docker-compose.yml` deployment config ahead of public launch.

- **Auth enabled by default**: `DAKERA_AUTH_ENABLED` now defaults to `true` (was `false`). The binary already defaults to `true` per CONFIGURATION.md — the compose was overriding it in the wrong direction.
- **`DAKERA_ROOT_API_KEY` is now required**: Removed the `dk_dev_root_key_change_in_production` fallback. Users must set a real key in `.env` before `docker compose up` — compose will fail with a clear message if unset.
- **Removed anonymous MinIO bucket access**: `mc anonymous set download myminio/dakera` was making all vector data publicly readable. Removed.
- **Resource limits added**: Dakera capped at 4G/2cpu, MinIO at 2G/1cpu to prevent runaway resource usage.
- **`.env.example` updated**: Now guides users to generate strong credentials with `openssl rand -hex 32` before deploying.
- **README Security section added**: Pre-launch checklist covering auth, credentials, network isolation, and TLS.

## What was already good

- Persistent storage via named volumes ✓
- Health checks with proper intervals ✓
- `restart: unless-stopped` ✓
- S3 storage (MinIO) configured ✓
- Correct port bindings (3000 REST, 50051 gRPC) ✓
- Prometheus metrics at `/metrics` ✓
- Pre-configured Grafana dashboards ✓
- Multi-stage Dockerfiles ✓
- `.env` correctly gitignored ✓

## Test plan

- [ ] `cp .env.example .env` — verify it fails without setting `DAKERA_ROOT_API_KEY`
- [ ] Set `DAKERA_ROOT_API_KEY` in `.env` and verify `docker compose up -d` succeeds
- [ ] Confirm unauthenticated requests return 401
- [ ] Verify MinIO bucket is not anonymously accessible after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)