### PR TITLE
chore: bump dakera 0.8.3→0.8.4 + dashboard 0.3.25→0.3.26

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -3,7 +3,7 @@ name: dakera
 description: Dakera — AI agent memory platform
 type: application
 version: 0.1.0
-appVersion: "0.8.2"
+appVersion: "0.8.4"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.3"
+    tag: "0.8.4"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -65,7 +65,7 @@ dashboard:
   enabled: true
   image:
     repository: ghcr.io/dakera-ai/dakera-dashboard
-    tag: "0.3.23"
+    tag: "0.3.26"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.3}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.4}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -260,7 +260,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.25}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.26}
     container_name: dakera-dashboard
     ports:
       - "${HA_DASHBOARD_PORT:-3202}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.3}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.4}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -123,7 +123,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.25}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.26}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

Batch version bump across all deploy configurations:

- `docker/docker-compose.yml`: dakera `0.8.3→0.8.4`, dashboard `0.3.25→0.3.26`
- `docker/docker-compose.ha.yml`: dakera `0.8.3→0.8.4`, dashboard `0.3.25→0.3.26`
- `charts/dakera/values.yaml`: dakera tag `0.8.3→0.8.4`, dashboard tag `0.3.23→0.3.26`
- `charts/dakera/Chart.yaml`: appVersion `0.8.2→0.8.4`

## What changed

- **dakera v0.8.4**: Adds `GET /v1/ops/stats` Read-scoped stats endpoint (DAK-852)
- **dakera-dashboard v0.3.26**: Updates stats panel to call `/v1/ops/stats` instead of `/admin/cluster/status` (fix DAK-853)

## Deploy note

Dashboard v0.3.26 Docker multi-arch image is being re-published (arm64 job was previously hung — tag re-pushed to re-trigger). Configs are safe to merge now; deploy once Docker image publish completes.

Closes 4d953c7c-6cac-4eb9-b1fa-02fff169ebcb