### PR TITLE
feat(dx5): VS Code/Cursor devcontainer — one-command local dev stack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,89 @@
+{
+  // Dakera local dev environment for VS Code / Cursor
+  // Opens a workspace with Dakera + MinIO running as sidecar services.
+  // No credentials or local installs required — everything runs in Docker.
+  "name": "Dakera Local Dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "workspace",
+  "workspaceFolder": "/workspace",
+
+  // Forward Dakera and MinIO ports to localhost
+  "forwardPorts": [3000, 50051, 9000, 9001],
+  "portsAttributes": {
+    "3000": {
+      "label": "Dakera REST API",
+      "onAutoForward": "silent"
+    },
+    "50051": {
+      "label": "Dakera gRPC",
+      "onAutoForward": "silent"
+    },
+    "9000": {
+      "label": "MinIO S3 API",
+      "onAutoForward": "silent"
+    },
+    "9001": {
+      "label": "MinIO Console",
+      "onAutoForward": "openBrowser"
+    }
+  },
+
+  // Language runtimes for SDK development
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": false,
+      "upgradePackages": false
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "stable"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.22"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Rust
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        // Python
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        // TypeScript / Node
+        "ms-vscode.vscode-typescript-next",
+        // Go
+        "golang.go",
+        // Tools
+        "humao.rest-client",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  },
+
+  // Install Dakera SDKs and print connection info after the container starts
+  "postCreateCommand": "pip install --quiet dakera 2>/dev/null || true; npm install --quiet -g dakera 2>/dev/null || true; echo '' && echo '=== Dakera local dev stack ready ===' && echo '  REST API:      http://localhost:3000' && echo '  gRPC:          localhost:50051' && echo '  MinIO Console: http://localhost:9001  (minioadmin / minioadmin)' && echo '  Auth:          disabled (local dev only)' && echo ''",
+
+  // Environment variables available in the workspace shell
+  "remoteEnv": {
+    "DAKERA_API_URL": "http://dakera:3000",
+    "DAKERA_GRPC_URL": "dakera:50051",
+    "DAKERA_ROOT_API_KEY": "dev-local-insecure-key"
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,117 @@
+# =============================================================================
+# Dakera Local Dev Stack — devcontainer services
+# =============================================================================
+# Used by .devcontainer/devcontainer.json.
+# Starts Dakera + MinIO alongside the VS Code / Cursor workspace container.
+#
+# Auth is intentionally disabled for local development.
+# Do NOT use this configuration in production or any internet-facing deployment.
+# =============================================================================
+
+services:
+  # VS Code / Cursor workspace container
+  workspace:
+    image: mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+    volumes:
+      - ../:/workspace:cached
+      - dakera-vscode-ext:/root/.vscode-server/extensions
+    environment:
+      - DAKERA_API_URL=http://dakera:3000
+      - DAKERA_GRPC_URL=dakera:50051
+      - DAKERA_ROOT_API_KEY=dev-local-insecure-key
+    command: sleep infinity
+    depends_on:
+      dakera:
+        condition: service_healthy
+    networks:
+      - dakera-dev
+
+  # ==========================================================================
+  # Dakera — Vector Database Server
+  # ==========================================================================
+  dakera:
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
+    ports:
+      - "3000:3000"
+      - "50051:50051"
+    environment:
+      - RUST_LOG=info
+      - DAKERA_HOST=0.0.0.0
+      - DAKERA_PORT=3000
+      - DAKERA_GRPC_PORT=50051
+      - DAKERA_STORAGE=s3
+      - DAKERA_S3_ENDPOINT=http://minio:9000
+      - DAKERA_S3_BUCKET=dakera
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - DAKERA_S3_REGION=us-east-1
+      - DAKERA_L1_CACHE_SIZE=536870912
+      - DAKERA_L2_CACHE_PATH=/data/rocksdb
+      # Auth disabled for local dev — enable in production
+      - DAKERA_AUTH_ENABLED=false
+    volumes:
+      - dakera-cache:/data/cache
+      - dakera-rocksdb:/data/rocksdb
+    depends_on:
+      minio-setup:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - dakera-dev
+
+  # ==========================================================================
+  # MinIO — S3-Compatible Object Storage
+  # ==========================================================================
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - dakera-dev
+
+  # ==========================================================================
+  # MinIO Setup — Initialize the 'dakera' bucket on first start
+  # ==========================================================================
+  minio-setup:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb local/dakera --ignore-existing;
+      echo 'MinIO bucket ready';
+      exit 0;
+      "
+    networks:
+      - dakera-dev
+
+volumes:
+  dakera-cache:
+  dakera-rocksdb:
+  minio-data:
+  dakera-vscode-ext:
+
+networks:
+  dakera-dev:
+    driver: bridge

--- a/README.md
+++ b/README.md
@@ -7,10 +7,42 @@ Deployment configurations for Dakera -- a high-performance vector database built
 
 This repository contains Docker configurations, high-availability clustering, load balancing, and monitoring setup for running Dakera in development and production environments.
 
+## VS Code / Cursor Devcontainer (Recommended)
+
+The fastest way to get a full Dakera dev environment — no local installs required.
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-started/get-docker/) + [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), or [Cursor](https://www.cursor.com/).
+
+```bash
+git clone https://github.com/dakera-ai/dakera-deploy
+# Open the folder in VS Code / Cursor, then:
+# "Reopen in Container" when prompted (or Ctrl+Shift+P → Dev Containers: Reopen in Container)
+```
+
+That's it. The container build will:
+1. Pull the Dakera server image and MinIO
+2. Initialize the storage bucket
+3. Install Python, Node, Go, and Rust SDKs
+4. Open VS Code/Cursor with Rust Analyzer, REST Client, and other extensions pre-configured
+
+**Service endpoints (available on localhost):**
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| Dakera REST API | http://localhost:3000 | Main API |
+| Dakera gRPC | localhost:50051 | gRPC endpoint |
+| MinIO Console | http://localhost:9001 | `minioadmin` / `minioadmin` |
+| MinIO S3 API | http://localhost:9000 | S3-compatible |
+
+Auth is disabled for local dev. See [docker-compose deployment](#default-full-single-node) for production auth setup.
+
+---
+
 ## Deployment Profiles
 
 | Profile | Description | Use Case |
 |---------|-------------|----------|
+| **devcontainer** | VS Code/Cursor one-click setup | SDK development, local testing |
 | **local** | Single instance, in-memory storage | Quick testing, no dependencies |
 | **dev** | MinIO storage backend for development | Local development with persistence |
 | **default** | Dakera + MinIO with full configuration | Staging / single-node production |
@@ -102,6 +134,9 @@ Pre-configured dashboards include request rates, latency percentiles, cache hit 
 
 ```
 dakera-deploy/
+├── .devcontainer/                   # VS Code / Cursor devcontainer
+│   ├── devcontainer.json            # Container config (extensions, ports, env)
+│   └── docker-compose.yml           # Dakera + MinIO dev services
 ├── docker/                          # Docker deployment configs
 │   ├── Dockerfile                   # Production multi-stage build
 │   ├── Dockerfile.dev               # Dev build with fast incremental compilation


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` — VS Code/Cursor config with port forwarding, Rust/Python/Node/Go features, and IDE extensions
- Adds `.devcontainer/docker-compose.yml` — Dakera + MinIO sidecar services (auth disabled for local dev)
- Updates `README.md` — new devcontainer section at the top with setup steps and endpoint table

## Usage

```bash
git clone https://github.com/dakera-ai/dakera-deploy
# Open in VS Code/Cursor → "Reopen in Container"
# Dakera REST API:  http://localhost:3000
# MinIO Console:    http://localhost:9001
```

## Test plan

- [ ] Clone repo and open in VS Code with Dev Containers extension
- [ ] Confirm "Reopen in Container" prompt appears
- [ ] Verify Dakera health: `curl http://localhost:3000/health`
- [ ] Verify MinIO bucket initialized at http://localhost:9001
- [ ] Check `DAKERA_API_URL` env var is set in workspace terminal
- [ ] Confirm postCreateCommand prints connection info

## Notes

- Auth intentionally disabled for local dev (`DAKERA_AUTH_ENABLED=false`)
- Part of Phase 1 v0.3.0 DX improvements — DAK-101

🤖 Generated with [Claude Code](https://claude.com/claude-code)