### PR TITLE
fix(deploy): sync docker-compose.yml to server before compose up

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,12 +35,30 @@ jobs:
           }
           echo "✅ Image exists"
 
+      - name: Checkout deploy config
+        uses: actions/checkout@v4
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ env.SERVER_IP }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync docker-compose.yml to server
+        run: |
+          echo "Syncing docker/docker-compose.yml to server..."
+          # Resolve compose dir via container label; fall back to known install path
+          COMPOSE_DIR=$(ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+            ${{ env.DEPLOY_USER }}@${{ env.SERVER_IP }} \
+            "CONTAINER=\$(docker ps --filter 'name=dakera' --format '{{.Names}}' | head -1); \
+             [ -n \"\$CONTAINER\" ] && docker inspect \"\$CONTAINER\" --format '{{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}' 2>/dev/null || true")
+          COMPOSE_DIR="${COMPOSE_DIR:-/home/dakera/ops/repos/dakera-deploy/docker}"
+          echo "Compose dir: $COMPOSE_DIR"
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+            docker/docker-compose.yml \
+            "${{ env.DEPLOY_USER }}@${{ env.SERVER_IP }}:$COMPOSE_DIR/docker-compose.yml"
+          echo "✅ docker-compose.yml synced"
 
       - name: Deploy via SSH
         run: |
@@ -59,7 +77,7 @@ jobs:
             # Try docker-compose if available
             if [ -f /opt/dakera/docker-compose.yml ]; then
               cd /opt/dakera
-              DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d
+              DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d --force-recreate minio minio-setup dakera
             else
               echo "ERROR: No docker-compose.yml found at /opt/dakera/"
               exit 1
@@ -69,7 +87,8 @@ jobs:
             COMPOSE_DIR=$(docker inspect "$CONTAINER" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || echo "")
             if [ -n "$COMPOSE_DIR" ] && [ -d "$COMPOSE_DIR" ]; then
               cd "$COMPOSE_DIR"
-              DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d
+              # Force-recreate minio so new resource limits (cpus/memory) take effect
+              DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d --force-recreate minio minio-setup dakera
             else
               echo "Stopping old container and starting new one..."
               # Get the current container's config

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 5G
+          memory: 4G
           cpus: "2.0"
         reservations:
           memory: 512M
@@ -88,8 +88,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: "1.0"
+          memory: 4G
+          cpus: "2.0"
         reservations:
           memory: 512M
           cpus: "0.25"


### PR DESCRIPTION
## Summary
- Adds `actions/checkout` so the runner has the latest `docker/docker-compose.yml`
- New "Sync docker-compose.yml to server" step: SCPs the file to the server's compose dir before running `docker compose up -d`
- Adds `--force-recreate minio minio-setup dakera` so resource limit changes (MinIO cpus 1.0→2.0, memory 2G→4G from PR#106) actually take effect

Without this, triggering deploy-production.yml after a docker-compose.yml change (like the MinIO limits fix) would leave the server running the old config — the compose up would be a no-op for MinIO.

Needed for DAK-3975 (apply MinIO CPU/memory limits to production).

## Test plan
- [ ] CI passes
- [ ] Trigger deploy-production.yml with version `0.11.53` after merge — verify MinIO container recreated with new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)