### PR TITLE
fix(runner): add 1h OOM alert cooldown to prevent Telegram spam (DAK-5864)

### DIFF
--- a/scripts/runner/runner-health-monitor.sh
+++ b/scripts/runner/runner-health-monitor.sh
@@ -29,6 +29,7 @@ tg_alert() {
 
 RESTARTED=0
 FAILED_UNITS=""
+NOW=$(date +%s)
 
 # --- Check all runner services ---
 while IFS= read -r UNIT; do
@@ -60,8 +61,16 @@ if [ -n "$OOM_PROCS" ]; then
     RESTARTED=$((RESTARTED + 1))
   done < <(systemctl list-units 'actions.runner.*' --no-pager --no-legend --state=failed,dead 2>/dev/null | awk '{print $1}')
   
-  OOM_MSG="🔴 *[Platform] Runner OOM Detected — ${HOSTNAME}*%0A%0AOOM kill detected in journal. Affected runners restarted.%0A%0AContext:%0A\`$(echo "$OOM_PROCS" | head -2 | tr '\n' ' ' | cut -c1-200)\`"
-  tg_alert "$OOM_MSG"
+  # 1-hour cooldown to prevent Telegram spam (DAK-5864)
+  OOM_ALERT_FILE="$STATE_DIR/last-oom-alert"
+  LAST_OOM_ALERT=$(cat "$OOM_ALERT_FILE" 2>/dev/null || echo 0)
+  if [ $((NOW - LAST_OOM_ALERT)) -gt 3600 ]; then
+    OOM_MSG="🔴 *[Platform] Runner OOM Detected — ${HOSTNAME}*%0A%0AOOM kill detected in journal. Affected runners restarted.%0A%0AContext:%0A\`$(echo "$OOM_PROCS" | head -2 | tr '\n' ' ' | cut -c1-200)\`"
+    tg_alert "$OOM_MSG"
+    echo "$NOW" > "$OOM_ALERT_FILE"
+  else
+    log "OOM detected — alert suppressed, cooldown $(( 3600 - (NOW - LAST_OOM_ALERT) ))s remaining"
+  fi
 fi
 
 # --- Send Telegram alert for restarts ---
@@ -73,7 +82,6 @@ fi
 # --- Periodic status log every 30min ---
 TICK_FILE="$STATE_DIR/last-status-tick"
 LAST_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
-NOW=$(date +%s)
 if [ $((NOW - LAST_TICK)) -gt 1800 ]; then
   TOTAL=$(systemctl list-units 'actions.runner.*' --no-pager --no-legend 2>/dev/null | wc -l)
   ACTIVE=$(systemctl list-units 'actions.runner.*' --no-pager --no-legend --state=active 2>/dev/null | wc -l)


### PR DESCRIPTION
## Summary
- **Problem**: `runner-health-monitor.sh` sends a Telegram OOM alert every 5 minutes when OOM kills are detected, with no cooldown. This filled Telegram logs with identical alerts (DAK-5863 escalation).
- **Fix**: Track last OOM alert timestamp in `$STATE_DIR/last-oom-alert`. Skip the Telegram message if <3600s elapsed since the last alert. Auto-restart of dead runner units still fires unconditionally every run.
- **Scope**: `scripts/runner/runner-health-monitor.sh` only — no other files changed.

## Changes
- Hoisted `NOW=$(date +%s)` to top-level scope (line 32) so both OOM cooldown and 30-min status tick share one timestamp
- Added `last-oom-alert` state file check with 3600s cooldown before `tg_alert` in OOM block
- Logs suppressed alerts with remaining cooldown seconds for debuggability
- Removed duplicate `NOW=$(date +%s)` from the periodic status block

## Test plan
- [ ] OOM detected → first alert sends to Telegram, `last-oom-alert` written with current epoch
- [ ] OOM detected again <1h later → alert suppressed, journal shows "cooldown Ns remaining"
- [ ] OOM detected >1h after last alert → alert fires again, timestamp updated
- [ ] Runner service restarts still fire every 5min regardless of cooldown (restart loop is outside OOM block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)