### PR TITLE
chore: bump dakera server 0.11.42 → 0.11.46

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.42}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.46}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- Bumps dakera server Docker image from 0.11.42 to 0.11.46
- v0.11.46 already deployed to production and verified healthy
- Includes: CE-71 ML classifier, CE-73 auto-PRF, S3 retry backoff, deterministic hybrid sort, Docker healthcheck fix

## Test plan
- [x] Production health verified at v0.11.46
- [x] Release workflow completed (amd64+arm64+multi-arch)
- [x] Quick bench triggered post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)