### PR TITLE
ci: migrate to self-hosted ARM runner (DAK-910)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   validate:
     name: Validate Docker Configs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64]
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +37,7 @@ jobs:
 
   kustomize-validate:
     name: Kustomize Validate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64]
     steps:
       - uses: actions/checkout@v4
 
@@ -54,7 +54,7 @@ jobs:
 
   helm-lint:
     name: Helm Lint + Template
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64]
     steps:
       - uses: actions/checkout@v4
 
@@ -88,7 +88,7 @@ jobs:
 
   helm-deploy-test:
     name: Helm Deployment Test (kind)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Migrate all CI jobs from `ubuntu-latest` to the Hetzner ARM self-hosted runner per DAK-910 founder directive.

**Runner registered:** `hetzner-arm-deploy` @ 168.119.60.30
- Docker installed (docker 28.2.2)
- kubectl, helm, kind auto-installed by GHA actions (ARM64 variants)
- dakera image is multi-arch (arm64 supported since ARM runner migration)

**Jobs migrated:** validate, kustomize-validate, helm-lint, helm-deploy-test → `[self-hosted, linux, arm64]`

Part of ARM runner rollout: dakera ✅ dakera-dashboard ✅ dakera-mcp ✅ dakera-cli ✅ dakera-cortex (sibling PR) **dakera-deploy (this PR)**