### PR TITLE
chore: bump dakera 0.11.34 → 0.11.35 + add request timeout

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.10.1}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.35}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -77,6 +77,7 @@ x-dakera-env: &dakera-env
   DAKERA_TIER_CHECK_INTERVAL_SECS: "300"
   # Request limits
   DAKERA_MAX_BODY_SIZE: "524288000"
+  DAKERA_REQUEST_TIMEOUT: "${DAKERA_REQUEST_TIMEOUT:-120}"
   # Auth
   DAKERA_AUTH_ENABLED: "${DAKERA_AUTH_ENABLED:-false}"
   DAKERA_ROOT_API_KEY: "${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.ha.example)}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.34}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.35}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -42,6 +42,7 @@ services:
       - DAKERA_AUTO_TIER=true
       - DAKERA_TIER_CHECK_INTERVAL_SECS=300
       - DAKERA_MAX_BODY_SIZE=524288000
+      - DAKERA_REQUEST_TIMEOUT=${DAKERA_REQUEST_TIMEOUT:-120}
       - DAKERA_AUTH_ENABLED=${DAKERA_AUTH_ENABLED:-true}
       - DAKERA_ROOT_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.example)}
     volumes:


### PR DESCRIPTION
## Summary
- Bump dakera server image from 0.11.34 → 0.11.35 (CE-49/CE-51/CE-52 recall improvements)
- Add `DAKERA_REQUEST_TIMEOUT=120` to both single-node and HA compose files
- HA image bumped from stale 0.10.1 → 0.11.35

## Why
The full 1540Q LoCoMo bench failed with 408 recall timeout on Conv 41 (1000+ memories in namespace). Production server was using default 30s timeout. PR bench already has 120s timeout — production should match.

Run: https://github.com/Dakera-AI/dakera-bench/actions/runs/24943756779

## Test plan
- [ ] Verify compose files are valid: `docker compose -f docker/docker-compose.yml config`
- [ ] Verify HA compose: `docker compose -f docker/docker-compose.ha.yml config`
- [ ] Re-run main bench after deploying — Conv 41 should no longer timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)