### PR TITLE
chore(deploy): bump default dakera image 0.11.80→0.11.81

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.80}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- Bumps default Dakera container image from `0.11.80` → `0.11.81` across all Docker Compose configurations
- v0.11.81 includes: OnnxBackend BFCArena fix (DAK-6145), Cargo.lock candle-core sync

## Files Updated
- `docker/docker-compose.yml`
- `docker/docker-compose.ha.yml`
- `docker/docker-compose.local.yml`

## Release
https://github.com/Dakera-AI/dakera/releases/tag/v0.11.81

🤖 Generated with [Claude Code](https://claude.com/claude-code)