### PR TITLE
security: add explicit GITHUB_TOKEN permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Docker Configs


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to restrict GITHUB_TOKEN to read-only for CI workflows
- Limits blast radius if a compromised third-party action attempts unauthorized writes
- Follows [GitHub GITHUB_TOKEN hardening best practices](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## What changed

All CI jobs only need to checkout code (`contents: read`). No job writes to the repository, packages, or other GitHub resources during CI.

## Test plan
- [ ] CI passes with new permissions block
- [ ] No jobs fail due to permission denial

🤖 Generated with [Claude Code](https://claude.com/claude-code)