### PR TITLE
fix(minio): DAK-3430 — raise default MINIO_API_REQUESTS_MAX 1500→6000

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
-      - MINIO_API_REQUESTS_MAX=${MINIO_API_REQUESTS_MAX:-1500}
+      - MINIO_API_REQUESTS_MAX=${MINIO_API_REQUESTS_MAX:-6000}
     volumes:
       - minio-data:/data
     deploy:


### PR DESCRIPTION
## Summary

- MinIO's 1500/min default was breached by a single LoCoMo bench run (~3000 memories), causing a 4.5h production outage.
- Raise default to **6000/min** (100/s) — 5× headroom against a 20 req/s throttled bench (1200/min) and still well within single-node MinIO capacity.
- Override: `MINIO_API_REQUESTS_MAX=<value>` in `docker/.env`.

## Deployment

Production requires restarting MinIO to pick up the new env var:
\`\`\`bash
docker compose pull minio
docker compose up -d minio
\`\`\`

MinIO restart is fast (<5s) and the Dakera server reconnects automatically via retry logic.

## Test plan

- [ ] `docker compose config` shows `MINIO_API_REQUESTS_MAX: 6000`
- [ ] After deploy, `docker logs dakera-minio` should not show 429 rate-limit headers during a bench run
- [ ] Related: dakera-bench PR adds 20 req/s throttle (primary fix); this is defense in depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)