### PR TITLE
chore: bump dakera 0.11.0 → 0.11.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.0}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.1}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.0"
+    app.kubernetes.io/version: "0.11.1"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.0"
+        app.kubernetes.io/version: "0.11.1"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.0
+          image: ghcr.io/dakera-ai/dakera:0.11.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Patch release bump: Hybrid over-fetch regression fix ([DAK-1926](https://github.com/Dakera-AI/dakera/issues)).

**Changes since v0.11.0:**
- PR#156: `fix(engine): Hybrid over-fetch 5x→2x when not reranking` — removes RRF consensus-rank bias amplification that caused −6.1pp Recall@20 regression

**Files updated:**
- `docker/docker-compose.yml`: default image tag `0.11.0 → 0.11.1`
- `k8s/dakera/deployment.yaml`: version labels + container image `0.11.0 → 0.11.1`

release.yml run #24493890685 building + deploying v0.11.1 now (ETA ~28min).