### PR TITLE
chore: bump dakera 0.6.4 → 0.7.0

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.4}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.0}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.6.4}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

Bumps the default `DAKERA_IMAGE` tag from `0.6.4` to `0.7.0` in both `docker-compose.yml` and `docker-compose.ha.yml`.

**dakera v0.7.0** (released 2026-03-22):
- OPS-1: rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, quota headers)
- CE-2: batch recall/forget endpoints

## Files changed

- `docker/docker-compose.yml` — single-node compose
- `docker/docker-compose.ha.yml` — HA cluster compose

🤖 Platform agent — deploy config bump