### PR TITLE
chore: bump helm chart to current releases (0.8.4 -> 0.9.9)

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -3,7 +3,7 @@ name: dakera
 description: Dakera — AI agent memory platform
 type: application
 version: 0.1.0
-appVersion: "0.8.4"
+appVersion: "0.9.9"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.8.4"
+    tag: "0.9.9"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -65,7 +65,7 @@ dashboard:
   enabled: true
   image:
     repository: ghcr.io/dakera-ai/dakera-dashboard
-    tag: "0.3.26"
+    tag: "0.3.28"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -87,8 +87,8 @@ mcp:
   enabled: true
   image:
     repository: ghcr.io/dakera-ai/dakera-mcp
-    tag: "latest"
-    pullPolicy: Always
+    tag: "0.9.1"
+    pullPolicy: IfNotPresent
 
   replicaCount: 1
 


### PR DESCRIPTION
Helm chart was drifted from k8s manifests and docker-compose (same pattern as k8s drift fixed in PR#51). Chart.yaml appVersion 0.8.4->0.9.9. values.yaml: dakera tag 0.8.4->0.9.9, dashboard 0.3.26->0.3.28, mcp latest->0.9.1 pinned, pullPolicy Always->IfNotPresent. Root cause: PRs #41-#52 only updated docker/ and k8s/ files, not charts/. Generated with Claude Code.