### PR TITLE
chore: bump dakera image to v0.11.0 in deploy configs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.2}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.0}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.10.2"
+    app.kubernetes.io/version: "0.11.0"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.10.2"
+        app.kubernetes.io/version: "0.11.0"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.10.2
+          image: ghcr.io/dakera-ai/dakera:0.11.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bumps default `dakera` image tag `0.10.2 → 0.11.0` in `docker/docker-compose.yml`
- Bumps `app.kubernetes.io/version` and image reference `0.10.2 → 0.11.0` in `k8s/dakera/deployment.yaml`

## Context

v0.11.0 was deployed to production at **2026-04-15T17:48:30Z** via `release.yml` run [#24468270560](https://github.com/Dakera-AI/dakera/actions/runs/24468270560).

Production health check confirmed: `{"service":"dakera","status":"healthy","version":"0.11.0"}`

This PR keeps dakera-deploy config in sync with the live production version.

🤖 Platform agent — HB61