### PR TITLE
chore: bump dakera server 0.11.30 → 0.11.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-25
+
+### Changed
+
+- Bump dakera server image: `0.11.30` → `0.11.34` in docker-compose, Helm chart, k8s deployment, and values.yaml
+  - v0.11.31: parallel S3/Minio reads (DAK-2432)
+  - v0.11.32: parallel S3 reads fix
+  - v0.11.33: HNSW cache invalidation + session-aware recall (DAK-2434) — 82.4% benchmark recall
+  - v0.11.34: rustls-webpki RUSTSEC-2026-0104 security patch
+- Bump Helm chart version: `0.11.30` → `0.11.34` (Chart.yaml + values.yaml)
+
 ## [0.4.1] - 2026-04-13
 
 ### Changed

--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.11.30
-appVersion: "0.11.30"
+version: 0.11.34
+appVersion: "0.11.34"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.11.30"
+    tag: "0.11.34"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.30}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.34}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.30"
+    app.kubernetes.io/version: "0.11.34"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.30"
+        app.kubernetes.io/version: "0.11.34"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.30
+          image: ghcr.io/dakera-ai/dakera:0.11.34
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Batch version bump covering 4 server releases (v0.11.31–v0.11.34)
- v0.11.31: parallel S3/Minio reads
- v0.11.32: parallel S3 reads fix
- v0.11.33: HNSW cache invalidation + session-aware recall (82.4% benchmark — Phase 1 milestone)
- v0.11.34: rustls-webpki RUSTSEC-2026-0104 security patch
- Updates docker-compose.yml, Helm Chart.yaml + values.yaml, k8s deployment.yaml

## Test plan
- [ ] Helm lint passes in CI
- [ ] `docker compose config` validates with new image tag
- [ ] Production already running v0.11.33 via auto-deploy; v0.11.34 deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)