### PR TITLE
chore: bump dakera image to v0.11.37

### DIFF
--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.11.34"
+    tag: "0.11.37"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.35}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.37}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.35}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.37}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- Bump default dakera image tag from 0.11.35 → 0.11.37 (docker-compose + HA + Helm values)
- v0.11.37 includes: CE-54 fulltext index coverage (0.46% → 100%), CE-58 configurable RRF k, bench baseline recalibration
- **Post-deploy action**: `POST /admin/fulltext/reindex` to backfill ~1938 un-indexed memories

## Files changed
- `docker/docker-compose.yml` — 0.11.35 → 0.11.37
- `docker/docker-compose.ha.yml` — 0.11.35 → 0.11.37
- `charts/dakera/values.yaml` — 0.11.34 → 0.11.37

## Test plan
- [ ] CI: Helm lint + template + kind deployment test
- [ ] Verify health endpoint returns v0.11.37 after deploy
- [ ] Run POST /admin/fulltext/reindex post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)