### PR TITLE
feat: Hetzner infrastructure automation (DAK-1753)

### DIFF
--- a/.github/workflows/hetzner-health-check.yml
+++ b/.github/workflows/hetzner-health-check.yml
@@ -1,0 +1,106 @@
+name: Hetzner Server Health Check
+
+on:
+  schedule:
+    # Every 30 minutes
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: hetzner-health-check
+  cancel-in-progress: true
+
+env:
+  SERVER_IP: "178.104.45.161"
+  HEALTH_URL: "http://178.104.45.161:3300/health"
+  DEMO_URL: "http://178.104.45.161:3004"
+
+jobs:
+  health-check:
+    name: Check Server Health
+    runs-on: ubuntu-latest
+    outputs:
+      healthy: ${{ steps.check.outputs.healthy }}
+      server_status: ${{ steps.hetzner.outputs.server_status }}
+    steps:
+      - name: HTTP health probe
+        id: check
+        run: |
+          HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.HEALTH_URL }}" 2>/dev/null || echo "000")
+          DEMO_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.DEMO_URL }}" 2>/dev/null || echo "000")
+          echo "dakera health endpoint: $HTTP_CODE"
+          echo "4imapact-demo: $DEMO_CODE"
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "WARNING: dakera health endpoint returned $HTTP_CODE (demo: $DEMO_CODE)"
+          fi
+
+      - name: Check Hetzner server status
+        id: hetzner
+        if: steps.check.outputs.healthy == 'false'
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+        run: |
+          RESPONSE=$(curl -sf \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            "https://api.hetzner.cloud/v1/servers?per_page=50")
+          SERVER_INFO=$(echo "$RESPONSE" | jq -r \
+            --arg ip "${{ env.SERVER_IP }}" \
+            '.servers[] | select(.public_net.ipv4.ip == $ip) | {id,name,status,created}')
+          SERVER_ID=$(echo "$RESPONSE" | jq -r \
+            --arg ip "${{ env.SERVER_IP }}" \
+            '.servers[] | select(.public_net.ipv4.ip == $ip) | .id')
+          SERVER_STATUS=$(echo "$RESPONSE" | jq -r \
+            --arg ip "${{ env.SERVER_IP }}" \
+            '.servers[] | select(.public_net.ipv4.ip == $ip) | .status')
+          echo "Server info: $SERVER_INFO"
+          echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+          echo "server_status=$SERVER_STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Attempt soft reboot via Hetzner API
+        id: reboot
+        if: |
+          steps.check.outputs.healthy == 'false' &&
+          steps.hetzner.outputs.server_status == 'running'
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+          SERVER_ID: ${{ steps.hetzner.outputs.server_id }}
+        run: |
+          echo "Server is running but HTTP check failed — triggering soft reboot..."
+          RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.hetzner.cloud/v1/servers/${SERVER_ID}/actions/reboot")
+          ACTION_STATUS=$(echo "$RESPONSE" | jq -r '.action.status')
+          echo "Reboot action status: $ACTION_STATUS"
+          echo "reboot_triggered=true" >> "$GITHUB_OUTPUT"
+
+      - name: Send Telegram alert
+        if: steps.check.outputs.healthy == 'false'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          SERVER_STATUS="${{ steps.hetzner.outputs.server_status }}"
+          REBOOT="${{ steps.reboot.outputs.reboot_triggered }}"
+          if [ "$REBOOT" = "true" ]; then
+            MSG="⚠️ [Platform] Server 178.104.45.161 unreachable — soft reboot triggered via Hetzner API.\n\nHetzner status: $SERVER_STATUS\nHealth check: FAILED\nAction: Rebooting — check in ~2 minutes."
+          elif [ -z "$SERVER_STATUS" ]; then
+            MSG="🔴 [Platform] Server 178.104.45.161 unreachable AND Hetzner API lookup failed.\n\nHealth check: FAILED\nNote: Hetzner token may be invalid or server deleted. Manual intervention required."
+          else
+            MSG="🔴 [Platform] Server 178.104.45.161 health check FAILED.\n\nHetzner status: $SERVER_STATUS\nHealth check: FAILED\nNote: Server not in 'running' state — manual intervention required."
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":\"$MSG\"}" > /dev/null
+
+  report-healthy:
+    name: Log Healthy Status
+    runs-on: ubuntu-latest
+    needs: health-check
+    if: needs.health-check.outputs.healthy == 'true'
+    steps:
+      - name: Log healthy
+        run: echo "Server 178.104.45.161 is healthy. All checks passed."

