### PR TITLE
chore: bump dakera 0.8.0 → 0.8.1 (DAK-679 optional vector + INFRA-2 + DAK-664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-03-23
+
+### Fixed
+
+- Bump dakera image: `0.8.0` → `0.8.1` (DAK-679 optional vector in hybrid search, INFRA-2 release deploy fix, DAK-664 integration tests) (#33)
+
 ## [0.2.2] - 2026-03-22
 
 ### Fixed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.0}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.1}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - Vector Database Server
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.0}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.1}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

Bumps the Dakera API image from `0.8.0` → `0.8.1` in all deployment configs.

### What's in v0.8.1
- **fix(hybrid) DAK-679** — `vector` field is now optional in hybrid search (`HybridSearchRequest`). BM25-only queries work without providing an embedding vector. Existing callers with `vector` continue to work unchanged.
- **fix(ci) INFRA-2** — Release workflow deploy job now correctly pulls latest code before deploy.
- **test DAK-664** — Integration tests added for decay engine + autopilot admin API.

### Files changed
- `docker/docker-compose.yml` — default image: `dakera:0.8.0` → `dakera:0.8.1`
- `docker/docker-compose.ha.yml` — HA image: `dakera:0.8.0` → `dakera:0.8.1`
- `CHANGELOG.md` — add `[0.2.3]` entry

### Upstream release
https://github.com/Dakera-AI/dakera/releases/tag/v0.8.1

Co-Authored-By: Paperclip <noreply@paperclip.ing>