### PR TITLE
fix(ops-3): add DAKERA_REDIS_URL to HA compose for distributed Redis features

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -67,6 +67,8 @@ x-dakera-env: &dakera-env
   DAKERA_L1_CACHE_SIZE: "536870912"
   DAKERA_L2_CACHE_PATH: "/data/rocksdb"
   DAKERA_CACHE_REDIS_URL: "redis://redis:6379"
+  # OPS-3: shared Redis for rate-limit counters, SSE pub/sub fan-out, leader lock
+  DAKERA_REDIS_URL: "redis://redis:6379"
   # Tiered storage (L1 hot → L2 warm → L3 cold)
   DAKERA_TIERED_STORAGE: "true"
   DAKERA_HOT_TO_WARM_SECS: "3600"


### PR DESCRIPTION
## Problem

The 3-replica HA stack was missing `DAKERA_REDIS_URL` in `x-dakera-env`. The config reads `REDIS_URL` (prefixed to `DAKERA_REDIS_URL` by `env_with_fallback`), which controls the OPS-3 distributed Redis features:

- Rate-limit counters (Redis INCRBY with TTL — OPS-3 AC#2)
- SSE pub/sub fan-out across replicas (OPS-3 AC#3)
- Decay/consolidation leader lock (Redis SETNX — OPS-3 AC#4)
- Graceful degradation (single-node fallback — OPS-3 AC#5)

Without this env var, `RedisConfig::enabled = false` and all three replicas silently fell back to in-process single-node mode, defeating the entire OPS-3 feature set.

`DAKERA_CACHE_REDIS_URL` (present) is a separate config key for the L1.5 cache layer — it does not enable OPS-3 distributed features.

## Change

Added `DAKERA_REDIS_URL: "redis://redis:6379"` to `x-dakera-env` in `docker-compose.ha.yml`. All three dakera nodes inherit it via the `<<: *dakera-env` anchor.

## Testing

All 3 nodes now start with `RedisConfig { enabled: true, url: "redis://redis:6379" }`, connecting to the shared Redis container already defined in the compose file.

Related: dakera-ai/dakera#72 (leader lock), dakera-ai/dakera#74 (GLiNER/entity config), dakera-ai/dakera#75 (SSE pub/sub)