### PR TITLE
fix: valid no-op release workflow (stop workflow file failures)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,25 @@
-# NOTE: Docker image publishing is handled by the main dakera repo.
+name: Release
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+# Docker image publishing is handled by the main dakera repo.
 # dakera-deploy releases are for deployment config updates only.
-# This workflow is intentionally empty — no Docker build needed here.
+
+permissions:
+  contents: read
+
+jobs:
+  release-info:
+    name: Release Info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log release
+        run: |
+          echo "Deployment config release: ${{ github.ref_name }}"
+          echo "Docker image publishing is handled by the main dakera repo."
+          echo "No build artifacts needed for config-only releases."


### PR DESCRIPTION
## Problem

The `release.yml` workflow file (from PR #6) was left as comment-only YAML — no `name:`, `on:`, or `jobs:` keys. GitHub Actions parses this as an invalid workflow and fails every triggered run with:

> This run likely failed because of a workflow file issue.

This has been failing on every `push` to `main` since the change was merged.

## Fix

Replace the comment-only file with a minimal valid GHA workflow that has one job and one echo step. The job clearly states that Docker publishing is handled by the main `dakera` repo.

## Test Plan

- [ ] CI shows green on this PR
- [ ] No more workflow file errors on `dakera-deploy` main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)