### PR TITLE
chore(deploy): bump dashboard 0.3.18 → 0.3.20 (DX improvements)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.18}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.20}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.18}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.20}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
Bumps the default dakera-dashboard image tag from `0.3.18` to `0.3.20` in both `docker-compose.yml` and `docker-compose.ha.yml`.

**Changes included:**
- **v0.3.19**: Skeleton loading states across 25+ pages, retry buttons on error states (DAK-199, DAK-527, WCAG AA compliance)
- **v0.3.20**: Actionable error messages, onboarding reset, guide auto-resume (DAK-525)

Rebased onto main (supersedes the 0.3.16→0.3.18 commit already merged via PR#27).