### PR TITLE
fix: single-source API key management + auto-propagation

### DIFF
--- a/.github/workflows/server-ops.yml
+++ b/.github/workflows/server-ops.yml
@@ -61,7 +61,7 @@ jobs:
           done
           INSPECT
 
-      - name: Sync auth key
+      - name: Sync auth key to server
         if: inputs.action == 'sync-auth-key'
         env:
           NEW_KEY: ${{ secrets.DAKERA_ROOT_API_KEY }}
@@ -73,26 +73,61 @@ jobs:
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
             ${{ env.DEPLOY_USER }}@${{ env.SERVER_IP }} << SYNC_AUTH
           set -euo pipefail
+
+          # --- 1. Update docker .env (server container) ---
           ENV_FILE="/home/dakera/ops/repos/dakera-deploy/docker/.env"
           if [ ! -f "\$ENV_FILE" ]; then
             echo "❌ .env not found at \$ENV_FILE"
             exit 1
           fi
-          echo "Updating DAKERA_ROOT_API_KEY in \$ENV_FILE..."
+          echo "1/4 Updating DAKERA_ROOT_API_KEY in \$ENV_FILE..."
           if grep -q '^DAKERA_ROOT_API_KEY=' "\$ENV_FILE"; then
             sed -i "s|^DAKERA_ROOT_API_KEY=.*|DAKERA_ROOT_API_KEY=${NEW_KEY}|" "\$ENV_FILE"
           else
             echo "DAKERA_ROOT_API_KEY=${NEW_KEY}" >> "\$ENV_FILE"
           fi
-          echo "Restarting dakera containers..."
+
+          # --- 2. Update agent credentials (MCP + agent heartbeats) ---
+          CREDS="/home/dakera/ops/paperclip/.credentials"
+          if [ -f "\$CREDS" ]; then
+            echo "2/4 Updating DAKERA_API_KEY in \$CREDS..."
+            if grep -q '^DAKERA_API_KEY=' "\$CREDS"; then
+              sed -i "s|^DAKERA_API_KEY=.*|DAKERA_API_KEY=${NEW_KEY}|" "\$CREDS"
+            else
+              echo "DAKERA_API_KEY=${NEW_KEY}" >> "\$CREDS"
+            fi
+          else
+            echo "⚠️ Agent credentials file not found at \$CREDS — skipping"
+          fi
+
+          # --- 3. Restart containers ---
+          echo "3/4 Restarting dakera containers..."
           cd /home/dakera/ops/repos/dakera-deploy/docker
           docker compose --profile dashboard up -d --remove-orphans
           sleep 10
-          echo "Health check..."
-          curl -sf http://localhost:3300/health || echo "Port 3300: unhealthy"
-          echo ""
-          echo "✅ Auth key synced and containers restarted"
+
+          # --- 4. Validate auth works ---
+          echo "4/4 Validating auth with new key..."
+          HTTP_CODE=\$(curl -sf -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${NEW_KEY}" \
+            http://localhost:3300/health)
+          if [ "\$HTTP_CODE" = "200" ]; then
+            echo "✅ Auth validation passed (HTTP \$HTTP_CODE)"
+          else
+            echo "❌ Auth validation FAILED (HTTP \$HTTP_CODE)"
+            exit 1
+          fi
           SYNC_AUTH
+
+      - name: Sync auth key to bench repo
+        if: inputs.action == 'sync-auth-key'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_PACKAGES }}
+          NEW_KEY: ${{ secrets.DAKERA_ROOT_API_KEY }}
+        run: |
+          echo "Syncing DAKERA_API_KEY to dakera-bench repo secret..."
+          echo "$NEW_KEY" | gh secret set DAKERA_API_KEY -R dakera-ai/dakera-bench
+          echo "✅ dakera-bench secret updated"
 
       - name: Deploy version
         if: inputs.action == 'deploy-version'
@@ -164,7 +199,11 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           if [ "${{ job.status }}" = "success" ]; then
-            MSG="✅ [Platform] Server ops: ${{ inputs.action }} completed\nServer: ${{ env.SERVER_IP }}"
+            if [ "${{ inputs.action }}" = "sync-auth-key" ]; then
+              MSG="✅ [Platform] API key synced to all consumers\n\n• Server docker/.env\n• Agent .credentials\n• dakera-bench secret\n• Auth validated"
+            else
+              MSG="✅ [Platform] Server ops: ${{ inputs.action }} completed\nServer: ${{ env.SERVER_IP }}"
+            fi
           else
             MSG="❌ [Platform] Server ops: ${{ inputs.action }} FAILED\nServer: ${{ env.SERVER_IP }}\nCheck: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -79,7 +79,7 @@ x-dakera-env: &dakera-env
   DAKERA_MAX_BODY_SIZE: "524288000"
   # Auth
   DAKERA_AUTH_ENABLED: "${DAKERA_AUTH_ENABLED:-false}"
-  DAKERA_ROOT_API_KEY: "${DAKERA_ROOT_API_KEY:-dk_dev_root_key_change_in_production}"
+  DAKERA_ROOT_API_KEY: "${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.ha.example)}"
   # Logging
   RUST_LOG: "${RUST_LOG:-info,dakera=debug}"
 


### PR DESCRIPTION
## Summary

- **sync-auth-key workflow** now propagates the API key to ALL three consumers in one operation:
  1. Server `docker/.env` → container restart
  2. Agent `.credentials` → MCP + heartbeat processes
  3. `dakera-bench` repo secret → bench runs
- Adds **auth validation step** — workflow fails if the server rejects the new key
- Removes **hardcoded fallback key** from `docker-compose.ha.yml` (was `dk_dev_root_key_change_in_production`)
- **Detailed Telegram notification** lists which consumers were synced

Root cause of DAK-2290: key rotation on 2026-04-24 only updated `docker/.env` — the `.credentials` file and `dakera-bench` secret were stale, causing 401s in MCP and bench runs.

Also fixed locally: `.mcp.json` no longer hardcodes a stale key — it inherits `DAKERA_API_KEY` from the shell environment (set via `.credentials`).

## Test plan

- [ ] Verify workflow YAML is valid (CI lint)
- [ ] Trigger `sync-auth-key` manually and confirm all 3 consumers updated
- [ ] Verify Telegram notification shows consumer list
- [ ] Verify HA compose fails gracefully when `DAKERA_ROOT_API_KEY` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)