### PR TITLE
chore: bump dakera image to v0.10.2 in deploy configs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.1}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.2}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.10.1"
+    app.kubernetes.io/version: "0.10.2"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.10.1"
+        app.kubernetes.io/version: "0.10.2"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.10.1
+          image: ghcr.io/dakera-ai/dakera:0.10.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Update `docker/docker-compose.yml` default dakera image: `0.10.1` → `0.10.2`
- Update `k8s/dakera/deployment.yaml` image + version labels: `0.10.1` → `0.10.2`

## Context
v0.10.2 was deployed to production on 2026-04-13T19:48Z. This PR keeps deploy configs in sync with what's actually running.

**v0.10.2 includes:**
- `fix(inference)`: skip token_type_ids for ONNX models without it (DAK-1835)
- `feat(admin)`: POST /admin/namespaces/migrate-dimensions (DAK-1836)

## Test plan
- [ ] CI passes
- [ ] `docker-compose.yml` references `ghcr.io/dakera-ai/dakera:0.10.2`
- [ ] `k8s/dakera/deployment.yaml` labels and image updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)