### PR TITLE
fix(deploy): bump dakera-dashboard 0.3.0 → 0.3.1 — Safari black screen fix

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.0}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.1}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.0}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.1}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps `dakera-dashboard` from `0.3.0` → `0.3.1` in both `docker-compose.yml` and `docker-compose.ha.yml`

## Why

The previous v0.3.0 tag (`65ebf3a`) was cut at PR#6 merge (~21:55 UTC), **before** the iOS Safari black screen fix landed in PR#7 (`ce06f7c`, merged 23:06 UTC). Production was still serving the broken image.

v0.3.1 is tagged at `ce06f7c` and includes:
> `fix(safari): resolve iOS Safari black screen after WASM loads (DAK-286)`

## Related

- [DAK-287](/DAK/issues/DAK-287) — user report: black screen still visible
- [DAK-288](/DAK/issues/DAK-288) — CTO retag + redeploy task
- dakera-dashboard release: https://github.com/dakera-ai/dakera-dashboard/releases/tag/v0.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)