### PR TITLE
fix(deploy): remove stale container before recreate + fix hadolint CI on ARM (DAK-6541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,11 @@ permissions:
 jobs:
   validate:
     name: Validate Docker Configs
-    runs-on: [self-hosted, linux, arm64]
+    # GitHub-hosted: hadolint-action pulls ghcr.io/hadolint/hadolint which needs
+    # authenticated GHCR access; GitHub-hosted runners have ambient auth, self-hosted ARM do not.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Log in to GHCR (needed for hadolint container image on self-hosted runner)
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate docker-compose.yml
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Log in to GHCR (needed for hadolint container image on self-hosted runner)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate docker-compose.yml
         env:
           DAKERA_ROOT_API_KEY: ci-validation-placeholder

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -91,6 +91,9 @@ jobs:
             COMPOSE_DIR=$(docker inspect "$CONTAINER" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || echo "")
             if [ -n "$COMPOSE_DIR" ] && [ -d "$COMPOSE_DIR" ]; then
               cd "$COMPOSE_DIR"
+              # Remove stale container before recreate to prevent Docker naming conflicts
+              # (container_name + compose project-hash alias can collide on --force-recreate)
+              docker rm -f dakera 2>/dev/null || true
               # Force-recreate minio so new resource limits (cpus/memory) take effect
               DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d --force-recreate minio minio-setup dakera
             else


### PR DESCRIPTION
## Summary

- **Root cause (DAK-6541)**: `docker compose up --force-recreate` failed with `The container name "/fdbaa06c2bb4_dakera" is already in use` during the v0.11.90 deploy. Docker Compose's internal project-hash alias (`fdbaa06c2bb4_dakera`) clashed with the existing container that had `container_name: dakera` set. Despite the workflow failing, v0.11.90 was already created and running healthy.
- **Fix**: Add `docker rm -f dakera 2>/dev/null || true` before `docker compose up --force-recreate` to ensure no stale container name registration can conflict.
- **Production impact**: None — v0.11.90 is already healthy on production. This PR prevents recurrence on future deploys.

## Test plan
- [ ] Verify CI passes (workflow syntax check)
- [ ] Next production deploy should proceed without container naming conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)