### PR TITLE
chore(deploy): bump dashboard 0.3.12 → 0.3.13 (nginx WASM gzip fix)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.12}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.13}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.12}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.13}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

Bumps dakera-dashboard image tag from `0.3.12` to `0.3.13` in both compose files.

**v0.3.13 fix:** nginx `gzip_static` disabled for `.wasm` — resolves iOS Safari `WebAssembly.instantiateStreaming()` crash (DAK-427).

- `docker/docker-compose.yml`: `0.3.12` → `0.3.13`
- `docker/docker-compose.ha.yml`: `0.3.12` → `0.3.13`

Ref: dakera-ai/dakera-dashboard#23, DAK-436