### PR TITLE
fix(server-ops): deploy-version syncs .credentials to prevent post-deploy 401s (DAK-3438)

### DIFF
--- a/.github/workflows/server-ops.yml
+++ b/.github/workflows/server-ops.yml
@@ -170,6 +170,25 @@ jobs:
             else
               echo "DAKERA_ROOT_API_KEY=${NEW_KEY}" >> "\$ENV_FILE"
             fi
+
+            # Sync to agent credentials so heartbeats pick up the fresh key without restart.
+            # Without this, agent processes whose env was loaded before the deploy get 401s.
+            CREDS="/home/dakera/ops/paperclip/.credentials"
+            if [ -f "\$CREDS" ]; then
+              OLD_CREDS_KEY=\$(grep '^DAKERA_API_KEY=' "\$CREDS" 2>/dev/null | cut -d= -f2- || echo "")
+              if grep -q '^DAKERA_API_KEY=' "\$CREDS"; then
+                sed -i "s|^DAKERA_API_KEY=.*|DAKERA_API_KEY=${NEW_KEY}|" "\$CREDS"
+              else
+                echo "DAKERA_API_KEY=${NEW_KEY}" >> "\$CREDS"
+              fi
+              if [ "\$OLD_CREDS_KEY" != "${NEW_KEY}" ]; then
+                echo "⚠️  API key rotated — .credentials updated. In-flight agent heartbeats may still 401; next heartbeat will start clean."
+              else
+                echo "API key unchanged — .credentials already current"
+              fi
+            else
+              echo "⚠️  Agent credentials file not found at \$CREDS — skipping"
+            fi
           fi
 
           docker compose pull
@@ -201,6 +220,8 @@ jobs:
           if [ "${{ job.status }}" = "success" ]; then
             if [ "${{ inputs.action }}" = "sync-auth-key" ]; then
               MSG="✅ [Platform] API key synced to all consumers\n\n• Server docker/.env\n• Agent .credentials\n• dakera-bench secret\n• Auth validated"
+            elif [ "${{ inputs.action }}" = "deploy-version" ]; then
+              MSG="✅ [Platform] deploy-version v${{ inputs.version }} complete\n\n• Server: ${{ env.SERVER_IP }}\n• docker/.env updated\n• .credentials synced (agents pick up fresh key on next heartbeat)\n• Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             else
               MSG="✅ [Platform] Server ops: ${{ inputs.action }} completed\nServer: ${{ env.SERVER_IP }}"
             fi


### PR DESCRIPTION
## Problem

When `deploy-version` runs, it rewrites `docker/.env` with `DAKERA_ROOT_API_KEY` from the GH secret. If the secret value differs from the previous `.env` value, the production server starts rejecting any agent process whose in-memory `DAKERA_API_KEY` was loaded before the rotation — causing silent 401 failures on memory store calls until the process restarts.

Root cause: `deploy-version` only updated `docker/.env`. Only `sync-auth-key` updated `/home/dakera/ops/paperclip/.credentials`. This asymmetry was the bug.

Discovered during the DAK-3430 P0 merge sequence (2026-05-06): CTO heartbeat at 03:30Z lost MCP auth after a successful deploy, failing Phase 3 memory persistence silently.

## Fix

Inside the `deploy-version` SSH block, after syncing `DAKERA_ROOT_API_KEY` to `docker/.env`, the workflow now also upserts `DAKERA_API_KEY` in `.credentials` using the same sed-upsert pattern already used by `sync-auth-key`. Key-rotation is detected and logged in the Actions output.

Telegram success message updated to confirm both files were synced.

## Scope

In-flight heartbeats that already loaded the old key will still 401 for the remainder of that heartbeat. The next heartbeat starts clean. Fix #2 (adapter reads `.credentials` per-heartbeat) would solve in-flight 401s but requires adapter code changes — out of scope here.

Tracking: DAK-3430 → DAK-3431 → DAK-3438

🤖 Generated with [Claude Code](https://claude.com/claude-code)