### PR TITLE
chore: bump dakera-dashboard 0.3.20 → 0.3.21

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.20}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.21}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.20}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.21}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps dashboard image tag from `0.3.20` → `0.3.21` in both `docker-compose.yml` and `docker-compose.ha.yml`

## Fix included (DAK-568)

- nginx: `/admin/*` pages (Settings, Cluster, API Keys, Backups, Storage) now correctly serve the SPA instead of blank page
- Settings form: API key pre-populated from window global; empty URL allowed in same-origin proxy mode

## References

- Source commits: dakera-dashboard `89a7ab4` + `58de83f`
- Parent issue: DAK-568
- Deploy task: DAK-569