### PR TITLE
fix: tighten container memory limits for OOM prevention

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 8G
+          memory: 5G
           cpus: "2.0"
         reservations:
           memory: 512M
@@ -87,7 +87,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 1G
           cpus: "1.0"
         reservations:
           memory: 256M
@@ -205,7 +205,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 1G
           cpus: "1.0"
         reservations:
           memory: 256M


### PR DESCRIPTION
## Summary
- Dakera: 8G → 5G (actual RSS ~4.7GB, prevents overcommit)
- MinIO: 2G → 1G (cold storage tier, low memory needs)
- Dashboard: 2G → 1G (WASM app, <200MB typical usage)

Prevents recurrence of the 2026-04-26 OOM incident on the 16GB production host. These limits were applied live during the incident and need to be persisted in the repo.

Companion to PR#88 (L1 cache 1GB→512MB).

## Test plan
- [x] Already running in production since OOM fix
- [x] Server healthy at v0.11.39 with these limits
- [ ] Verify no OOM kills for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)