### PR TITLE
fix: increase MinIO memory limit 1G→2G to prevent OOM during bench

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,16 +88,16 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
           cpus: "1.0"
         reservations:
-          memory: 256M
+          memory: 512M
           cpus: "0.25"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 10
     restart: unless-stopped
     networks:
       - dakera-net


### PR DESCRIPTION
## Summary
- MinIO memory limit increased from 1G to 2G — bench run 25188018313 failed when MinIO was OOM-killed by Docker (4 restarts, `SIGTERM`)
- MinIO memory reservation increased 256M→512M to ensure adequate baseline allocation
- Healthcheck retries increased 5→10 to tolerate brief MinIO slowdowns during high-load bench runs

## Root Cause
Full 1540Q LoCoMo bench runs create concurrent ingestion + recall load across 10 conversations. MinIO's 1GB limit was insufficient — Docker's memory cgroup killed the process, causing recall timeouts and bench failure at conv-5.

## Test plan
- [x] Verified live: MinIO container recreated with 2GB limit, health check passes
- [x] `docker inspect` confirms `Memory: 2147483648`
- [ ] Re-dispatched bench run should complete without MinIO OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)