### PR TITLE
chore: bump dakera image to 0.11.40

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.39}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.40}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.39}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.40}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.34"
+    app.kubernetes.io/version: "0.11.40"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.34"
+        app.kubernetes.io/version: "0.11.40"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.34
+          image: ghcr.io/dakera-ai/dakera:0.11.40
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Bumps Dakera server image from 0.11.39 to 0.11.40 in docker-compose.yml and docker-compose.ha.yml
- Fixes stale k8s deployment.yaml (was at 0.11.34, now 0.11.40)
- v0.11.40 includes CE-64 lazy HNSW namespace loading (P0 server stability), CE-63 person name boost, CE-62 temporal boost infrastructure

## Test plan
- [ ] CI passes (docker-compose validation)
- [ ] Deploy to production after Docker image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)