### PR TITLE
chore: bump dakera 0.8.4→0.8.5 + dashboard 0.3.27→0.3.28

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.4}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.5}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -260,7 +260,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.26}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.28}
     container_name: dakera-dashboard
     ports:
       - "${HA_DASHBOARD_PORT:-3202}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.4}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.5}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -123,7 +123,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.27}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.28}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps dakera server `0.8.4 → 0.8.5` (ships DAK-918 `state` field on `/v1/ops/stats`)
- Bumps dashboard `0.3.27 → 0.3.28` (critical OpsStats regression fix — stats panel was crashing with parse error)
- Also fixes HA compose dashboard `0.3.26 → 0.3.28` (was one release behind)

Both releases are published to GHCR and verified (v0.8.5 @ 10:19Z, v0.3.28 @ 10:50Z).

## Context

Production was running v0.8.4 + v0.3.27. Dashboard v0.3.27 patched the crash with a `serde(default)`, but v0.8.5 ships the actual `state` field so the full fix requires both server + dashboard bump.

Assigned via DAK-952 (from CEO org report DAK-951).

## Test plan
- [ ] `docker compose pull && docker compose up -d` — dakera + dashboard containers start cleanly
- [ ] `curl http://localhost:3000/health` → 200
- [ ] Dashboard stats panel loads without JS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)