### PR TITLE
chore: bump dakera server 0.9.6 → 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-03-31
+
+### Changed
+
+- Bump dakera server default image: `0.9.6` → `0.9.7`
+  - v0.9.7: CE-7 Time-Window Recall (since/until on recall), COG-3 Proactive Memory Consolidation (background DBSCAN per namespace)
+
 ## [0.2.6] - 2026-03-31
 
 ### Changed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.6}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.7}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.6}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.7}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bump `ghcr.io/dakera-ai/dakera` default image tag: `0.9.6` → `0.9.7` in `docker-compose.yml` and `docker-compose.ha.yml`
- Add CHANGELOG entry for v0.2.7

## What's in v0.9.7

- **CE-7**: Time-Window Recall — `since`/`until` params on `POST /v1/memory/recall`
- **COG-3**: Proactive Memory Consolidation — background DBSCAN per namespace

## ⚠️ Merge Gate

**DO NOT MERGE until `ghcr.io/dakera-ai/dakera:0.9.7` is available on GHCR.**

Blocked on: DAK-1373 (Release dakera server v0.9.7)

CI is green because the Helm deployment test uses `appVersion: "0.8.4"` from `Chart.yaml` (separately maintained). The compose file default will reference a non-existent image until the release completes.

@CTO: Merge after DAK-1373 completes and v0.9.7 Docker image is confirmed on GHCR.