### PR TITLE
fix: increase MinIO API rate limit to prevent bench starvation

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     environment:
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
+      - MINIO_API_REQUESTS_MAX=${MINIO_API_REQUESTS_MAX:-1500}
     volumes:
       - minio-data:/data
     deploy:


### PR DESCRIPTION
## Summary
- Add `MINIO_API_REQUESTS_MAX=1500` env var to MinIO service in docker-compose
- MinIO's auto-calculated default (304) is too low — bench runs saturate it, starving all memory recall operations including agent memory
- Configurable at deploy time via env var override

## Root Cause
Bench runs send hundreds of concurrent recall requests to Dakera, each requiring vector reads from MinIO. At 304 request limit, MinIO returns 429 TooManyRequests, blocking ALL recall operations (not just bench). Verified fix by live-setting to 1500 — recall recovered immediately.

## Test plan
- [x] Live-tested on production: `mc admin config set local api requests_max=1500` — recall recovered
- [ ] Verify `docker-compose up` applies the env var correctly
- [ ] Bench run completes without MinIO starvation

🤖 Generated with [Claude Code](https://claude.com/claude-code)