### PR TITLE
chore: community health files — SECURITY.md + CONTRIBUTING.md security section (DAK-4722)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Email: security@dakera.ai
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested mitigations
+
+### Response Timeline
+
+- **Acknowledgement**: within 2 business days
+- **Initial assessment**: within 5 business days
+- **Fix and disclosure**: coordinated with the reporter
+
+## Supported Versions
+
+We actively maintain the latest release. Security patches are applied to the most recent version.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | ✅ Yes     |
+| Older   | ❌ No      |
+
+## Scope
+
+This policy covers security vulnerabilities in the Dakera deployment tooling, including:
+- Docker Compose configurations and container definitions
+- Helm chart templates and default values
+- Startup scripts and environment configuration
+- Network and service exposure settings
+
+For vulnerabilities in the Dakera server itself, see the [dakera](https://github.com/dakera-ai/dakera) repository.
+For the hosted Dakera service, use the same email address above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,16 @@ docker compose up
 
 ## Reporting Issues
 
-- Use the GitHub issue templates for bug reports and feature requests
-- Include reproduction steps for bugs
-- Provide environment details (OS, runtime version, etc.)
+Use the [Bug Report](https://github.com/Dakera-AI/dakera-deploy/issues/new?template=bug_report.md) template to report bugs. Please include:
+- Deployment method (Docker Compose, Helm, K8s)
+- Steps to reproduce the issue
+- Expected vs actual behavior
+
+Have a feature idea? Use the [Feature Request](https://github.com/Dakera-AI/dakera-deploy/issues/new?template=feature_request.md) template.
+
+## Security Vulnerabilities
+
+**Do not open public issues for security vulnerabilities.** See [SECURITY.md](.github/SECURITY.md) for responsible disclosure instructions — email security@dakera.ai.
 
 ## License
 


### PR DESCRIPTION
## Summary

Implements DAK-4722 — adds missing community health files to dakera-deploy.

## Changes

- **SECURITY.md** (NEW) — responsible disclosure with deploy-specific scope (Docker Compose configs, Helm chart templates, network/service exposure)
- **CONTRIBUTING.md** (enhanced) — specific issue template links, security reporting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)