### PR TITLE
fix: reduce L1 cache 1GB→512MB (server stability P0)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minioadmin}
       - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
       - DAKERA_S3_REGION=us-east-1
-      - DAKERA_L1_CACHE_SIZE=1073741824
+      - DAKERA_L1_CACHE_SIZE=536870912
       - DAKERA_L2_CACHE_PATH=/data/rocksdb
       # Tiered storage (L1 hot → L2 warm → L3 cold via S3)
       - DAKERA_TIERED_STORAGE=true


### PR DESCRIPTION
## Summary
- Reduce `DAKERA_L1_CACHE_SIZE` from 1GB (1073741824) to 512MB (536870912) in `docker/docker-compose.yml`
- Part of P0 server stability fix — Dakera was consuming 4.7GB RSS on startup with 1GB L1 cache
- Production server has only 16GB total with CI runners, agents, and MinIO competing for RAM

## Test plan
- [ ] Deploy to staging and verify Dakera starts with ~512MB L1 cache allocation
- [ ] Confirm RSS stays under 3GB on startup
- [ ] Run memory-intensive workload and verify no OOM kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)