### PR TITLE
chore: bump deploy configs to v0.11.30 (SEC-3 passphrase hardening)

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.11.29
-appVersion: "0.11.29"
+version: 0.11.30
+appVersion: "0.11.30"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.11.29"
+    tag: "0.11.30"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.29}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.30}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.2"
+    app.kubernetes.io/version: "0.11.30"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.2"
+        app.kubernetes.io/version: "0.11.30"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.2
+          image: ghcr.io/dakera-ai/dakera:0.11.30
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bumps Dakera server image from **v0.11.29 → v0.11.30** across all deploy targets
- **v0.11.30** includes SEC-3 security hardening: passphrase validation at API boundary, rejects empty/short passphrases with startup warning (7 new security tests)
- Also corrects stale `k8s/deployment.yaml` image tag from `0.11.2` → `0.11.30`

## Files changed
| File | Change |
|------|--------|
| `charts/dakera/Chart.yaml` | version + appVersion: 0.11.29 → 0.11.30 |
| `charts/dakera/values.yaml` | image tag: 0.11.29 → 0.11.30 |
| `docker/docker-compose.yml` | default image: 0.11.29 → 0.11.30 |
| `k8s/dakera/deployment.yaml` | image + labels: 0.11.2 → 0.11.30 |

## Deploy note
After merge, the `deploy-version` workflow will be triggered to push v0.11.30 to production (178.104.45.161). SEC-3 is a security patch — immediate deploy.

Source: https://github.com/Dakera-AI/dakera/pull/244 (merged 2026-04-25T03:21Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)