### PR TITLE
chore: bump dakera image 0.11.66→0.11.75 (binary HNSW + TieredEngine)

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.66}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dakera
     app.kubernetes.io/component: server
-    app.kubernetes.io/version: "0.11.66"
+    app.kubernetes.io/version: "0.11.75"
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: dakera
         app.kubernetes.io/component: server
-        app.kubernetes.io/version: "0.11.66"
+        app.kubernetes.io/version: "0.11.75"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.66
+          image: ghcr.io/dakera-ai/dakera:0.11.75
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Bumps all Dakera image references from `0.11.66` → `0.11.75` across Docker Compose and Kubernetes manifests
- Covers: `docker-compose.yml`, `docker-compose.ha.yml`, `docker-compose.local.yml`, `k8s/dakera/deployment.yaml`

## What's in v0.11.75

Binary HNSW + TieredEngine wiring (PR https://github.com/Dakera-AI/dakera/pull/548)

**Safety note:** Binary HNSW is opt-in via `DAKERA_SEARCH_MODE=hybrid`. Default Float mode behavior is unchanged — safe to deploy without config changes.

Release workflow: https://github.com/dakera-ai/dakera/actions/runs/26698822037

## Test plan

- [ ] CI green on this PR
- [ ] CTO merges via auto-merge label
- [ ] Post-deploy: `curl http://178.104.45.161:3300/health` returns healthy with v0.11.75

🤖 Generated with [Claude Code](https://claude.com/claude-code)