### PR TITLE
ci: migrate release workflow to self-hosted ARM runner (DAK-919)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release-info:
     name: Release Info
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64]
     steps:
       - name: Log release
         run: |


### PR DESCRIPTION
## Summary
- Moves release workflow from `ubuntu-latest` to `[self-hosted, linux, arm64]` (Hetzner private runner `hetzner-arm-deploy`)
- Part of DAK-919 founder directive: migrate all repos to private Hetzner ARM runners

## Changes
- `.github/workflows/release.yml`: `runs-on` → `[self-hosted, linux, arm64]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)