### PR TITLE
chore(deploy): bump default image tag 0.11.55 → 0.11.58

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.58}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.58}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.55}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.58}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.55"
+    app.kubernetes.io/version: "0.11.58"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.55"
+        app.kubernetes.io/version: "0.11.58"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.55
+          image: ghcr.io/dakera-ai/dakera:0.11.58
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bumps default `DAKERA_IMAGE` tag from `0.11.58` across all deploy configs
- Covers `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.ha.yml`, and `k8s/dakera/deployment.yaml`
- v0.11.58 includes: ONNX session pool (N=4), parallel upsert I/O, request timeout 600s

## Why

Production server at 178.104.45.161 is running v0.11.58. Default image tag was stale at 0.11.55, creating a drift between the deploy repo docs and what fresh deployments would pull.

## Verification

Production health confirmed: `curl http://178.104.45.161:3300/health` → `{"service":"dakera","status":"healthy","version":"0.11.58"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)