### PR TITLE
fix: replace non-existing security@dakera.ai with GitHub Security Advisories

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,9 +8,9 @@ If you discover a security vulnerability in this project, please report it respo
 
 ### How to Report
 
-Email: security@dakera.ai
+Please report security vulnerabilities via [GitHub Security Advisories](https://github.com/dakera-ai/dakera-deploy/security/advisories/new).
 
-Please include:
+Include:
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
@@ -40,4 +40,4 @@ This policy covers security vulnerabilities in the Dakera deployment tooling, in
 - Network and service exposure settings
 
 For vulnerabilities in the Dakera server itself, see the [dakera](https://github.com/dakera-ai/dakera) repository.
-For the hosted Dakera service, use the same email address above.
+For the hosted Dakera service, use the same reporting channel above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Have a feature idea? Use the [Feature Request](https://github.com/Dakera-AI/dake
 
 ## Security Vulnerabilities
 
-**Do not open public issues for security vulnerabilities.** See [SECURITY.md](.github/SECURITY.md) for responsible disclosure instructions — email security@dakera.ai.
+**Do not open public issues for security vulnerabilities.** See [SECURITY.md](.github/SECURITY.md) for responsible disclosure instructions — report via [GitHub Security Advisories](https://github.com/dakera-ai/dakera-deploy/security/advisories/new).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replaced `security@dakera.ai` (non-existing email, confirmed DAK-5062) with GitHub Security Advisories links in:
  - `.github/SECURITY.md`
  - `CONTRIBUTING.md`

Closes DAK-5064

🤖 Generated with [Claude Code](https://claude.com/claude-code)