### PR TITLE
chore: bump dakera image to v0.11.47

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.42}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.47}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.46}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.47}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
Aligns docker-compose (0.11.46→0.11.47) and HA compose (0.11.42→0.11.47) with production deploy.

🤖 Generated with Claude Code