### PR TITLE
chore: bump dashboard to v0.3.27

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,7 +123,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.26}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.27}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary
- Bumps dashboard default image tag from `0.3.26` → `0.3.27`

## Why
v0.3.27 fixes 3 production regressions (DAK-896):
- **CRITICAL**: `state: Option<String>` in `OpsStats` struct — `/v1/ops/stats` doesn't return `state`, causing serde parse failure → red toast on every page load (API also fixed in dakera PR#57/DAK-918)
- **Mobile**: KG toolbar `overflow-x-auto` fix
- **Mobile**: Namespaces page header `flex-wrap gap-3`

## References
- Dashboard release: v0.3.27
- API fix: dakera PR#57 (DAK-918, merged to main)
- Original issues: DAK-896, DAK-911

🤖 Generated with [Claude Code](https://claude.com/claude-code)