### PR TITLE
feat(ci): Helm chart OCI publishing to GHCR

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -1,0 +1,65 @@
+name: Publish Helm Chart
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  chart-publish:
+    name: Publish Helm Chart to GHCR
+    runs-on: [self-hosted, linux, arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Extract chart version
+        id: chart
+        run: |
+          VERSION=$(grep '^version:' charts/dakera/Chart.yaml | awk '{print $2}')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: ${VERSION}"
+
+      - name: Lint chart
+        run: |
+          helm lint charts/dakera/ \
+            --set dakera.rootApiKey=ci-lint \
+            --set minio.rootPassword=ci-lint
+
+      - name: Package chart
+        run: helm package charts/dakera/
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push chart to GHCR OCI
+        run: |
+          helm push "dakera-${{ steps.chart.outputs.version }}.tgz" \
+            oci://ghcr.io/dakera-ai/charts
+
+      - name: Verify push
+        run: |
+          echo "✅ Helm chart published:"
+          echo "   oci://ghcr.io/dakera-ai/charts/dakera:${{ steps.chart.outputs.version }}"
+          echo ""
+          echo "Install with:"
+          echo "  helm install dakera oci://ghcr.io/dakera-ai/charts/dakera \\"
+          echo "    --version ${{ steps.chart.outputs.version }} \\"
+          echo "    --namespace dakera --create-namespace \\"
+          echo "    --set dakera.rootApiKey=<your-key> \\"
+          echo "    --set minio.rootPassword=<your-password>"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED)](https://docs.docker.com/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-Ready-326CE5)](https://kubernetes.io/)
-[![Helm](https://img.shields.io/badge/Helm-Chart-0F1689)](https://helm.sh/)
+[![Helm](https://img.shields.io/badge/Helm-v0.9.9-0F1689)](https://github.com/orgs/dakera-ai/packages/container/package/charts%2Fdakera)
 
 Deployment configurations for Dakera — the AI agent memory platform. Persistent, session-aware, cross-agent memory for your AI agents.
 
@@ -413,18 +413,18 @@ curl http://localhost:3000/health
 
 ### Option B: Helm
 
+The chart is published to GHCR as an OCI artifact. Helm 3.8+ required.
+
 ```bash
-# Install with Helm
-helm install dakera ./charts/dakera \
-  --namespace dakera \
-  --create-namespace \
+# Install from GHCR OCI (recommended)
+helm install dakera oci://ghcr.io/dakera-ai/charts/dakera --version 0.9.9 \
+  --namespace dakera --create-namespace \
   --set dakera.rootApiKey=$(openssl rand -hex 32) \
   --set minio.rootPassword=$(openssl rand -hex 16)
 
 # With ingress + monitoring enabled
-helm install dakera ./charts/dakera \
-  --namespace dakera \
-  --create-namespace \
+helm install dakera oci://ghcr.io/dakera-ai/charts/dakera --version 0.9.9 \
+  --namespace dakera --create-namespace \
   --set dakera.rootApiKey=$(openssl rand -hex 32) \
   --set minio.rootPassword=$(openssl rand -hex 16) \
   --set ingress.enabled=true \
@@ -432,12 +432,25 @@ helm install dakera ./charts/dakera \
   --set ingress.dashboardHost=dashboard.dakera.yourdomain.com \
   --set monitoring.enabled=true
 
-# Upgrade
-helm upgrade dakera ./charts/dakera --reuse-values
+# Upgrade to a new version
+helm upgrade dakera oci://ghcr.io/dakera-ai/charts/dakera --version <new-version> --reuse-values
 
 # Uninstall
 helm uninstall dakera -n dakera
 ```
+
+<details>
+<summary>Install from local checkout</summary>
+
+```bash
+git clone https://github.com/dakera-ai/dakera-deploy
+helm install dakera ./dakera-deploy/charts/dakera \
+  --namespace dakera --create-namespace \
+  --set dakera.rootApiKey=$(openssl rand -hex 32) \
+  --set minio.rootPassword=$(openssl rand -hex 16)
+```
+
+</details>
 
 ### Resource Summary
 

--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.1.0
+version: 0.9.9
 appVersion: "0.9.9"
 keywords:
   - agent-memory


### PR DESCRIPTION
## Summary

Implements [DAK-1459](/DAK/issues/DAK-1459) — Helm chart OCI publishing per founder (Duckk666) Option B approval.

- **`chart-publish.yml`**: new GHA workflow triggered on `v*` tags — lints, packages, and pushes the chart to `oci://ghcr.io/dakera-ai/charts`
- **`Chart.yaml`**: version bumped `0.1.0 → 0.9.9` (aligns with `appVersion`/server version)
- **`README.md`**: Option B: Helm updated to OCI install command; Helm badge updated to v0.9.9 with GHCR link; local checkout kept as collapsible fallback

## Install command (after publish)

```bash
helm install dakera oci://ghcr.io/dakera-ai/charts/dakera --version 0.9.9 \
  --namespace dakera --create-namespace \
  --set dakera.rootApiKey=$(openssl rand -hex 32) \
  --set minio.rootPassword=$(openssl rand -hex 16)
```

## Security

GHCR packages can be made public without exposing the private `dakera-deploy` repo. Satisfies ORG SECURITY POLICY — no new public repos created.

## Test plan

- [ ] CI: helm-lint + helm-deploy-test pass (existing jobs cover the chart)
- [ ] On merge to main + tag `v0.9.9`: chart-publish workflow runs and pushes to `ghcr.io/dakera-ai/charts/dakera:0.9.9`
- [ ] GHCR package visibility set to public after first push
- [ ] DevRel triggered to document OCI install method