### PR TITLE
fix: add explicit permissions blocks to Hetzner workflows

### DIFF
--- a/.github/workflows/hetzner-firewall.yml
+++ b/.github/workflows/hetzner-firewall.yml
@@ -11,6 +11,8 @@ on:
           - add-docker-ports
           - list-rules
 
+permissions: {}
+
 concurrency:
   group: hetzner-firewall
   cancel-in-progress: false

--- a/.github/workflows/hetzner-health-check.yml
+++ b/.github/workflows/hetzner-health-check.yml
@@ -5,6 +5,8 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: hetzner-health-check
   cancel-in-progress: true

--- a/.github/workflows/hetzner-server-manage.yml
+++ b/.github/workflows/hetzner-server-manage.yml
@@ -19,6 +19,8 @@ on:
         required: false
         default: "cpx32"
 
+permissions: {}
+
 jobs:
   manage:
     name: "${{ inputs.action }}"

--- a/.github/workflows/hetzner-snapshot.yml
+++ b/.github/workflows/hetzner-snapshot.yml
@@ -22,6 +22,8 @@ on:
         required: false
         default: "manual"
 
+permissions: {}
+
 concurrency:
   group: hetzner-snapshot
   cancel-in-progress: false

--- a/.github/workflows/reboot-arm-server.yml
+++ b/.github/workflows/reboot-arm-server.yml
@@ -7,6 +7,8 @@ on:
         description: 'Server IP to reboot (or rebuild if runner server). Defaults to ARM_RUNNER_IP secret if omitted.'
         required: false
 
+permissions: {}
+
 jobs:
   server-action:
     name: Server action via Hetzner API


### PR DESCRIPTION
## Summary
- Add `permissions: {}` (least-privilege) to 5 Hetzner workflow files that were inheriting default write-all GITHUB_TOKEN scope
- Affected workflows: hetzner-health-check, hetzner-snapshot, hetzner-firewall, hetzner-server-manage, reboot-arm-server

Part of security audit DAK-4969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)