### PR TITLE
chore: bump dakera server to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-13
+
+### Changed
+
+- Bump dakera server image: `0.9.15` → `0.10.0` in docker-compose, docker-compose.ha, Helm chart, and k8s/dakera/deployment.yaml
+  - v0.10.0: CE-10 Memory Compression + CE-12 Smart Routing + BENCH-1 LoCoMo benchmark
+- Bump Helm chart version: `0.9.15` → `0.10.0` (Chart.yaml + values.yaml)
+- Align docker-compose.ha.yml image tag (was 0.9.14, now 0.10.0)
+
 ## [0.3.2] - 2026-04-07
 
 ### Changed

--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.9.15
-appVersion: "0.9.15"
+version: 0.10.0
+appVersion: "0.10.0"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.9.14"
+    tag: "0.10.0"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.14}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.0}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.9.15}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.9.14"
+    app.kubernetes.io/version: "0.10.0"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.9.14"
+        app.kubernetes.io/version: "0.10.0"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.9.14
+          image: ghcr.io/dakera-ai/dakera:0.10.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bump dakera server image `0.9.15` → `0.10.0` in docker-compose.yml
- Bump dakera server image `0.9.14` → `0.10.0` in docker-compose.ha.yml (was lagging)
- Bump Helm chart version + appVersion to `0.10.0`, values.yaml tag to `0.10.0`
- Bump k8s/dakera/deployment.yaml image + version labels to `0.10.0`
- CHANGELOG: add v0.4.0 entry

v0.10.0 includes: CE-10 Memory Compression, CE-12 Smart Routing, BENCH-1 LoCoMo benchmark.

## Test plan

- [ ] `helm lint charts/dakera` passes
- [ ] `docker compose -f docker/docker-compose.yml config` validates
- [ ] `docker compose -f docker/docker-compose.ha.yml config` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)