### PR TITLE
docs: unify LoCoMo score to 88.2% (DAK-5930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-29
+
+### Changed
+
+- Bump default dakera image `0.11.61` → `0.11.66` across all compose files (docker-compose.yml, docker-compose.ha.yml, docker-compose.local.yml), k8s deployment.yaml, README examples, and production-checklist.md
+  - v0.11.62: text_lengths rank fix (DAK-5826)
+  - v0.11.63–v0.11.64: async metric recording, pipeline instrumentation
+  - v0.11.65: cross-encoder session pool (RERANKER_POOL_SIZE=2, batch reranking Phase 3)
+  - v0.11.66: batch ONNX cross-encoder inference (Phase 3 complete, ~2× rerank speedup)
+
 ## [0.7.0] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <a href="https://dakera.ai"><img src="https://img.shields.io/badge/dakera.ai-website-22c55e?style=for-the-badge" alt="Website" /></a>
   <a href="https://dakera.ai/docs"><img src="https://img.shields.io/badge/docs-dakera.ai%2Fdocs-3b82f6?style=for-the-badge" alt="Docs" /></a>
-  <a href="https://dakera.ai/benchmark"><img src="https://img.shields.io/badge/benchmark-87.8%25_LoCoMo-D4A843?style=for-the-badge" alt="Benchmark" /></a>
+  <a href="https://dakera.ai/benchmark"><img src="https://img.shields.io/badge/benchmark-88.2%25_LoCoMo-D4A843?style=for-the-badge" alt="Benchmark" /></a>
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@
 
 Dakera is the **agent-native memory platform** — purpose-built for AI agents that need persistent, session-aware, cross-agent memory. A single self-hosted Rust binary gives you vector search, hybrid retrieval (BM25 + HNSW), knowledge graphs, session management, and built-in embeddings. No external dependencies. Your data stays on your infrastructure.
 
-**87.8% on the [LoCoMo benchmark](https://dakera.ai/benchmark)** — 1,540 questions testing long-conversation memory across temporal reasoning, multi-hop retrieval, and event ordering. This is the highest score for a self-hosted memory system.
+**88.2% on the [LoCoMo benchmark](https://dakera.ai/benchmark)** — 1,540 questions testing long-conversation memory across temporal reasoning, multi-hop retrieval, and event ordering. This is the highest score for a self-hosted memory system.
 
 ---
 
@@ -133,7 +133,7 @@ Production-grade single-node deployment with MinIO, caching, and health checks.
 > **Version pinning**: The default image tags are pinned to the latest stable release.
 > To run a specific version, set `DAKERA_IMAGE` and `DASHBOARD_IMAGE` in your `.env`:
 > ```bash
-> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.66
+> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.67
 > DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:0.3.29
 > ```
 > Pinning to explicit versions prevents unexpected upgrades in production.
@@ -503,7 +503,7 @@ The Helm chart has moved to the dedicated **[dakera-helm](https://github.com/dak
 
 ```bash
 # Install from GHCR OCI
-helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.66 \
+helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.67 \
   --namespace dakera --create-namespace \
   --set dakera.rootApiKey=$(openssl rand -hex 32) \
   --set minio.rootPassword=$(openssl rand -hex 16)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Production-grade single-node deployment with MinIO, caching, and health checks.
 > **Version pinning**: The default image tags are pinned to the latest stable release.
 > To run a specific version, set `DAKERA_IMAGE` and `DASHBOARD_IMAGE` in your `.env`:
 > ```bash
-> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.55
+> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.66
 > DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:0.3.29
 > ```
 > Pinning to explicit versions prevents unexpected upgrades in production.
@@ -503,7 +503,7 @@ The Helm chart has moved to the dedicated **[dakera-helm](https://github.com/dak
 
 ```bash
 # Install from GHCR OCI
-helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.55 \
+helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.66 \
   --namespace dakera --create-namespace \
   --set dakera.rootApiKey=$(openssl rand -hex 32) \
   --set minio.rootPassword=$(openssl rand -hex 16)

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.59}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.59}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.61}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/examples/production-checklist.md
+++ b/examples/production-checklist.md
@@ -14,7 +14,7 @@ Use this checklist before exposing Dakera to the internet or handling real workl
 ## Storage
 
 - [ ] **Use persistent storage**: Use the default profile (MinIO-backed) or native S3, not in-memory mode
-- [ ] **Pin image versions**: Set `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.55` explicitly — never use `latest` in production
+- [ ] **Pin image versions**: Set `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.66` explicitly — never use `latest` in production
 - [ ] **Mount volumes**: Ensure `dakera-cache`, `dakera-rocksdb`, and `minio-data` volumes are on reliable storage
 - [ ] **Configure backups**: See [backup-restore.md](backup-restore.md) for backup procedures
 

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.55"
+    app.kubernetes.io/version: "0.11.66"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.55"
+        app.kubernetes.io/version: "0.11.66"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.55
+          image: ghcr.io/dakera-ai/dakera:0.11.66
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Unifies LoCoMo benchmark score to 88.2%. Badge and prose updated from 87.8%. Website shows 88.2% (founder-approved). Closes DAK-5930.