### PR TITLE
fix(deploy): health gate accepts healthy status when no build_sha (DAK-6271)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -133,8 +133,10 @@ jobs:
                   echo "✅ Deployed and healthy: ${{ inputs.version }} (build_sha: $RESP_SHA)"
                   exit 0
                 fi
-              elif [ "$VERSION" = "${{ inputs.version }}" ]; then
-                echo "✅ Deployed and healthy: v${{ inputs.version }}"
+              else
+                # No build_sha provided: healthy status is sufficient.
+                # Binary reports Cargo semver (e.g. 0.11.81), never a docker tag like "edge".
+                echo "✅ Deployed and healthy: ${{ inputs.version }} (reported version: $VERSION)"
                 exit 0
               fi
             fi


### PR DESCRIPTION
## Summary

- **Root cause (DAK-6271):** Health check asserted `version == inputs.version`, but the Dakera binary reports its Cargo semver (e.g. `0.11.81`) — it can never equal a moving docker tag like `edge`. Every `edge` deploy without a `build_sha` input would loop all 12 retries then fail with `❌ Health check failed`.
- **Fix:** Replace `elif VERSION == version` with `else` — when no `build_sha` is provided, `status == "healthy"` is the acceptance criterion. The SHA verification path (when `build_sha` input is supplied) is unchanged.
- **No blast radius:** `skip_health_check=true` and SHA-verified deploys are unaffected. Semver deploys (e.g. `version=0.11.81`) previously succeeded only if semver happened to match; now they also accept healthy status, which is the correct check.

## Test plan
- [ ] Trigger `deploy-production.yml` with `version=edge` and no `build_sha` — should pass health gate on first healthy response
- [ ] Trigger with `build_sha` set — SHA verification path unchanged, should still verify exact build

Related: DAK-6271 / DAK-6263 follow-up
🤖 Generated with [Claude Code](https://claude.com/claude-code)