### PR TITLE
chore(deploy): bump dashboard 0.3.13 → 0.3.14 (regression fixes)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.13}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.14}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.13}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.14}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary
- Bump `dakera-dashboard` image tag from `0.3.13` to `0.3.14` in both `docker-compose.yml` and `docker-compose.ha.yml`

## Changes in v0.3.14
- Memory Network blank canvas fixed (grid layout for >60 nodes)
- Mobile menu not appearing fixed (Safari transition-transform fix)
- Memory Audit fake data removed (live SSE stream)
- Memory Compare fake IDs removed (live API with agent_id inputs)
- VP Product sign-off: DAK-442, 8 screenshots (375px+1280px), 0 console errors

## After merge
Platform should redeploy using the updated image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)