### PR TITLE
chore(chart): bump Helm chart version 0.9.9 → 0.9.11

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.9.9
-appVersion: "0.9.9"
+version: 0.9.11
+appVersion: "0.9.11"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.9.9"
+    tag: "0.9.11"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
## Summary

- Sync chart `version` and `appVersion` from 0.9.9 → 0.9.11 in `Chart.yaml`
- Update default image `tag` to `0.9.11` in `values.yaml`

## Why

dakera server is at v0.9.11 (shipped 2026-04-06T10:12Z) but the Helm chart was still pointing to v0.9.9. Once the chart is published and visibility is set to public (DAK-1540), users will get the correct version.

## Related

- DAK-1540: Helm chart GHCR publish + visibility
- Note: chart `0.9.11` will be published once this PR merges (workflow triggers on `v*` tags or manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)