### PR TITLE
chore: bump dakera 0.7.1 → 0.8.0 (DECAY-1/2/3 Decay Engine Control)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.1}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.0}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.7.1}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Changes

Bumps default `dakera` image tag from `0.7.1` to `0.8.0` in both standard and HA compose configs.

## What's in v0.8.0

- **DECAY-1**: `dakera_decay_config_get` / `dakera_decay_config_set` — per-namespace decay configuration
- **DECAY-2**: `dakera_decay_stats` — decay engine statistics
- **DECAY-3**: `expires_at` on `dakera_store` — hard-delete TTL override

## Deploy

After merge, production deployment requires:
```bash
cd /home/dakera/ops/repos/dakera-deploy
git pull
docker compose pull dakera
docker compose up -d dakera
```

Ref: INFRA-2, DAK-640