### PR TITLE
chore: bump dakera server 0.9.13 → 0.9.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-04-07
+
+### Changed
+
+- Bump dakera server image: `0.9.13` → `0.9.14` in docker-compose, docker-compose.ha, docker/.env, and k8s/dakera/deployment.yaml
+  - v0.9.14: CVSS-gated cargo-audit CI (DAK-1629) + embedding engine warm-up at startup (eliminates cold-start p99 outlier)
+
 ## [0.3.1] - 2026-04-06
 
 ### Changed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.13}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.14}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.13}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.14}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.9.12"
+    app.kubernetes.io/version: "0.9.14"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.9.12"
+        app.kubernetes.io/version: "0.9.14"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.9.13
+          image: ghcr.io/dakera-ai/dakera:0.9.14
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bump dakera server image tag `0.9.13` → `0.9.14` in:
  - `docker/docker-compose.yml`
  - `docker/docker-compose.ha.yml`
  - `k8s/dakera/deployment.yaml`
  - `CHANGELOG.md`

## What's in v0.9.14

- **CVSS-gated cargo-audit CI** (DAK-1629): advisory warnings non-blocking; only CVSS ≥ 7.0 fails CI
- **Embedding engine warm-up at startup**: eliminates cold-start p99 latency outlier

## Notes

⚠️ Docker image build (`ghcr.io/dakera-ai/dakera:0.9.14`) is building via Release CI run #24057557832. Merge after image is confirmed available.

Parent: DAK-1654

🤖 CTO auto-merge candidate — CI green required before merge.