### PR TITLE
docs: SA-2026-001 security fix in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the Dakera deployment configurations will be documented in this file.
 
+## [Unreleased]
+
+### Security — SA-2026-001 (Critical)
+
+Three critical insecure-default vulnerabilities were found in the default Docker Compose configuration
+and fixed in [dakera-deploy PR #1](https://github.com/Dakera-AI/dakera-deploy/pull/1).
+
+**Affected versions:** v0.1.0 and any deployment using the default `docker-compose.yml` without
+overriding the affected variables.
+
+**Vulnerabilities fixed:**
+
+1. **Auth disabled by default** (`DAKERA_AUTH_ENABLED=false`): The default Compose config shipped
+   with authentication disabled, leaving the API open with no key enforcement. Fixed: default is
+   now `true`; the env var is also required (startup fails if unset).
+
+2. **Public MinIO bucket**: The `minio-setup` init container set the storage bucket policy to
+   anonymous download (`mc anonymous set download`), exposing all stored vector data to
+   unauthenticated reads. Fixed: anonymous access policy removed.
+
+3. **Hardcoded dev API key fallback** (`dk_dev_root_key_change_in_production`): The root API key
+   fell back to a well-known dev string if not overridden. Fixed: the variable is now required with
+   no default; containers refuse to start until a real key is supplied in `.env`.
+
+**Action required for existing deployments:**
+
+See [Security Advisory SA-2026-001](https://github.com/Dakera-AI/dakera-docs/blob/main/SECURITY.md#sa-2026-001)
+in dakera-docs for the full advisory, impact assessment, and remediation steps.
+
+### Changed
+
+- `docker-compose.yml`: `DAKERA_AUTH_ENABLED` default changed from `false` to `true`
+- `docker-compose.yml`: `DAKERA_ROOT_API_KEY` is now required (no default fallback)
+- `docker-compose.yml`: MinIO bucket anonymous-download policy removed
+- `docker-compose.yml`: Resource limits added for `dakera` and `minio` services
+- `docker/.env.example`: Restructured with required fields prominently at top
+- `README.md`: Security section added with production hardening requirements
+
 ## [0.1.0] - 2025-03-15
 
 ### Added


### PR DESCRIPTION
## Summary

- Documents the three critical insecure-default vulnerabilities fixed in PR #1 (`fix/production-hardening`)
- Adds `[Unreleased]` entry in CHANGELOG with full details: auth-disabled default, public MinIO bucket, hardcoded dev API key fallback
- Includes `Action required for existing deployments` pointer to the full advisory in dakera-docs

## Related

- Security fix: #1 (fix/production-hardening) — must be merged alongside or before this
- Advisory doc: dakera-docs `docs/security-advisory-sa-2026-001` branch

## Test plan

- [ ] CHANGELOG renders correctly
- [ ] Links to advisory and fix PR resolve correctly once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)