### PR TITLE
chore: bump dakera image to v0.11.39

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.38}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.39}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.38}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.39}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- Bumps dakera image from v0.11.38 to v0.11.39 in docker-compose and HA configs
- v0.11.39 = CE-61 major dep migrations (axum 0.8, tonic 0.14, hmac 0.13, opendal 0.55)
- Full 1540Q bench: 87.3% overall (ATH)

## Test plan
- [ ] CI checks pass
- [ ] Image `ghcr.io/dakera-ai/dakera:0.11.39` verified available

🤖 Generated with [Claude Code](https://claude.com/claude-code)