### PR TITLE
feat(deploy): pin default images to versioned tags — dakera:v0.6.0 + dashboard:v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ docker compose -f docker-compose.dev.yml up -d
 
 Production-grade single-node deployment with MinIO, caching, and health checks.
 
+> **Version pinning**: The default image tags are pinned to the latest stable release.
+> To run a specific version, set `DAKERA_IMAGE` and `DASHBOARD_IMAGE` in your `.env`:
+> ```bash
+> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:v0.6.0
+> DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:v0.3.0
+> ```
+> Pinning to explicit versions prevents unexpected upgrades in production.
+
 **First-time setup — configure credentials before starting:**
 
 ```bash

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:v0.6.0}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:latest}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:v0.3.0}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:v0.6.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:latest}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:v0.3.0}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Change default image tags from `:latest` to explicit versioned tags
- `docker-compose.yml`: `dakera:v0.6.0`, `dakera-dashboard:v0.3.0`
- `docker-compose.ha.yml`: same versioned defaults
- `README.md`: add version pinning guidance

Prevents unexpected upgrades in production. Users can override via `DAKERA_IMAGE`/`DASHBOARD_IMAGE` env vars.