### PR TITLE
chore: bump deploy configs to v0.11.29 (security patch)

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.10.1
-appVersion: "0.10.1"
+version: 0.11.29
+appVersion: "0.11.29"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.10.1"
+    tag: "0.11.29"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.2}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.29}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bumps Helm chart version and appVersion: `0.10.1` → `0.11.29`
- Bumps Helm values.yaml image tag: `0.10.1` → `0.11.29`
- Bumps docker-compose.yml default image: `0.11.2` → `0.11.29`

## Context

[DAK-2342](/DAK/issues/DAK-2342) — Security patch deploy request.

Production is confirmed healthy at v0.11.31 (ahead of v0.11.29), so security patches are already live. This PR brings the public deploy configs in sync with the latest official GitHub release (v0.11.29).

## Verification

Production health check:
```
GET http://178.104.45.161:3300/health
{"service":"dakera","status":"healthy","version":"0.11.31"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)