### PR TITLE
fix: absorb curl non-zero exit in health check

### DIFF
--- a/.github/workflows/hetzner-health-check.yml
+++ b/.github/workflows/hetzner-health-check.yml
@@ -26,14 +26,14 @@ jobs:
       - name: HTTP health probe
         id: check
         run: |
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.HEALTH_URL }}" 2>/dev/null)
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.HEALTH_URL }}" 2>/dev/null) || true
           [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
           if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "204" ]; then
             echo "Direct port 3300 returned $HTTP_CODE — trying HTTPS via Caddy (port 443)..."
-            HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 "https://${{ env.SERVER_IP }}/health" 2>/dev/null)
+            HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 "https://${{ env.SERVER_IP }}/health" 2>/dev/null) || true
             [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
           fi
-          DEMO_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.DEMO_URL }}" 2>/dev/null)
+          DEMO_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.DEMO_URL }}" 2>/dev/null) || true
           [ -z "$DEMO_CODE" ] && DEMO_CODE="000"
           echo "dakera health endpoint: $HTTP_CODE"
           echo "4imapact-demo: $DEMO_CODE"
@@ -89,10 +89,10 @@ jobs:
         id: recheck
         if: steps.restart.outputs.restart_attempted == 'true'
         run: |
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.HEALTH_URL }}" 2>/dev/null)
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ env.HEALTH_URL }}" 2>/dev/null) || true
           [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
           if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "204" ]; then
-            HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 "https://${{ env.SERVER_IP }}/health" 2>/dev/null)
+            HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 "https://${{ env.SERVER_IP }}/health" 2>/dev/null) || true
             [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
           fi
           echo "Post-restart health check: $HTTP_CODE"


### PR DESCRIPTION
## Summary
- Curl returns exit code 28 on timeout, which caused the health check step to fail immediately under GitHub Actions' `set -e` shell mode
- Added `|| true` to all curl commands so the HTTP status code is captured even when curl fails (timeout, connection refused, etc.)
- Follow-up to https://github.com/Dakera-AI/dakera-deploy/pull/75

## Test plan
- [ ] Trigger `hetzner-health-check.yml` — should report healthy (port 3300 now open via firewall)
- [ ] Even if port 3300 were blocked, the HTTPS fallback on port 443 should prevent step failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)