### PR TITLE
deploy(DAK-6284): flip DAKERA_TIERED=1 + pin image to optA-baked-ec6ef91

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91}
   restart: unless-stopped
   networks:
     - dakera-ha-net
@@ -75,10 +75,8 @@ x-dakera-env: &dakera-env
   DAKERA_WARM_TO_COLD_SECS: "86400"
   DAKERA_AUTO_TIER: "true"
   DAKERA_TIER_CHECK_INTERVAL_SECS: "300"
-  # Hybrid search (binary HNSW). DAK-6203: DAKERA_TIERED OFF — the Model2Vec
-  # StaticBackend needs a locally-distilled matrix (DAKERA_MODEL2VEC_PATH); there
-  # is no remote model2vec repo. Set to "1" only after mounting a local matrix.
-  DAKERA_TIERED: "0"
+  # DAK-6209/DAK-6284: TIERED ON — optA-baked-ec6ef91 has ONNX baked in (DAK-6272 cold-boot guard).
+  DAKERA_TIERED: "1"
   DAKERA_SEARCH_MODE: "hybrid"
   # Request limits
   DAKERA_MAX_BODY_SIZE: "524288000"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -41,9 +41,8 @@ services:
       - DAKERA_WARM_TO_COLD_SECS=86400
       - DAKERA_AUTO_TIER=true
       - DAKERA_TIER_CHECK_INTERVAL_SECS=300
-      # DAK-6203: DAKERA_TIERED OFF — Model2Vec StaticBackend needs a local
-      # DAKERA_MODEL2VEC_PATH matrix (no remote model2vec repo exists).
-      - DAKERA_TIERED=0
+      # DAK-6209/DAK-6284: TIERED ON — optA-baked-ec6ef91 has ONNX baked in (DAK-6272 cold-boot guard).
+      - DAKERA_TIERED=1
       - DAKERA_SEARCH_MODE=hybrid
       - DAKERA_MAX_BODY_SIZE=524288000
       - DAKERA_REQUEST_TIMEOUT=${DAKERA_REQUEST_TIMEOUT:-600}

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -25,9 +25,8 @@ data:
   DAKERA_WARM_TO_COLD_SECS: "86400"
   DAKERA_AUTO_TIER: "true"
   DAKERA_TIER_CHECK_INTERVAL_SECS: "300"
-  # DAK-6203: DAKERA_TIERED OFF — Model2Vec StaticBackend needs a local
-  # DAKERA_MODEL2VEC_PATH matrix (no remote model2vec repo exists).
-  DAKERA_TIERED: "0"
+  # DAK-6209/DAK-6284: TIERED ON — optA-baked-ec6ef91 has ONNX baked in (DAK-6272 cold-boot guard).
+  DAKERA_TIERED: "1"
   DAKERA_SEARCH_MODE: "hybrid"
   DAKERA_MAX_BODY_SIZE: "524288000"
   DAKERA_REQUEST_TIMEOUT: "120"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:0.11.75
+          image: ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Flip `DAKERA_TIERED` 0→1 in all three configs (docker-compose.yml, docker-compose.ha.yml, k8s/configmap.yaml)
- Pin prod image to `ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91` in all four image refs

## Authorization

Founder-approved ship: DAK-6282, Telegram 2026-06-03 12:43Z: *"9.7x ingest for a small cat3 -2.6pp regression is ok... I APPROVE IT"*. CTO-sequenced via DAK-6284.

## Dependencies verified

- PR#596 (b87f4977): tier code on main, DAKERA_TIERED=0 default ✅
- PR#608 (ec6ef918, DAK-6272): cold-boot ONNX integrity guard merged ✅
- Image `ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91`: build run https://github.com/dakera-ai/dakera/actions/runs/26881137390 SUCCESS, ONNX sha256-verified at bake time ✅

## Deploy

After merge: trigger `deploy-production.yml` with `version=optA-baked-ec6ef91` and `build_sha=ec6ef918`.
Verify: `curl -s <prod>/health/ready` must show `tiered_engine=ACTIVE`.

Closes DAK-6284 / ships DAK-6209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)