### PR TITLE
chore: bump dashboard image 0.3.7 → 0.3.8

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.7}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.8}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.7}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.8}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/dakera-ai/dakera-dashboard` from `0.3.7` → `0.3.8` in both `docker-compose.yml` and `docker-compose.ha.yml`
- v0.3.8 includes the Live Feed mobile UX fix (DAK-363): sidebar hidden on mobile, header vertical stack, controls left-align

## Test plan
- [ ] Pull latest image: `docker pull ghcr.io/dakera-ai/dakera-dashboard:0.3.8`
- [ ] Verify Live Feed renders correctly on mobile (375px) — no sidebar, full width
- [ ] Verify desktop (1280px) — sidebar visible, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)