### PR TITLE
chore: bump dakera default to 0.8.3 (rustls security patch)

### DIFF
--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.2"
+    tag: "0.8.3"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.2}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.3}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.2}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.3}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.8.2"
+    app.kubernetes.io/version: "0.8.3"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.8.2"
+        app.kubernetes.io/version: "0.8.3"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.8.2
+          image: ghcr.io/dakera-ai/dakera:0.8.3
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bumps dakera image tag from `0.8.2` → `0.8.3` across all deploy configs (docker-compose, HA compose, k8s deployment, Helm values)
- v0.8.3 contains rustls `0.23.36→0.23.37` security patch (8 CVEs, closes DAK-796)

## Root Cause

Production was stuck on v0.8.2 despite a successful v0.8.3 release at 08:04Z. The deploy step in `release.yml` clones dakera-deploy and runs `docker compose up -d`, but dakera-deploy still referenced `0.8.2` at deploy time — so the container was not updated.

## Changes
- `docker/docker-compose.yml` — `0.8.2` → `0.8.3`
- `docker/docker-compose.ha.yml` — `0.8.2` → `0.8.3`
- `k8s/dakera/deployment.yaml` — `0.8.2` → `0.8.3` (image + version labels)
- `charts/dakera/values.yaml` — `0.8.2` → `0.8.3`

## Test plan
- [ ] CI green (Helm lint, Docker validate, Kustomize validate)
- [ ] After merge, production deploy updates container to `dakera:0.8.3`
- [ ] `docker ps` on server confirms new image running

🤖 Generated with [Claude Code](https://claude.com/claude-code)