### PR TITLE
docs: deploy completeness audit — security fixes, version bumps, examples (DAK-4926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-14
+
+### Security
+
+- **HA compose**: Remove `mc anonymous set download` from MinIO setup — HA stack still had the SA-2026-001 anonymous bucket vulnerability that was fixed in the default compose
+- **HA compose**: Replace hardcoded `dk_dev_root_key_change_in_production` fallback in dashboard with required env var (`DAKERA_ROOT_API_KEY` is now required, matching the default compose behavior)
+
+### Changed
+
+- Bump dakera server image: `0.11.48` → `0.11.55` in docker-compose, docker-compose.ha, and k8s deployment
+  - v0.11.49–v0.11.55: CE-111 through CE-117 recall improvements, ML classifier tuning, temporal inference, smart scoring weights
+- Bump k8s dakera deployment: align version labels (`0.11.40` → `0.11.55`) and image tag (`0.11.42` → `0.11.55`)
+- Fix docker-compose.local.yml: replace `build` context (required dakera source) with pre-built GHCR image — the "Zero to Running in 5 Minutes" quickstart now works without cloning the server repo
+- Remove deprecated `version: "3.8"` from docker-compose.dev.yml
+
+### Added
+
+- `examples/` directory with deployment guides:
+  - `quickstart.md` — store and recall first memory in 5 minutes
+  - `environment-variables.md` — complete env var reference including tiered storage, Redis, request limits, and HA port overrides
+  - `production-checklist.md` — security, storage, HA, and monitoring checklist
+  - `backup-restore.md` — MinIO backup procedures and disaster recovery
+
+### Fixed
+
+- README: HA section listed wrong ports (3000/50051/9001) — corrected to actual HA defaults (3100/50151/9101)
+- README: HA architecture diagram showed wrong Prometheus (:9090) and Grafana (:3001) ports — corrected to :9190/:3203
+- README: Remove private repo link (`dakera-cli`) from Related Repositories
+- README: Add missing environment variable sections (tiered storage, request limits, Redis)
+- README: Update version pinning example from v0.9.9 to v0.11.55
+
 ## [0.4.2] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Production-grade single-node deployment with MinIO, caching, and health checks.
 > **Version pinning**: The default image tags are pinned to the latest stable release.
 > To run a specific version, set `DAKERA_IMAGE` and `DASHBOARD_IMAGE` in your `.env`:
 > ```bash
-> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.9.9
-> DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:0.3.28
+> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.55
+> DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:0.3.29
 > ```
 > Pinning to explicit versions prevents unexpected upgrades in production.
 
@@ -139,11 +139,11 @@ cd docker
 docker compose -f docker-compose.ha.yml up -d
 ```
 
-- REST API (load balanced): http://localhost:3000
-- gRPC API (load balanced): localhost:50051
+- REST API (load balanced): http://localhost:3100
+- gRPC API (load balanced): localhost:50151
 - Traefik Dashboard: http://localhost:8080
-- MinIO Console: http://localhost:9001
-- Cluster status: http://localhost:3000/admin/cluster/status
+- MinIO Console: http://localhost:9101
+- Cluster status: http://localhost:3100/admin/cluster/status
 
 ### Monitoring (Prometheus + Grafana)
 
@@ -173,6 +173,15 @@ Pre-configured dashboards include request rates, latency percentiles, cache hit 
 ### Kubernetes
 
 Production deployment via kubectl or Helm. See [Kubernetes Deployment](#kubernetes-deployment) below.
+
+## Deployment Guides
+
+Step-by-step guides in the [`examples/`](examples/) directory:
+
+- **[Quickstart](examples/quickstart.md)** — Store and recall your first memory in 5 minutes
+- **[Environment Variables](examples/environment-variables.md)** — Complete reference for all configuration options
+- **[Production Checklist](examples/production-checklist.md)** — Security, storage, HA, and monitoring checklist
+- **[Backup & Restore](examples/backup-restore.md)** — MinIO backup procedures and disaster recovery
 
 ## Directory Structure
 
@@ -223,6 +232,11 @@ dakera-deploy/
 │               ├── dashboards.yml   # Dashboard auto-provisioning config
 │               └── json/
 │                   └── dakera-overview.json  # Overview + decay dashboards
+├── examples/                        # Deployment guides and references
+│   ├── quickstart.md                # Zero-to-running tutorial
+│   ├── environment-variables.md     # Complete env var reference
+│   ├── production-checklist.md      # Pre-production checklist
+│   └── backup-restore.md           # Backup and restore procedures
 ├── LICENSE
 ├── CHANGELOG.md
 └── README.md
@@ -270,12 +284,36 @@ dakera-deploy/
 | `DAKERA_GOSSIP_BIND` | `0.0.0.0:7946` | Gossip bind address |
 | `DAKERA_API_ADVERTISE` | - | Advertised API URL for the node |
 
+### Tiered Storage
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_TIERED_STORAGE` | `false` | Enable L1→L2→L3 tiered storage |
+| `DAKERA_HOT_TO_WARM_SECS` | `3600` | Seconds before hot data moves to warm (RocksDB) |
+| `DAKERA_WARM_TO_COLD_SECS` | `86400` | Seconds before warm data moves to cold (S3) |
+| `DAKERA_AUTO_TIER` | `false` | Automatic tier promotion/demotion |
+| `DAKERA_TIER_CHECK_INTERVAL_SECS` | `300` | Interval for tier check sweep |
+
+### Request Limits
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_MAX_BODY_SIZE` | `524288000` | Max request body size in bytes (500MB) |
+| `DAKERA_REQUEST_TIMEOUT` | `120` | Request timeout in seconds |
+
+### Redis (HA Mode)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_CACHE_REDIS_URL` | - | Redis URL for distributed cache |
+| `DAKERA_REDIS_URL` | - | Redis URL for rate-limit counters and SSE fan-out |
+
 ### Authentication
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DAKERA_AUTH_ENABLED` | `false` | Enable API authentication |
-| `DAKERA_ROOT_API_KEY` | - | Root API key (change in production) |
+| `DAKERA_ROOT_API_KEY` | - | Root API key (**required** in production compose) |
 
 ## HA Architecture
 
@@ -317,7 +355,7 @@ dakera-deploy/
                     │
               ┌─────▼──────┐    ┌────────────┐
               │ Prometheus  │───▶│  Grafana   │
-              │   :9090     │    │   :3001    │
+              │   :9190     │    │   :3203    │
               └─────────────┘    └────────────┘
 ```
 
@@ -466,14 +504,13 @@ Before deploying to a production or internet-facing environment:
 | Network isolation | Do **not** expose MinIO ports (9000, 9001) publicly |
 | TLS termination | Use a reverse proxy (nginx, Traefik, Caddy) with HTTPS |
 
-See [CONFIGURATION.md](https://github.com/dakera-ai/dakera-docs/blob/main/CONFIGURATION.md) for the full authentication reference.
+See [dakera.ai](https://dakera.ai) for the full authentication and configuration reference.
 
 ## Related Repositories
 
 | Repository | Description |
 |------------|-------------|
 | [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) | MCP Server for AI agent memory (83 tools) |
-| [dakera-cli](https://github.com/dakera-ai/dakera-cli) | Command-line interface |
 | [dakera-py](https://github.com/dakera-ai/dakera-py) | Python SDK |
 | [dakera-js](https://github.com/dakera-ai/dakera-js) | TypeScript/JavaScript SDK |
 | [dakera-go](https://github.com/dakera-ai/dakera-go) | Go SDK |

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,8 +1,6 @@
 # Dakera Development Docker Compose
 # Lightweight setup for local development and testing
 
-version: "3.8"
-
 services:
   # ==========================================================================
   # MinIO - S3-Compatible Object Storage (Development)

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.48}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -252,7 +252,6 @@ services:
       /bin/sh -c "
       mc alias set myminio http://minio:9000 $${MINIO_ROOT_USER:-minioadmin} $${MINIO_ROOT_PASSWORD:-minioadmin};
       mc mb myminio/dakera --ignore-existing;
-      mc anonymous set download myminio/dakera;
       echo 'Dakera bucket ready';
       exit 0;
       "
@@ -269,7 +268,7 @@ services:
       - "${HA_DASHBOARD_PORT:-3202}:3000"
     environment:
       - DAKERA_API_UPSTREAM=http://dakera-traefik:3000
-      - DAKERA_API_KEY=${DAKERA_ROOT_API_KEY:-dk_dev_root_key_change_in_production}
+      - DAKERA_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.ha.example)}
     depends_on:
       dakera-1:
         condition: service_healthy

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,8 +1,6 @@
 services:
   dakera:
-    build:
-      context: ..
-      dockerfile: deploy/Dockerfile.local
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.48}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/examples/backup-restore.md
+++ b/examples/backup-restore.md
@@ -1,0 +1,103 @@
+# Backup and Restore
+
+Dakera stores all persistent data in S3-compatible storage (MinIO by default). Backups protect against data loss from hardware failure, accidental deletion, or corrupted upgrades.
+
+## What to Back Up
+
+| Component | Location | Contains |
+|-----------|----------|----------|
+| MinIO data | `minio-data` Docker volume | All memory vectors, metadata, and namespace data |
+| RocksDB cache | `dakera-rocksdb` Docker volume | L2 warm-tier cache (rebuilds automatically from S3) |
+| Environment config | `docker/.env` | API keys, MinIO credentials, custom settings |
+
+**MinIO data is the critical backup target.** RocksDB is a cache that rebuilds from S3 on startup.
+
+## Backup Procedures
+
+### Option 1: MinIO Client (`mc`)
+
+The MinIO client can mirror the entire bucket to a local directory or another S3-compatible target.
+
+```bash
+# Install mc (if not already available)
+# https://min.io/docs/minio/linux/reference/minio-mc.html
+
+# Configure the MinIO alias
+mc alias set dakera-local http://localhost:9000 minioadmin minioadmin
+
+# Mirror to a local directory
+mc mirror dakera-local/dakera /backups/dakera-$(date +%Y%m%d)
+
+# Mirror to another S3 bucket (offsite backup)
+mc alias set backup-s3 https://s3.amazonaws.com ACCESS_KEY SECRET_KEY
+mc mirror dakera-local/dakera backup-s3/dakera-backup
+```
+
+### Option 2: Docker Volume Backup
+
+```bash
+# Stop Dakera to ensure consistency
+docker compose down
+
+# Back up the MinIO volume
+docker run --rm \
+  -v dakera_minio-data:/source:ro \
+  -v /backups:/backup \
+  alpine tar czf /backup/minio-data-$(date +%Y%m%d).tar.gz -C /source .
+
+# Restart
+docker compose up -d
+```
+
+### Option 3: Scheduled Backups with Cron
+
+```bash
+# Add to crontab: daily backup at 2 AM
+0 2 * * * mc mirror --overwrite dakera-local/dakera /backups/dakera-daily 2>&1 | logger -t dakera-backup
+```
+
+## Restore Procedures
+
+### Restore from `mc` Mirror
+
+```bash
+# Stop Dakera
+docker compose down
+
+# Restore the bucket contents
+mc mirror /backups/dakera-20260514 dakera-local/dakera
+
+# Restart
+docker compose up -d
+```
+
+### Restore from Volume Backup
+
+```bash
+# Stop Dakera
+docker compose down
+
+# Remove the old volume and recreate
+docker volume rm dakera_minio-data
+docker volume create dakera_minio-data
+
+# Restore
+docker run --rm \
+  -v dakera_minio-data:/target \
+  -v /backups:/backup:ro \
+  alpine tar xzf /backup/minio-data-20260514.tar.gz -C /target
+
+# Restart
+docker compose up -d
+
+# Verify health
+curl http://localhost:3000/health
+```
+
+## Best Practices
+
+- **Test restores regularly** — a backup you haven't tested is not a backup
+- **Keep offsite copies** — mirror to a separate S3 provider or physical location
+- **Retain multiple snapshots** — keep at least 7 daily and 4 weekly backups
+- **Back up `.env` separately** — losing your `DAKERA_ROOT_API_KEY` means losing access to encrypted data
+- **Monitor backup size** — sudden changes in backup size may indicate data corruption or unexpected growth

--- a/examples/environment-variables.md
+++ b/examples/environment-variables.md
@@ -1,0 +1,108 @@
+# Environment Variable Reference
+
+Complete reference for all Dakera server environment variables. Set these in `docker/.env` (Docker Compose) or in your Kubernetes Secret/ConfigMap.
+
+## Required (Production)
+
+| Variable | Description |
+|----------|-------------|
+| `DAKERA_ROOT_API_KEY` | Root API key. Generate with `openssl rand -hex 32`. The default compose refuses to start without this. |
+| `MINIO_ROOT_USER` | MinIO admin username. Change from `minioadmin` in production. |
+| `MINIO_ROOT_PASSWORD` | MinIO admin password. Change from `minioadmin` in production. |
+
+## Core
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_HOST` | `0.0.0.0` | Bind address |
+| `DAKERA_PORT` | `3000` | REST API port |
+| `DAKERA_GRPC_PORT` | `50051` | gRPC API port |
+| `DAKERA_STORAGE` | `memory` | Storage backend: `memory` (ephemeral) or `s3` (persistent) |
+| `RUST_LOG` | `info` | Log verbosity (`error`, `warn`, `info`, `debug`, `trace`) |
+| `DAKERA_AUTH_ENABLED` | `true` (prod) / `false` (local) | Require API key authentication |
+
+## S3 / MinIO Storage
+
+Required when `DAKERA_STORAGE=s3`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_S3_ENDPOINT` | — | S3-compatible endpoint (e.g. `http://minio:9000`) |
+| `DAKERA_S3_BUCKET` | `dakera` | Storage bucket name |
+| `DAKERA_S3_REGION` | `us-east-1` | S3 region |
+| `AWS_ACCESS_KEY_ID` | — | S3 access key (or `DAKERA_S3_ACCESS_KEY`) |
+| `AWS_SECRET_ACCESS_KEY` | — | S3 secret key (or `DAKERA_S3_SECRET_KEY`) |
+
+## Cache
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_L1_CACHE_SIZE` | `536870912` (512MB) | In-memory L1 cache size in bytes |
+| `DAKERA_L2_CACHE_PATH` | `/data/rocksdb` | RocksDB L2 cache directory |
+| `DAKERA_CACHE_DIR` | `/data/cache` | General cache directory |
+
+## Tiered Storage
+
+Automatically moves data between hot (L1), warm (L2/RocksDB), and cold (L3/S3) tiers.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_TIERED_STORAGE` | `false` | Enable tiered storage |
+| `DAKERA_HOT_TO_WARM_SECS` | `3600` | Seconds before hot → warm tier transition |
+| `DAKERA_WARM_TO_COLD_SECS` | `86400` | Seconds before warm → cold tier transition |
+| `DAKERA_AUTO_TIER` | `false` | Enable automatic tier transitions |
+| `DAKERA_TIER_CHECK_INTERVAL_SECS` | `300` | Interval between tier sweep checks |
+
+## Cluster (HA Mode)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_CLUSTER_MODE` | `false` | Enable cluster mode |
+| `DAKERA_CLUSTER_ROLE` | — | Node role: `primary` or `replica` |
+| `DAKERA_CLUSTER_SEEDS` | — | Comma-separated seed nodes (`host:port,host:port`) |
+| `DAKERA_NODE_ID` | — | Unique node identifier |
+| `DAKERA_GOSSIP_PORT` | `7946` | Gossip protocol port |
+| `DAKERA_GOSSIP_BIND` | `0.0.0.0:7946` | Gossip bind address |
+| `DAKERA_API_ADVERTISE` | — | Advertised API URL for the node |
+| `DAKERA_CACHE_REDIS_URL` | — | Redis URL for distributed cache |
+| `DAKERA_REDIS_URL` | — | Redis URL for rate-limit counters and SSE pub/sub |
+
+## Request Limits
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_MAX_BODY_SIZE` | `524288000` | Max request body size in bytes (500 MB) |
+| `DAKERA_REQUEST_TIMEOUT` | `120` | Request timeout in seconds |
+
+## Docker Compose Port Overrides
+
+The default and HA compose files expose different ports to allow co-deployment on the same host.
+
+### Default Profile (`docker-compose.yml`)
+
+| Variable | Default | Service |
+|----------|---------|---------|
+| `DAKERA_PORT` | `3000` | Dakera REST API |
+| `DAKERA_GRPC_PORT` | `50051` | Dakera gRPC |
+| `MINIO_API_PORT` | `9000` | MinIO S3 API |
+| `MINIO_CONSOLE_PORT` | `9001` | MinIO web console |
+| `PROMETHEUS_PORT` | `9090` | Prometheus (monitoring profile) |
+| `GRAFANA_PORT` | `3003` | Grafana (monitoring profile) |
+| `DASHBOARD_PORT` | `3002` | Dashboard UI (dashboard profile) |
+
+### HA Profile (`docker-compose.ha.yml`)
+
+All HA ports use the `HA_` prefix to avoid conflicts with the default profile.
+
+| Variable | Default | Service |
+|----------|---------|---------|
+| `HA_LB_HTTP_PORT` | `3100` | Traefik → Dakera REST API |
+| `HA_LB_GRPC_PORT` | `50151` | Traefik → Dakera gRPC |
+| `HA_TRAEFIK_PORT` | `8080` | Traefik dashboard |
+| `HA_MINIO_API_PORT` | `9100` | MinIO S3 API |
+| `HA_MINIO_CONSOLE_PORT` | `9101` | MinIO web console |
+| `HA_REDIS_PORT` | `6480` | Redis |
+| `HA_DASHBOARD_PORT` | `3202` | Dashboard UI |
+| `HA_PROMETHEUS_PORT` | `9190` | Prometheus (monitoring profile) |
+| `HA_GRAFANA_PORT` | `3203` | Grafana (monitoring profile) |
+| `HA_JAEGER_UI_PORT` | `16787` | Jaeger UI (monitoring profile) |

--- a/examples/production-checklist.md
+++ b/examples/production-checklist.md
@@ -1,0 +1,48 @@
+# Production Deployment Checklist
+
+Use this checklist before exposing Dakera to the internet or handling real workloads.
+
+## Security
+
+- [ ] **Set a strong API key**: `DAKERA_ROOT_API_KEY=$(openssl rand -hex 32)`
+- [ ] **Enable authentication**: `DAKERA_AUTH_ENABLED=true` (default in production compose)
+- [ ] **Change MinIO credentials**: Replace `minioadmin`/`minioadmin` with strong credentials
+- [ ] **Do NOT expose MinIO ports publicly**: Ports 9000/9001 should only be accessible within the Docker network
+- [ ] **Enable TLS**: Use a reverse proxy (Traefik, nginx, Caddy) with HTTPS certificates
+- [ ] **Restrict network access**: Use firewall rules to limit who can reach the API
+
+## Storage
+
+- [ ] **Use persistent storage**: Use the default profile (MinIO-backed) or native S3, not in-memory mode
+- [ ] **Pin image versions**: Set `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.55` explicitly — never use `latest` in production
+- [ ] **Mount volumes**: Ensure `dakera-cache`, `dakera-rocksdb`, and `minio-data` volumes are on reliable storage
+- [ ] **Configure backups**: See [backup-restore.md](backup-restore.md) for backup procedures
+
+## Performance
+
+- [ ] **Set resource limits**: The default compose includes memory (4G) and CPU (2.0) limits — adjust based on your workload
+- [ ] **Tune L1 cache**: `DAKERA_L1_CACHE_SIZE` defaults to 512MB — increase for memory-heavy workloads
+- [ ] **Enable tiered storage**: Set `DAKERA_TIERED_STORAGE=true` to automatically tier hot/warm/cold data
+- [ ] **Monitor MinIO**: If using MinIO, set `MINIO_API_REQUESTS_MAX` (default 6000) based on your concurrency
+
+## High Availability
+
+- [ ] **Use the HA profile** for production: `docker compose -f docker-compose.ha.yml up -d`
+- [ ] **Deploy 3+ nodes**: The HA compose includes 3 Dakera nodes by default
+- [ ] **Set up Redis**: Required for HA mode — distributed cache, rate-limit counters, SSE fan-out
+- [ ] **Configure seed nodes**: Each node needs `DAKERA_CLUSTER_SEEDS` pointing to other nodes
+- [ ] **Test failover**: Stop one node and verify traffic routes to remaining nodes
+
+## Monitoring
+
+- [ ] **Enable the monitoring profile**: `docker compose -f docker-compose.ha.yml --profile monitoring up -d`
+- [ ] **Check dashboards**: Grafana at the configured port has pre-built Dakera dashboards
+- [ ] **Set up alerts**: Configure Prometheus alerting rules for health check failures and high latency
+- [ ] **Monitor `/metrics`**: Dakera exposes Prometheus metrics at `GET /metrics`
+
+## Kubernetes-Specific
+
+- [ ] **Use External Secrets**: Don't store secrets in YAML — use External Secrets Operator or HashiCorp Vault
+- [ ] **Configure HPA**: The included HPA scales Dakera pods 1–5 based on CPU; set `minReplicas: 3` for HA
+- [ ] **Add cert-manager**: Annotate the ingress for automatic TLS certificate management
+- [ ] **Use native S3**: In cloud environments (AWS, GCP), use native S3/GCS instead of MinIO

--- a/examples/quickstart.md
+++ b/examples/quickstart.md
@@ -1,0 +1,70 @@
+# Dakera Quickstart Guide
+
+Get Dakera running and store your first memory in under 5 minutes.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-started/get-docker/) (v20.10+)
+- [Docker Compose](https://docs.docker.com/compose/install/) (v2.0+)
+- `curl` (for testing)
+
+## Step 1: Clone and Start
+
+```bash
+git clone https://github.com/dakera-ai/dakera-deploy
+cd dakera-deploy/docker
+docker compose -f docker-compose.local.yml up -d
+```
+
+This starts Dakera in **in-memory mode** — no external dependencies, no config files needed.
+
+## Step 2: Verify Health
+
+```bash
+curl http://localhost:3000/health
+```
+
+Expected response:
+```json
+{"status":"ok"}
+```
+
+## Step 3: Store a Memory
+
+```bash
+curl -X POST http://localhost:3000/v1/memories \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "my-agent",
+    "content": "The user prefers dark mode and uses VS Code."
+  }'
+```
+
+## Step 4: Recall Memories
+
+```bash
+curl -X POST http://localhost:3000/v1/memories/recall \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "my-agent",
+    "query": "What IDE does the user prefer?"
+  }'
+```
+
+Dakera returns semantically relevant memories ranked by similarity.
+
+## Step 5: Stop
+
+```bash
+docker compose -f docker-compose.local.yml down
+```
+
+## Next Steps
+
+| Goal | Guide |
+|------|-------|
+| Persist data across restarts | Use `docker compose up -d` (default profile with MinIO) |
+| Enable authentication | See [environment-variables.md](environment-variables.md) |
+| Production deployment | See [production-checklist.md](production-checklist.md) |
+| High availability | See the [HA section](../README.md#high-availability-3-node-cluster) in the README |
+| Use an SDK | [Python](https://github.com/dakera-ai/dakera-py) · [TypeScript](https://github.com/dakera-ai/dakera-js) · [Go](https://github.com/dakera-ai/dakera-go) · [Rust](https://github.com/dakera-ai/dakera-rs) |

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.40"
+    app.kubernetes.io/version: "0.11.55"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.40"
+        app.kubernetes.io/version: "0.11.55"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.42
+          image: ghcr.io/dakera-ai/dakera:0.11.55
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Comprehensive documentation and security audit of dakera-deploy per founder directive DAK-4923.

### Security Fixes
- **HA compose**: Removed `mc anonymous set download` from MinIO setup — SA-2026-001 vulnerability was still present in HA stack
- **HA compose**: Replaced hardcoded `dk_dev_root_key_change_in_production` fallback with required env var

### Version Bumps (0.11.48 → 0.11.55)
- `docker-compose.yml`, `docker-compose.ha.yml`: server image → 0.11.55
- `docker-compose.local.yml`: replaced broken `build` context with pre-built GHCR image
- `k8s/dakera/deployment.yaml`: aligned version labels (0.11.40) and image tag (0.11.42) → 0.11.55

### New: `examples/` Directory
- `quickstart.md` — store and recall first memory in 5 minutes
- `environment-variables.md` — complete env var reference (tiered storage, Redis, request limits, HA port overrides)
- `production-checklist.md` — security, storage, HA, and monitoring checklist
- `backup-restore.md` — MinIO backup procedures and disaster recovery

### README Fixes
- HA section: corrected ports from 3000/50051/9001 to actual HA defaults 3100/50151/9101
- HA architecture diagram: fixed Prometheus (:9090→:9190) and Grafana (:3001→:3203) ports
- Added missing env var sections (tiered storage, request limits, Redis)
- Updated version pinning example from v0.9.9 to v0.11.55
- Removed private repo link (`dakera-cli`) from Related Repositories
- Replaced dakera-docs reference with dakera.ai website link

### Cleanup
- Removed deprecated `version: "3.8"` from docker-compose.dev.yml

## Test plan

- [ ] `docker compose -f docker/docker-compose.local.yml up -d` starts successfully with GHCR image
- [ ] `docker compose -f docker/docker-compose.ha.yml up -d` requires DAKERA_ROOT_API_KEY (no fallback)
- [ ] HA MinIO bucket is not publicly accessible after setup
- [ ] All README port references match actual compose file defaults
- [ ] No broken links in README or examples/

🤖 Generated with [Claude Code](https://claude.com/claude-code)