### PR TITLE
chore: release v0.2.0 — devcontainer + pinned images + CI hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-21
+
+### Added
+
+- VS Code / Cursor devcontainer for one-command local dev stack (#8)
+- Pinned default images to versioned tags in all compose files — dakera `0.6.3`, dakera-dashboard `0.3.3` (#9)
+
+### Fixed
+
+- Remove broken Docker publish workflow; add valid no-op release workflow (#6, #7)
+- Remove `v` prefix from GHCR image tags — GHCR publishes `0.6.x` not `v0.6.x` (#10)
+- Bump dakera image: `0.6.0` → `0.6.2` (Memory Network fix) → `0.6.3` (rustls security patch) (#12, #14)
+- Bump dakera-dashboard: `0.3.0` → `0.3.1` (Safari black screen fix) → `0.3.2` (WASM + mobile nav fix) → `0.3.3` (SSE api_key fix)
+- Sync HA compose image versions to match standard compose configs
+
+### Security
+
+- Add explicit `GITHUB_TOKEN` permissions to CI workflow (#5)
+
+## [0.1.1] - 2026-03-18
+
 ### Security — SA-2026-001 (Critical)
 
 Three critical insecure-default vulnerabilities were found in the default Docker Compose configuration

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.2}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.3}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.2}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.3}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"


### PR DESCRIPTION
## Release v0.2.0

Catchup CHANGELOG update + HA compose sync. All 14 commits since v0.1.1 are already in main; this branch adds:

1. `fix(deploy): sync HA compose image versions to current releases` — aligns HA compose file image pins with standard compose
2. `chore: release v0.2.0` — CHANGELOG updated with v0.2.0 and backfilled v0.1.1 sections

### What's in v0.2.0
- **Added**: VS Code/Cursor devcontainer, pinned versioned image tags (dakera 0.6.3, dashboard 0.3.3)
- **Fixed**: Broken CI workflow, GHCR image tag prefix, multiple image version bumps, HA sync
- **Security**: Explicit GITHUB_TOKEN CI permissions

CI on prior commits already green. No breaking changes.