### PR TITLE
chore: bump dakera image to v0.11.38

### DIFF
--- a/charts/dakera/Chart.yaml
+++ b/charts/dakera/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dakera
 description: Dakera — AI agent memory platform
 type: application
-version: 0.11.34
-appVersion: "0.11.34"
+version: 0.11.38
+appVersion: "0.11.38"
 keywords:
   - agent-memory
   - ai-memory

--- a/charts/dakera/values.yaml
+++ b/charts/dakera/values.yaml
@@ -9,7 +9,7 @@
 dakera:
   image:
     repository: ghcr.io/dakera-ai/dakera
-    tag: "0.11.37"
+    tag: "0.11.38"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.37}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.38}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.37}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.38}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- Bump Dakera server image from v0.11.37 to v0.11.38 across docker-compose, HA compose, and Helm chart
- Align Chart.yaml version/appVersion (was stuck at 0.11.34)

## Changes in v0.11.38
- **CE-60**: BM25 fulltext cache sync fix — `persist_fulltext_index` wrote to storage but never updated in-memory cache. All callers operated on stale clones. Now cache is refreshed after every persist.
- **DAK-2539**: BM25 indexing for consolidate/summarize paths
- Full 1540Q bench: **86.2% overall (new ATH)**, Cat1 85.8%, Cat4 90.0%

## Files changed
- `docker/docker-compose.yml` — 0.11.37 → 0.11.38
- `docker/docker-compose.ha.yml` — 0.11.37 → 0.11.38
- `charts/dakera/Chart.yaml` — version+appVersion 0.11.34 → 0.11.38
- `charts/dakera/values.yaml` — tag 0.11.37 → 0.11.38

🤖 Generated with [Claude Code](https://claude.com/claude-code)