--- a/.github/workflows/hetzner-provision-staging.yml
+++ b/.github/workflows/hetzner-provision-staging.yml
@@ -1,0 +1,131 @@
+name: Hetzner Provision Staging Server
+
+# Reusable template for spinning up ephemeral staging environments.
+# Run manually; outputs the new server's IP and ID for follow-up steps.
+# IMPORTANT: Remember to run the "Deprovision" job when done to avoid costs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: "Server name (e.g. staging-pr-123)"
+        required: true
+      server_type:
+        description: "Hetzner server type (cx22 = 2vCPU/4GB, cx32 = 4vCPU/8GB)"
+        required: false
+        default: "cx22"
+      image:
+        description: "OS image (ubuntu-24.04, ubuntu-22.04, debian-12)"
+        required: false
+        default: "ubuntu-24.04"
+      location:
+        description: "Datacenter location (nbg1, fsn1, hel1)"
+        required: false
+        default: "nbg1"
+
+concurrency:
+  group: hetzner-provision-${{ inputs.server_name }}
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    name: Provision ${{ inputs.server_name }}
+    runs-on: ubuntu-latest
+    outputs:
+      server_id: ${{ steps.create.outputs.server_id }}
+      server_ip: ${{ steps.create.outputs.server_ip }}
+    steps:
+      - name: Check for existing server
+        id: check_existing
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+        run: |
+          EXISTING=$(curl -sf \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            "https://api.hetzner.cloud/v1/servers?per_page=50" \
+            | jq -r --arg name "${{ inputs.server_name }}" \
+              '.servers[] | select(.name == $name) | .id')
+          if [ -n "$EXISTING" ]; then
+            echo "ERROR: Server '${{ inputs.server_name }}' already exists (id: $EXISTING). Aborting to prevent duplicate."
+            exit 1
+          fi
+          echo "No existing server with that name. Proceeding."
+
+      - name: Create server
+        id: create
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+        run: |
+          RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.hetzner.cloud/v1/servers" \
+            -d '{
+              "name": "${{ inputs.server_name }}",
+              "server_type": "${{ inputs.server_type }}",
+              "image": "${{ inputs.image }}",
+              "location": "${{ inputs.location }}",
+              "labels": {
+                "source": "github-actions",
+                "env": "staging",
+                "workflow_run": "${{ github.run_id }}"
+              },
+              "start_after_create": true
+            }')
+          SERVER_ID=$(echo "$RESPONSE" | jq -r '.server.id')
+          if [ -z "$SERVER_ID" ] || [ "$SERVER_ID" = "null" ]; then
+            echo "ERROR: Server creation failed: $RESPONSE"
+            exit 1
+          fi
+          SERVER_IP=$(echo "$RESPONSE" | jq -r '.server.public_net.ipv4.ip')
+          echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+          echo "server_ip=$SERVER_IP" >> "$GITHUB_OUTPUT"
+          echo "Created server: id=$SERVER_ID ip=$SERVER_IP"
+
+      - name: Wait for server to be running
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+          SERVER_ID: ${{ steps.create.outputs.server_id }}
+        run: |
+          for i in $(seq 1 30); do
+            STATUS=$(curl -sf \
+              -H "Authorization: Bearer $HETZNER_TOKEN" \
+              "https://api.hetzner.cloud/v1/servers/$SERVER_ID" \
+              | jq -r '.server.status')
+            echo "Attempt $i/30 — server status: $STATUS"
+            if [ "$STATUS" = "running" ]; then
+              echo "Server is running."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "TIMEOUT: server did not reach running state within 5 minutes."
+          exit 1
+
+      - name: Send Telegram notification
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          MSG="🆕 [Platform] Staging server provisioned\n\nName: ${{ inputs.server_name }}\nIP: ${{ steps.create.outputs.server_ip }}\nType: ${{ inputs.server_type }} / ${{ inputs.image }} @ ${{ inputs.location }}\nID: ${{ steps.create.outputs.server_id }}\n\n⚠️ Remember to deprovision when done to avoid charges."
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":\"$MSG\"}" > /dev/null
+
+  deprovision:
+    name: Deprovision ${{ inputs.server_name }}
+    runs-on: ubuntu-latest
+    needs: provision
+    # This job is intentionally manual — change 'false' to trigger deprovisioning.
+    # In practice: re-run this workflow with the same server_name after staging is done.
+    if: false
+    steps:
+      - name: Delete server
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+          SERVER_ID: ${{ needs.provision.outputs.server_id }}
+        run: |
+          curl -sf -X DELETE \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            "https://api.hetzner.cloud/v1/servers/$SERVER_ID"
+          echo "Server $SERVER_ID deleted."

