### PR TITLE
fix(server-ops): avoid false exit-1 on successful deploy (DAK-3449)

### DIFF
--- a/.github/workflows/server-ops.yml
+++ b/.github/workflows/server-ops.yml
@@ -196,17 +196,22 @@ jobs:
 
           echo "Waiting for startup..."
           sleep 15
+          DEPLOYED=0
           for i in \$(seq 1 12); do
             RESPONSE=\$(curl -sf --max-time 10 "http://localhost:3300/health" 2>/dev/null || echo '{"error":"unreachable"}')
             VER=\$(echo "\$RESPONSE" | jq -r '.version // "unknown"')
             STATUS=\$(echo "\$RESPONSE" | jq -r '.status // "unknown"')
             echo "Attempt \$i/12 — status=\$STATUS version=\$VER"
             if [ "\$VER" = "\${VERSION}" ] && [ "\$STATUS" = "healthy" ]; then
-              echo "✅ Deployed and healthy: v\${VERSION}"
-              exit 0
+              DEPLOYED=1
+              break
             fi
             sleep 10
           done
+          if [ "\$DEPLOYED" -eq 1 ]; then
+            echo "✅ Deployed and healthy: v\${VERSION}"
+            exit 0
+          fi
           echo "❌ Health check failed after 2 minutes"
           exit 1
           DEPLOY


### PR DESCRIPTION
## Summary

- Replaces `exit 0` inside the health-poll `for` loop in the SSH heredoc with a `DEPLOYED=1; break` pattern
- After the loop, a single `if [ "$DEPLOYED" -eq 1 ]` block emits the success message and exits 0
- This eliminates the ambiguity where `exit 0` inside a loop body inside an SSH heredoc with `set -euo pipefail` can propagate as exit code 1 to the GitHub Actions step

**Root cause:** `exit 0` fired correctly on the remote (SSH session closed cleanly), but the interaction between `set -euo pipefail`, the heredoc subshell context, and how GitHub Actions counts the step's exit code caused the runner to see exit 1. Using a flag variable + `break` keeps all exit decisions at the top level of the script, after the loop terminates, which is unambiguous.

**Evidence from failing run:** https://github.com/Dakera-AI/dakera-deploy/actions/runs/25416165752
```
Attempt 1/12 — status=healthy version=0.11.50
✅ Deployed and healthy: v0.11.50
##[error]Process completed with exit code 1.
```
Production was healthy but workflow was marked failure.

## Test plan

- [ ] Trigger `deploy-version` workflow dispatch for the next release and confirm the step exits green
- [ ] Verify Telegram notification sends the success variant (not the failure one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)