### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration for automated weekly dependency updates
- Monitors Docker base images (in /docker) and GitHub Actions workflows
- PRs open on Mondays with a limit of 3 per ecosystem

## Test plan
- [ ] Verify dependabot.yml is valid YAML
- [ ] Dependabot should start opening PRs next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)