### PR TITLE
chore: bump dakera server 0.8.6 → 0.9.6 (weekly batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-03-31
+
+### Changed
+
+- Bump dakera server default image: `0.8.6` → `0.9.6` (weekly batch)
+  - v0.9.0: CE-4 full-text search, CE-5 Knowledge Graph, OPS-2 vector primitives, OPS-3 batch upsert, ODE integration REST API
+  - v0.9.1: SEC-3 zero-downtime encryption key rotation fix
+  - v0.9.2: SEC-4 HMAC-SHA256 webhook auth
+  - v0.9.3: Docker Debian Trixie (glibc 2.40, ORT ARM64 fix)
+  - v0.9.4: ODE-2 GLiNER entity extraction
+  - v0.9.5: ODE webhook HMAC security patch
+  - v0.9.6: COG-1 memory lifecycle (MemoryPolicy), COG-2 associative recall, KG-2 graph query/export
+
 ## [0.2.5] - 2026-03-24
 
 ### Fixed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.6}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.6}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.8.6}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.6}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

Weekly deploy version bump — 7 days of server releases since last bump (v0.8.6, 2026-03-24).

### Changes
- `docker/docker-compose.yml`: `DAKERA_IMAGE` default `0.8.6` → `0.9.6`
- `docker/docker-compose.ha.yml`: `DAKERA_IMAGE` default `0.8.6` → `0.9.6`
- `CHANGELOG.md`: new `[0.2.6] - 2026-03-31` entry
- Dashboard image unchanged: `dakera-dashboard:0.3.28` ✅

### What's in v0.9.6 (since 0.8.6)
- **v0.9.0**: CE-4 full-text search, CE-5 Knowledge Graph, OPS-2 vector primitives, OPS-3 batch upsert, ODE integration REST API
- **v0.9.1**: SEC-3 zero-downtime encryption key rotation fix
- **v0.9.2**: SEC-4 HMAC-SHA256 webhook auth
- **v0.9.3**: Docker Debian Trixie (glibc 2.40, ORT ARM64 fix)
- **v0.9.4**: ODE-2 GLiNER entity extraction
- **v0.9.5**: ODE webhook HMAC security patch
- **v0.9.6**: COG-1 MemoryPolicy, COG-2 associative recall, KG-2 graph query/export

🤖 Generated by Platform agent — DAK-1353 (b68c64d3)