### PR TITLE
fix(deploy): sync HA compose image versions — dakera 0.6.3 + dashboard 0.3.3

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.2}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.3}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.2}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.3}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"


### PR DESCRIPTION
## Summary

The HA compose file (`docker-compose.ha.yml`) was not updated when the standard compose file received image bumps.

- Bump `dakera` 0.6.2 → **0.6.3** (rustls-webpki GHSA-pwjx-qhcg-rvj4 security patch)
- Bump `dakera-dashboard` 0.3.2 → **0.3.3** (SSE `?api_key=` query-param fix for EventSource)

## Test plan
- [ ] `docker compose -f docker-compose.ha.yml config` validates cleanly
- [ ] Images are consistent with `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)