### PR TITLE
chore(deploy): bump default image to v0.11.77

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.75}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bumps default `DAKERA_IMAGE` tag in all docker-compose files from `0.11.75` → `0.11.77`
- Files updated: `docker-compose.yml`, `docker-compose.ha.yml`, `docker-compose.local.yml`
- Production has been running v0.11.77 since 2026-05-31T01:21Z (deployed via deploy-production workflow)

## What's in v0.11.77

- All 4×100x feature gaps resolved: `SearchMode::Hybrid` default, `is_static` flag for `ReembedJob`, `ReembedJob` decrypt+decompress fix, docker-compose DAKERA_TIERED=1 + DAKERA_SEARCH_MODE=hybrid
- HNSW binary traversal fix (PR#551): binary overselect_ef now 500 for correct top-k recall
- Binary traversal Recall@10 ~100%

## Test plan
- [ ] CI passes (lint + schema validation)
- [ ] Verify `docker compose up -d` pulls the correct v0.11.77 image

🤖 Generated with [Claude Code](https://claude.com/claude-code)