### PR TITLE
chore: bump dakera server 0.9.12 → 0.9.13 + dashboard 0.3.28 → 0.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-06
+
+### Changed
+
+- Bump dakera server image: `0.9.12` → `0.9.13` in docker-compose, docker-compose.ha, and k8s/dakera/deployment.yaml
+  - v0.9.13: Security patch — DAK-1596 untrack .mcp.json + add to .gitignore; CVSS-gated cargo-audit + embedding warm-up (DAK-1629)
+- Bump dashboard image: `0.3.28` → `0.3.29` in docker-compose, docker-compose.ha, and k8s/dashboard/deployment.yaml
+  - v0.3.29: KPI metrics panel at /observe/kpis (DAK-1578)
+
 ## [0.3.0] - 2026-04-01
 
 ### Changed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.12}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.13}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -262,7 +262,7 @@ services:
   # Dakera Dashboard — Web UI
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.28}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.29}
     container_name: dakera-dashboard
     ports:
       - "${HA_DASHBOARD_PORT:-3202}:3000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.12}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.13}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -168,7 +168,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.28}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.29}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.9.12
+          image: ghcr.io/dakera-ai/dakera:0.9.13
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/dashboard/deployment.yaml
+++ b/k8s/dashboard/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: dashboard
-          image: ghcr.io/dakera-ai/dakera-dashboard:0.3.28
+          image: ghcr.io/dakera-ai/dakera-dashboard:0.3.29
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bump dakera server default image `0.9.12` → `0.9.13` (docker-compose, docker-compose.ha, k8s)
  - v0.9.13: Security patch — DAK-1596 (.mcp.json credential leak fix) + CVSS-gated cargo-audit + embedding warm-up (DAK-1629)
- Bump dashboard default image `0.3.28` → `0.3.29` (docker-compose, docker-compose.ha, k8s)
  - v0.3.29: KPI metrics panel at /observe/kpis (DAK-1578)

## Files Changed

- `docker/docker-compose.yml`
- `docker/docker-compose.ha.yml`
- `k8s/dakera/deployment.yaml`
- `k8s/dashboard/deployment.yaml`
- `CHANGELOG.md` — added [0.3.1] entry

## Test plan

- [x] Production confirmed running v0.9.13 + dashboard v0.3.29 (healthy locally)
- [x] Both images published to GHCR with correct tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)