### PR TITLE
chore: bump dakera 0.8.1→0.8.2 + dashboard 0.3.22→0.3.23 (DAK-767)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
           dockerfile: docker/Dockerfile
           failure-threshold: warning
 
+  kustomize-validate:
+    name: Kustomize Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up kubectl (includes kustomize)
+        uses: azure/setup-kubectl@v4
+
+      - name: kustomize build (validate raw manifests)
+        run: kustomize build k8s/ > /tmp/kustomize-output.yaml
+
+      - name: Check rendered manifest summary
+        run: |
+          echo "Rendered $(wc -l < /tmp/kustomize-output.yaml) lines"
+          grep "^kind:" /tmp/kustomize-output.yaml | sort | uniq -c | sort -rn
+
   helm-lint:
     name: Helm Lint + Template
     runs-on: ubuntu-latest
@@ -94,8 +111,9 @@ jobs:
 
       - name: Pre-pull dakera image into kind
         run: |
-          docker pull ghcr.io/dakera-ai/dakera:0.8.1
-          kind load docker-image ghcr.io/dakera-ai/dakera:0.8.1 --name dakera-ci
+          DAKERA_TAG=$(grep '^appVersion:' charts/dakera/Chart.yaml | awk '{gsub(/"/, "", $2); print $2}')
+          docker pull ghcr.io/dakera-ai/dakera:${DAKERA_TAG}
+          kind load docker-image ghcr.io/dakera-ai/dakera:${DAKERA_TAG} --name dakera-ci
 
       - name: Create namespace
         run: kubectl create namespace dakera

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-03-24
+
+### Fixed
+
+- Bump dakera image: `0.8.1` → `0.8.2` (DAK-720 SSE connected event, DAK-729 reposition as AI agent memory platform) (DAK-767)
+- Bump dakera-dashboard: `0.3.22` → `0.3.23` (DAK-722 live feed idle-state, DAK-571 health badge)
+- Configure GitHub Actions deploy secrets (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`) — fixes silent deploy failures since v0.8.1 (DAK-767)
+
 ## [0.2.3] - 2026-03-23
 
 ### Fixed

--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -3,7 +3,7 @@ name: dakera
 description: Dakera — AI agent memory platform
 type: application
 version: 0.1.0
-appVersion: "0.8.1"
+appVersion: "0.8.2"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -3,7 +3,7 @@ name: dakera
 description: Dakera — AI agent memory platform
 type: application
 version: 0.1.0
-appVersion: "0.8.2"
+appVersion: "0.8.1"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.1"
+    tag: "0.8.2"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -65,7 +65,7 @@ dashboard:
   enabled: true
   image:
     repository: ghcr.io/dakera-ai/dakera-dashboard
-    tag: "0.3.22"
+    tag: "0.3.23"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.1"
+    tag: "0.8.2"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.2"
+    tag: "0.8.1"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -24,7 +24,7 @@
 # =============================================================================
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.1}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.2}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -249,7 +249,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.22}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.23}
     container_name: dakera-dashboard
     ports:
       - "${DASHBOARD_PORT:-3002}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.1}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.2}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -121,7 +121,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.22}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.23}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.8.2"
+    app.kubernetes.io/version: "0.8.1"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.8.2"
+        app.kubernetes.io/version: "0.8.1"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.8.2
+          image: ghcr.io/dakera-ai/dakera:0.8.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.8.1"
+    app.kubernetes.io/version: "0.8.2"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.8.1"
+        app.kubernetes.io/version: "0.8.2"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.8.1
+          image: ghcr.io/dakera-ai/dakera:0.8.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bump dakera server image `0.8.1` → `0.8.2` across docker-compose, HA compose, Helm chart, and k8s manifests
- Bump dakera-dashboard image `0.3.22` → `0.3.23` across docker-compose, HA compose, and Helm chart
- Add CHANGELOG [0.2.4] entry noting the deploy-secret fix from DAK-767

## What's in v0.8.2
- DAK-720: SSE `connected` event on stream open
- DAK-729: Reposition as AI agent memory platform

## What's in dashboard v0.3.23
- DAK-722: Live feed idle-state ("Connected — no recent events" after 5s)
- DAK-571: Health badge + localStorage key sync

## Context (DAK-767)
The `Deploy to Server` job has been silently failing since v0.8.1 due to missing GitHub secrets (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`). Those secrets have now been configured — this PR ensures the next release auto-deploys the correct version.

Production server is currently on `dakera:0.8.0` and `dashboard:0.3.22` — a manual deploy will run immediately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Paperclip <noreply@paperclip.ing>