### PR TITLE
chore: bump k8s images to current releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-04-01
+
+### Changed
+
+- Bump k8s dakera server image: `0.8.3` → `0.9.8` (k8s manifests were drifted from docker-compose)
+- Bump k8s dashboard image: `0.3.22` → `0.3.28`
+- Pin k8s mcp image: `latest` → `0.9.1` (reproducible deployments)
+
 ## [0.2.8] - 2026-04-01
 
 ### Changed

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.8.3"
+    app.kubernetes.io/version: "0.9.8"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.8.3"
+        app.kubernetes.io/version: "0.9.8"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.8.3
+          image: ghcr.io/dakera-ai/dakera:0.9.8
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/dashboard/deployment.yaml
+++ b/k8s/dashboard/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera-dashboard
     app.kubernetes.io/component: dashboard
-    app.kubernetes.io/version: "0.3.22"
+    app.kubernetes.io/version: "0.3.28"
 spec:
   replicas: 1
   selector:
@@ -21,12 +21,12 @@ spec:
       labels:
         app.kubernetes.io/name: dakera-dashboard
         app.kubernetes.io/component: dashboard
-        app.kubernetes.io/version: "0.3.22"
+        app.kubernetes.io/version: "0.3.28"
     spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: dashboard
-          image: ghcr.io/dakera-ai/dakera-dashboard:0.3.22
+          image: ghcr.io/dakera-ai/dakera-dashboard:0.3.28
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/mcp/deployment.yaml
+++ b/k8s/mcp/deployment.yaml
@@ -26,8 +26,8 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: dakera-mcp
-          image: ghcr.io/dakera-ai/dakera-mcp:latest
-          imagePullPolicy: Always
+          image: ghcr.io/dakera-ai/dakera-mcp:0.9.1
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 3001


### PR DESCRIPTION
## Summary

- Bump k8s dakera server image: `0.8.3` → `0.9.8` (k8s manifests were severely drifted from docker-compose — missed all bumps since PR#48)
- Bump k8s dashboard image: `0.3.22` → `0.3.28`
- Pin k8s mcp image: `latest` → `0.9.1` (reproducible deployments)

## Root Cause

PRs #48–#50 only updated `docker/docker-compose*.yml` but not `k8s/*/deployment.yaml`. This drift was caught during the 2026-04-01 CI/CD health scan.

## Test plan
- [ ] CI helm-deploy-test green
- [ ] All 3 k8s deployment.yaml files contain correct image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)