### PR TITLE
fix(DAK-6352): add libbz2-dev to runner provisioning packages

### DIFF
--- a/.github/workflows/provision-runner-server.yml
+++ b/.github/workflows/provision-runner-server.yml
@@ -83,6 +83,7 @@ jobs:
             - cmake
             - pkg-config
             - libssl-dev
+            - libbz2-dev
             - gcc
             - g++
             - docker.io


### PR DESCRIPTION
## Summary

- Add `libbz2-dev` to cloud-init package list in `provision-runner-server.yml`

## Root cause

RocksDB requires `bzlib.h` (from `libbz2-dev`) to compile. The package was missing from the provisioning script, causing CI failures on `hetzner-arm-dakera` with:

```
fatal error: bzlib.h: No such file or directory
compilation terminated.
Process completed with exit code 101
```

## Discovery

Detected during Platform Heartbeat [DAK-6350](/DAK/issues/DAK-6350) on 2026-06-04.  
Affected PR: https://github.com/Dakera-AI/dakera/pull/620 (CI run https://github.com/Dakera-AI/dakera/actions/runs/26933529123)

## Fix applied

- Hotpatch: `apt-get install -y libbz2-dev` on ARM runner (168.119.60.30)
- This PR: adds `libbz2-dev` to provision script so fresh server builds include it

Tracks: [DAK-6352](/DAK/issues/DAK-6352)