### PR TITLE
chore: bump dakera 0.11.1 → 0.11.2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.1}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.2}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.1"
+    app.kubernetes.io/version: "0.11.2"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.1"
+        app.kubernetes.io/version: "0.11.2"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.1
+          image: ghcr.io/dakera-ai/dakera:0.11.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Bump dakera image tag 0.11.1 → 0.11.2 in docker-compose + k8s deployment
- v0.11.2 contains: revert default fusion RRF→MinMax (DAK-1948 fix)

## Changes
- `docker/docker-compose.yml`: image tag 0.11.1 → 0.11.2
- `k8s/dakera/deployment.yaml`: image + labels 0.11.1 → 0.11.2

## Deploy status
- release.yml run #24523627265 queued (tag v0.11.2 pushed 17:09Z)
- ETA: Docker build ~30-40min, production flip ~17:45-18:00Z
- Validate: `curl http://178.104.45.161:3300/health` → version=0.11.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)