### PR TITLE
chore(deploy): bump dashboard 0.3.16 → 0.3.18 (WASM permanent load fix)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.16}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.18}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.16}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.18}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps `dakera-dashboard` image tag from `0.3.16` → `0.3.18` in both `docker-compose.yml` and `docker-compose.ha.yml`
- v0.3.18 includes the permanent WASM load fix (DAK-519) — resolves the 19.3 MB WASM cold-load failure on slow connections

## Changes

- `docker/docker-compose.yml`: dashboard image `0.3.16` → `0.3.18`
- `docker/docker-compose.ha.yml`: dashboard image `0.3.16` → `0.3.18`

## GitHub Release

https://github.com/Dakera-AI/dakera-dashboard/releases/tag/v0.3.18

## Test plan

- [ ] Pull updated image: `docker pull ghcr.io/dakera-ai/dakera-dashboard:0.3.18`
- [ ] Redeploy with `docker compose up -d --profile dashboard`
- [ ] Verify dashboard loads at 375px and 1280px viewports with no WASM load failure
- [ ] Take screenshots (mandatory: 375px + 1280px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)