### PR TITLE
fix(deploy): remove 'v' prefix from image tags — GHCR uses 0.6.0 not v0.6.0

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:v0.6.0}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.0}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:v0.3.0}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.0}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:v0.6.0}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:v0.3.0}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.0}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- The CI Release workflow extracts the tag version with `${GITHUB_REF#refs/tags/v}`, stripping the `v` prefix
- So GHCR has `dakera:0.6.0` and `dakera-dashboard:0.3.0`, not `v0.6.0` / `v0.3.0`
- This caused `docker pull` failures when using the default image references in compose

## Changes

- `docker/docker-compose.yml`: `v0.6.0` → `0.6.0`, `v0.3.0` → `0.3.0`
- `docker/docker-compose.ha.yml`: same fixes

## Test plan

- [ ] `docker pull ghcr.io/dakera-ai/dakera:0.6.0` — succeeds ✅
- [ ] `docker pull ghcr.io/dakera-ai/dakera-dashboard:0.3.0` — pending dashboard publish
- [ ] `docker compose pull` resolves without manifest errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)