### PR TITLE
chore: bump dakera server 0.9.8 → 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-01
+
+### Changed
+
+- Bump dakera server image: `0.9.8` → `0.9.9` in docker-compose, docker-compose.ha, and k8s/dakera/deployment.yaml
+  - v0.9.9: SEC-5 per-namespace rate limiting for store/recall ops (MemoryPolicy)
+
 ## [0.2.9] - 2026-04-01
 
 ### Changed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.8}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.9}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.8}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.9}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.9.8"
+    app.kubernetes.io/version: "0.9.9"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.9.8"
+        app.kubernetes.io/version: "0.9.9"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.9.8
+          image: ghcr.io/dakera-ai/dakera:0.9.9
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bump `ghcr.io/dakera-ai/dakera` default image: `0.9.8` → `0.9.9` across all deployment configs
  - `docker/docker-compose.yml`
  - `docker/docker-compose.ha.yml`
  - `k8s/dakera/deployment.yaml` (k8s included in same commit to prevent drift — lesson from PR#51)

**v0.9.9** (2026-04-01): SEC-5 per-namespace rate limiting for `store`/`recall` ops via `MemoryPolicy`.

## Test plan
- [ ] CI helm-deploy-test green
- [ ] Kustomize Validate green
- [ ] Validate Docker Configs green
- [ ] Helm Lint + Template green

🤖 Generated with [Claude Code](https://claude.com/claude-code)