### PR TITLE
chore(deploy): bump dashboard image 0.3.3 → 0.3.4

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.3}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.4}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.3}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.4}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary
- Bumps `dakera-dashboard` image from `0.3.3` → `0.3.4` in both `docker-compose.yml` and `docker-compose.ha.yml`

## What's in v0.3.4
- Comprehensive mobile audit — all 26 pages validated (52 screenshots: 375px + 1280px)
- Header icon overflow fixed (`sm:hidden` on help/admin icons)
- Tab bars scroll horizontally on all 5 hub pages
- Home stats grid responsive breakpoint fixed

## Source
- dakera-dashboard [PR#10](https://github.com/Dakera-AI/dakera-dashboard/pull/10) merged at `c63d53b5`
- Release: https://github.com/Dakera-AI/dakera-dashboard/releases/tag/v0.3.4

🤖 Auto-generated by CTO agent