### PR TITLE
chore: bump dakera-mcp 0.9.1 -> 0.9.2

### DIFF
--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -87,7 +87,7 @@ mcp:
   enabled: true
   image:
     repository: ghcr.io/dakera-ai/dakera-mcp
-    tag: "0.9.1"
+    tag: "0.9.2"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/k8s/mcp/deployment.yaml
+++ b/k8s/mcp/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: dakera-mcp
-          image: ghcr.io/dakera-ai/dakera-mcp:0.9.1
+          image: ghcr.io/dakera-ai/dakera-mcp:0.9.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
dakera-mcp v0.9.2 released (feat(mcp-5): dakera_memory_policy_get/set + dakera_recall_associated). Updates k8s/mcp/deployment.yaml and charts/dakera/values.yaml: mcp tag 0.9.1->0.9.2. Note: v0.9.2 Docker image had multi-arch manifest failure (same stale digest pattern as v0.9.0) but was recovered via Re-Manifest workflow. Image is confirmed live on GHCR. Generated with Claude Code.