### PR TITLE
fix(docker): use 127.0.0.1 in healthchecks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -167,6 +167,6 @@ EXPOSE 3000 50051
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://127.0.0.1:3000/health || exit 1
 
 CMD ["dakera"]

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -38,7 +38,7 @@ EXPOSE 3000 50051
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://127.0.0.1:3000/health || exit 1
 
 # Run the server
 CMD ["dakera"]

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -44,7 +44,7 @@ x-dakera-common: &dakera-common
     - "50051"
     - "7946"
   healthcheck:
-    test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+    test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
     interval: 10s
     timeout: 5s
     retries: 5

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -13,7 +13,7 @@ services:
       - DAKERA_GRPC_PORT=50051
       - DAKERA_STORAGE=memory
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -32,7 +32,7 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       minio-setup:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- Replaces `localhost` with `127.0.0.1` in all Docker healthcheck commands across 5 files
- Prevents false-negative healthchecks on Alpine-based containers where `localhost` resolves to `::1` (IPv6) but services bind only `127.0.0.1` (IPv4)
- Aligns with dakera core [PR#320](https://github.com/Dakera-AI/dakera/pull/320) (merged)

## Files changed

- `docker/Dockerfile` — main healthcheck
- `docker/Dockerfile.local` — local dev healthcheck
- `docker/docker-compose.yml` — standalone deploy
- `docker/docker-compose.local.yml` — local MinIO + dakera
- `docker/docker-compose.ha.yml` — HA cluster nodes

## Test plan

- [x] All healthcheck URLs updated to use explicit IPv4
- [x] Comment-only references to localhost left unchanged (port mapping docs)
- [ ] Verify healthchecks work on Alpine and Debian containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)