### PR TITLE
fix(deploy): increase dakera memory limit 4G → 8G (OOM during full bench)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 8G
           cpus: "2.0"
         reservations:
           memory: 512M


### PR DESCRIPTION
## Problem

Dakera container (v0.11.11) OOM-killed 10 times today during full LoCoMo bench runs. Root cause: the server runs a **local ONNX Runtime embedding model** — under full bench load (1540 store ops across 10 conversations), memory spikes beyond 4GiB due to:

- ONNX Runtime model allocations (observed via `ort::logging: Allocated memory` in server logs)  
- Full-text and vector index loading for all bench namespaces (each namespace restores index from storage on first access)
- L1 cache (1GiB configured) + ONNX runtime + BM25 indices + overhead → exceeds 4GiB

## Fix

Increase memory limit from `4G` to `8G`. Host has 15GiB total / 10GiB available — safe margin.

Memory-swap also raised to 16G (`docker update --memory 8g --memory-swap 16g`) to give the kernel room before hard-killing.

## Already Applied

The live container was updated with `docker update --memory 8g` — no restart needed. This PR persists the config for future deploys.

## Bench Impact

Full 1540Q LoCoMo bench targeting v0.11.11 at `http://178.104.45.161:3300` will be dispatched after merge to validate CE-26 (temporal anchor) and CE-27 (RERANK_BLEND_ALPHA=0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)