### PR TITLE
chore(deploy): bump dashboard 0.3.14 → 0.3.16 (WASM fixes)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.14}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.16}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.14}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.16}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps `dakera-dashboard` default image tag from `0.3.14` → `0.3.16` in both `docker-compose.yml` and `docker-compose.ha.yml`
- **v0.3.15**: nginx conditional gzip (non-iOS UA only) + cold-load timeout increased 8s → 20s — fixes WASM load failures on slow connections
- **v0.3.16**: WASM binary size reduction (19.3 MB → <10 MB) — dramatically improves cold-load performance

## Files changed
- `docker/docker-compose.yml` line 124
- `docker/docker-compose.ha.yml` line 252

## Test plan
- [ ] CI green (lint/validate)
- [ ] After merge: `docker compose pull && docker compose up -d --profile dashboard`
- [ ] Verify `docker ps` shows `dakera-dashboard:0.3.16`
- [ ] Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)