### PR TITLE
chore: bump Helm chart to v0.9.15

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.9.14
-appVersion: "0.9.14"
+version: 0.9.15
+appVersion: "0.9.15"
 keywords:
   - agent-memory
   - ai-memory


### PR DESCRIPTION
## Summary

- Bumps Helm chart `version` and `appVersion` from `0.9.14` → `0.9.15`
- Tracks server v0.9.15 (already running in production per PR #64)

## Changes

- `charts/dakera/Chart.yaml`: `version: 0.9.15`, `appVersion: "0.9.15"`

## Context

Server v0.9.15 shipped 2026-04-07T20:13Z (DAK-1689 HNSW fix, DAK-1690 wake-up endpoint, DAK-1691 session-end auto-consolidation). docker-compose.yml was bumped in PR #64. Helm chart was the remaining drift.

Merging this will trigger the `Publish Helm Chart` workflow.

🤖 Release agent