### PR TITLE
chore(deploy): bump default dakera image 0.11.77→0.11.80

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.77}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary

- Bump default dakera server image from 0.11.77 → 0.11.80 across all docker-compose configs
- v0.11.80 includes CE-TORA8 temporal gate (Cat3 +5.9pp to 76.6%) and GPU OOM fixes
- LoCoMo bench 26734532287 passed all gates: https://github.com/dakera-ai/dakera-bench/actions/runs/26734532287

## Changes

- `docker/docker-compose.yml` — default server image bumped
- `docker/docker-compose.ha.yml` — default server image bumped  
- `docker/docker-compose.local.yml` — default server image bumped

## Verification

Production at 178.104.45.161 already running v0.11.80 healthy ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)