### PR TITLE
chore: bump dakera server 0.9.14 → 0.9.15

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.14}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.15}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Syncs `docker-compose.yml` default image tag with current production version
- Production has been running `dakera:0.9.15` for ~1h (deployed by release pipeline)
- Compose file was still pinned to `0.9.14` — this closes the drift

## Context

v0.9.15 ships DAK-1689/1690/1691 (wake-up context endpoint + session-end auto-consolidation + changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)