### PR TITLE
fix(infra): increase dakera container memory limit 4G→8G (LME bench OOM)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,8 +51,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
-          cpus: "2.0"
+          memory: 8G
+          cpus: "4.0"
         reservations:
           memory: 512M
           cpus: "0.5"


### PR DESCRIPTION
## Root Cause

Production dakera container OOM during LME bench (2026-05-27 ~03:01Z).

**Evidence**:
- `docker stats`: 3.446GiB / 4GiB (86%) under normal load
- LME bench run [26482766915](https://github.com/dakera-ai/dakera-bench/actions/runs/26482766915): /v1/memories/store/batch timeouts → exit 137 at 9000s
- Container restart visible: `dakera` was `Up 3 hours` as of 06:01Z (restarted at ~03:01Z mid-bench)
- Server has 15.6GB RAM, 8 CPUs — only 4G/2CPU was allocated

**Load profile**: LME bench (50 users × parallel_users=4 concurrent) saturates ONNX inference + L1 cache. max_batch_size=1 (after PR#476 revert) means one ONNX call per memory. 4 concurrent users = 4 simultaneous ONNX sessions.

## Fix

- dakera memory limit: **4G → 8G**
- dakera CPU limit: **2.0 → 4.0**

Server resource check:
- RAM: 15.6GB total, 8.4GB available ✅ 
- CPUs: 8 cores ✅
- minio: 4G limit (unchanged), currently at 2.3G used

## Deployment

After merge, re-trigger Deploy to Production with `version=0.11.59` to apply new limits via `--force-recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)