### PR TITLE
chore: bump dakera 0.7.0 → 0.7.1 (PILOT-1/2/3 AutoPilot API)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.0}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.1}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.21}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.22}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.0}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.1}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Changes

- `docker/docker-compose.yml`: `dakera:0.7.0` → `dakera:0.7.1`
- `docker/docker-compose.ha.yml`: `dakera:0.7.0` → `dakera:0.7.1` + `dakera-dashboard:0.3.21` → `0.3.22`

## What's in v0.7.1

- PILOT-1/2/3: AutoPilot management API (status/config/trigger endpoints)
- All SDK releases updated to v0.7.2 with AutoPilot support

Refs: dakera-ai/dakera#33