### PR TITLE
fix(minio): DAK-3969 — raise MinIO CPU 1.0→2.0 and memory 2G→4G

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 5G
+          memory: 4G
           cpus: "2.0"
         reservations:
           memory: 512M
@@ -88,8 +88,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: "1.0"
+          memory: 4G
+          cpus: "2.0"
         reservations:
           memory: 512M
           cpus: "0.25"


### PR DESCRIPTION
## Root Cause

MinIO was capped at **1.0 CPU** and **2G RAM** in the single-node compose. With 9000+ vectors accumulated during a full LoCoMo bench run, every HNSW recall fires many concurrent S3 requests into MinIO. The 1-CPU Docker limit became the bottleneck, causing MinIO to saturate at 100% CPU and search times to balloon to **30-37 seconds** on both bench and production.

## Changes

| Service | Before | After |
|---------|--------|-------|
| MinIO `cpus` | `1.0` | `2.0` |
| MinIO `memory` | `2G` | `4G` (per DAK-3969 fix option 2: "Tune MinIO with >=4GB RAM") |
| Dakera `memory` | `5G` | `4G` (reduced to stay within 8GB prod server budget) |

## Deployment

Requires a `docker compose up -d --force-recreate minio dakera` on production (178.104.45.161) to take effect. Production SSH is currently broken — CTO/founder needs to apply once SSH is restored, or via the existing server-ops workflow.

## Related

- DAK-3969 (this issue)
- DAK-3430 (previous MinIO fix: raised MINIO_API_REQUESTS_MAX 1500→6000)
- Companion PR in dakera-bench: adds local server mode to locomo.yml (DAK-3969 fix option 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)