### PR TITLE
chore: bump dakera-dashboard to v0.3.10

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.8}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.10}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.8}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.10}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

Bumps dakera-dashboard from **v0.3.8 → v0.3.10** in both compose files.

**Docker image published:** `ghcr.io/dakera-ai/dakera-dashboard:0.3.10` ✅

### Changes included in v0.3.10
- **DAK-382** (PR#21): Mobile breadcrumb fix — hide ancestors, prevent label wrap at 375px
- **DAK-389** (PR#19): Filter Builder desktop blank — CSS safelist sm:w-96 + sm:border-*
- **DAK-390** (PR#20): Hub sub-nav tabs hidden on desktop — fix

All 3 PRs passed mobile QA (375px + 1280px screenshots confirmed).

### Files
- `docker/docker-compose.yml`: 0.3.8 → 0.3.10
- `docker/docker-compose.ha.yml`: 0.3.8 → 0.3.10