### PR TITLE
fix(deploy): bump dakera image 0.6.3 → 0.6.4 — SSE query-param auth

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.3}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.4}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

Bumps the default dakera server image from `0.6.3` → `0.6.4`.

v0.6.4 adds `?api_key=` query parameter support for EventSource SSE connections, which is required for the Live Feed page in dakera-dashboard v0.3.3.

## Changes

- `docker/docker-compose.yml`: `dakera:0.6.3` → `dakera:0.6.4`

## Related

- DAK-321: v0.6.4 release (SSE query-param auth)
- DAK-328: Redeploy dashboard with SSE fix (this PR completes the server side)
- DAK-325: CTO merged dakera PR#28 (SSE auth)
- Dashboard image already at `0.3.3` (PR#15, merged)

## Verification

After merge + redeploy:
1. Dashboard Live Feed page connects without SSE Connection Error
2. `GET /v1/events/stream?api_key=<key>` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)