### PR TITLE
chore: bump default Dakera image to v0.11.73

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.73}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.73}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.73}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bumps default `DAKERA_IMAGE` fallback from `0.11.66` → `0.11.73` in all Docker Compose files
- Applies to: `docker-compose.yml`, `docker-compose.ha.yml`, `docker-compose.local.yml`
- Production deployments using `DAKERA_IMAGE` env override are unaffected

## Context

v0.11.73 was released on 2026-05-30 (CE-TORA4 SharesEntity graph traversal, Cat3 70.7%). Release workflow run: https://github.com/Dakera-AI/dakera/actions/runs/26685426058

## Test plan
- [ ] Release workflow 26685426058 completes (Docker image available at ghcr.io/dakera-ai/dakera:0.11.73)
- [ ] `docker pull ghcr.io/dakera-ai/dakera:0.11.73` succeeds
- [ ] Production health endpoint confirms v0.11.73 after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)