### PR TITLE
chore: bump dakera image default 0.11.59→0.11.61 (CE-95 + GLiNER fix)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.59}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.61}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bumps the default dakera container image from `0.11.59` to `0.11.61`
- v0.11.60: CE-94 ablation — Cat3 bench +3.7pp to 71.7%
- v0.11.61: CE-95 (HNSW ef_search 50→100) + GLiNER HF model path fix (resolves NER 503 errors)

## Related

- DAK-5807: Deploy v0.11.61 to fix GLiNER NER
- https://github.com/Dakera-AI/dakera/releases/tag/v0.11.61
- CTO merged PR#136 (HF_TOKEN env var) — production .env already configured

## Test plan

- [ ] CI green on this PR
- [ ] Production deployed to v0.11.61 and health endpoint returns `"version":"0.11.61"`
- [ ] GLiNER NER returns entities (not 503) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)