--- a/.github/workflows/hetzner-snapshot.yml
+++ b/.github/workflows/hetzner-snapshot.yml
@@ -1,0 +1,98 @@
+name: Hetzner Snapshot
+
+on:
+  workflow_call:
+    inputs:
+      reason:
+        description: "Snapshot reason label (e.g. pre-deploy, manual)"
+        required: false
+        type: string
+        default: "manual"
+    outputs:
+      snapshot_id:
+        description: "ID of the created snapshot image"
+        value: ${{ jobs.snapshot.outputs.snapshot_id }}
+      snapshot_name:
+        description: "Name of the created snapshot image"
+        value: ${{ jobs.snapshot.outputs.snapshot_name }}
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Snapshot reason label"
+        required: false
+        default: "manual"
+
+concurrency:
+  group: hetzner-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Create Server Snapshot
+    runs-on: ubuntu-latest
+    outputs:
+      snapshot_id: ${{ steps.create.outputs.snapshot_id }}
+      snapshot_name: ${{ steps.create.outputs.snapshot_name }}
+    steps:
+      - name: Resolve server ID
+        id: resolve
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+        run: |
+          SERVER_ID=$(curl -sf \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            "https://api.hetzner.cloud/v1/servers?per_page=50" \
+            | jq -r '.servers[] | select(.public_net.ipv4.ip == "178.104.45.161") | .id')
+          if [ -z "$SERVER_ID" ]; then
+            echo "ERROR: server 178.104.45.161 not found in Hetzner account"
+            exit 1
+          fi
+          echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+          echo "Resolved server ID: $SERVER_ID"
+
+      - name: Create snapshot
+        id: create
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+          SERVER_ID: ${{ steps.resolve.outputs.server_id }}
+        run: |
+          LABEL="${{ inputs.reason }}-$(date -u +%Y%m%d-%H%M)"
+          RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: Bearer $HETZNER_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.hetzner.cloud/v1/servers/${SERVER_ID}/actions/create_image" \
+            -d "{\"description\":\"$LABEL\",\"type\":\"snapshot\",\"labels\":{\"source\":\"github-actions\",\"reason\":\"${{ inputs.reason }}\"}}")
+          ACTION_ID=$(echo "$RESPONSE" | jq -r '.action.id')
+          IMAGE_ID=$(echo "$RESPONSE" | jq -r '.image.id')
+          if [ -z "$ACTION_ID" ] || [ "$ACTION_ID" = "null" ]; then
+            echo "ERROR: snapshot creation failed: $RESPONSE"
+            exit 1
+          fi
+          echo "snapshot_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
+          echo "snapshot_name=$LABEL" >> "$GITHUB_OUTPUT"
+          echo "action_id=$ACTION_ID" >> "$GITHUB_OUTPUT"
+          echo "Snapshot action $ACTION_ID started (image id: $IMAGE_ID, label: $LABEL)"
+
+      - name: Wait for snapshot completion
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER }}
+          ACTION_ID: ${{ steps.create.outputs.action_id }}
+        run: |
+          for i in $(seq 1 24); do
+            STATUS=$(curl -sf \
+              -H "Authorization: Bearer $HETZNER_TOKEN" \
+              "https://api.hetzner.cloud/v1/actions/${ACTION_ID}" \
+              | jq -r '.action.status')
+            echo "Attempt $i/24 — action status: $STATUS"
+            if [ "$STATUS" = "success" ]; then
+              echo "Snapshot completed successfully."
+              exit 0
+            fi
+            if [ "$STATUS" = "error" ]; then
+              echo "ERROR: snapshot action failed."
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "TIMEOUT: snapshot did not complete within 4 minutes — action may still be running."
+          exit 1


### PR DESCRIPTION
## Summary

- **hetzner-snapshot.yml** — reusable `workflow_call` that creates a snapshot of `178.104.45.161` before any deploy; polls until complete (4 min timeout); outputs `snapshot_id` and `snapshot_name` for downstream steps
- **hetzner-health-check.yml** — runs every 30 min via cron; probes dakera health + 4imapact-demo; on failure queries Hetzner API for server status, triggers soft reboot if server is running-but-unreachable, sends Telegram alert
- **hetzner-provision-staging.yml** — `workflow_dispatch` template to spin up ephemeral staging servers (cx22/cx32, ubuntu-24.04, nbg1 default); duplicate-name guard; Telegram notification with IP + cost reminder
- **4imapact-rescue.yml** — updated to (1) call `hetzner-snapshot` as pre-deploy job, (2) fix `HETZNER_API_TOKEN` → `HETZNER` (correct secret name)

## Secrets

Repo secrets configured (private repo can't use org secrets on GitHub free plan):
- `HETZNER` ✅ — set from founder-confirmed key
- `TELEGRAM_BOT_TOKEN` ✅ — set from ops credentials
- `TELEGRAM_CHAT_ID` ✅ — set from ops credentials

## Test plan

- [ ] Trigger `hetzner-snapshot` via `workflow_dispatch` — verify snapshot appears in Hetzner console
- [ ] Verify `hetzner-health-check` runs on schedule and logs healthy status
- [ ] Simulate unreachable server: verify Telegram alert fires and reboot is triggered
- [ ] Trigger `hetzner-provision-staging` with `server_name=staging-test-1` — verify server created, IP returned, Telegram notification received; then manually delete from Hetzner console

Triggered by: DAK-1753 / DAK-1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)