### PR TITLE
chore: bump default dakera image 0.11.66→0.11.71 (weekly batch)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.71}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.71}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.71}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.66"
+    app.kubernetes.io/version: "0.11.71"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.66"
+        app.kubernetes.io/version: "0.11.71"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.66
+          image: ghcr.io/dakera-ai/dakera:0.11.71
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Bumps hardcoded default Dakera image version from `0.11.66` to `0.11.71` across all configs
- Files updated: `docker/docker-compose.yml`, `docker/docker-compose.local.yml`, `docker/docker-compose.ha.yml`, `k8s/dakera/deployment.yaml`
- Production was already running v0.11.71 via `.env` override — this syncs the defaults

## Changes (v0.11.67 → v0.11.71 highlights)
- FP32 GPU fix (ONNX)
- O(1) session lookup perf fix
- ONNX batch 8→32
- CPU LME bench fix (180× speedup)
- NER + PRF iterations=2 (Cat3 recall improvement)
- LLM-as-judge bench support
- temporal_rerank_multiplier experiments in progress

## Test plan
- [ ] Production health endpoint confirms v0.11.71: `curl http://178.104.45.161:3300/health`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)