### PR TITLE
chore(deploy): sync HA compose to dakera v0.6.4

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.3}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.4}
   restart: unless-stopped
   networks:
     - dakera-ha-net


### PR DESCRIPTION
## Summary

- Bumps `docker-compose.ha.yml` default dakera image from `0.6.3` → `0.6.4`
- Syncs with `docker-compose.yml` which was already updated in PR#17

## Changes

- `docker/docker-compose.ha.yml`: `ghcr.io/dakera-ai/dakera:0.6.3` → `0.6.4`

## Notes

v0.6.4 image build is in progress (Release workflow running). Platform can merge and apply once the image is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)