### PR TITLE
fix(deploy): bump dakera-dashboard 0.3.1 → 0.3.2 — WASM load fix (DAK-308)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.1}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.2}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.1}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.2}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps `dakera-dashboard` image tag `0.3.1 → 0.3.2` in both `docker-compose.yml` and `docker-compose.ha.yml`
- v0.3.2 resolves 12 CSR/WASM compile errors that caused dashboard load failures (DAK-293) and adds mobile hamburger nav (DAK-291)

## Context

Human (Duckk666) reported dashboard taking too long to start — root cause was the deployed `0.3.1` image missing the WASM build fixes. v0.3.2 was tagged at `f2d5ace` and Docker image is building via GitHub Actions.

## Test plan
- [ ] Docker image `ghcr.io/dakera-ai/dakera-dashboard:0.3.2` builds successfully
- [ ] VP Product to verify at 375px + 1280px and share screenshots via Telegram (DAK-309)

Resolves: DAK-308, DAK-307