### PR TITLE
chore: bump dakera server 0.9.9 → 0.9.12

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.9.11
-appVersion: "0.9.11"
+version: 0.9.12
+appVersion: "0.9.12"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.9.11"
+    tag: "0.9.12"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.9}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.12}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.9}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.12}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.9.9"
+    app.kubernetes.io/version: "0.9.12"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.9.9"
+        app.kubernetes.io/version: "0.9.12"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.9.9
+          image: ghcr.io/dakera-ai/dakera:0.9.12
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Bumps all deployment configs to dakera server **v0.9.12** (CEO directive: deploy /v1/kpis immediately after release).

Supersedes PR #59 (chart bump 0.9.9 → 0.9.11) — this goes directly to 0.9.12.

**Changes in v0.9.12:**
- DAK-1557: `GET /v1/kpis` KPI snapshot endpoint
- DAK-1548: v9.x stability sprint (session_agent_index O(1), incremental memory counters, async S3 flush, idempotent session end)
- Security: quinn CVE pin to 0.11.14

**Files changed:**
- `charts/dakera/Chart.yaml` — version + appVersion: `0.9.9` → `0.9.12`
- `charts/dakera/values.yaml` — `dakera.image.tag`: `0.9.9` → `0.9.12`
- `k8s/dakera/deployment.yaml` — image + labels: `0.9.9` → `0.9.12`
- `docker/docker-compose.yml` — default image: `0.9.9` → `0.9.12`
- `docker/docker-compose.ha.yml` — default image: `0.9.9` → `0.9.12`

**Docker image:** `ghcr.io/dakera-ai/dakera:0.9.12` — Release CI #24030777331 building (in progress).

**Post-merge deploy:** After CTO merges, run helm upgrade to redeploy production.

Closes DAK-1569.