### PR TITLE
Phase 1: Validate T-I-F reliability metadata for Dakera agent decisions

### DIFF
--- a/docker/docker-compose.tif-phase1.yml
+++ b/docker/docker-compose.tif-phase1.yml
@@ -2,8 +2,8 @@ services:
   dakera:
     image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
     ports:
-      - "3200:3000"
-      - "51051:50051"
+      - "127.0.0.1:3200:3000"
+      - "127.0.0.1:51051:50051"
     environment:
       - RUST_LOG=info
       - DAKERA_HOST=0.0.0.0
@@ -12,7 +12,7 @@ services:
       - DAKERA_STORAGE=memory
       - DAKERA_AUTH_ENABLED=false
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health/ready"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker/docker-compose.tif-phase1.yml
+++ b/docker/docker-compose.tif-phase1.yml
@@ -1,0 +1,19 @@
+services:
+  dakera:
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
+    ports:
+      - "3200:3000"
+      - "51051:50051"
+    environment:
+      - RUST_LOG=info
+      - DAKERA_HOST=0.0.0.0
+      - DAKERA_PORT=3000
+      - DAKERA_GRPC_PORT=50051
+      - DAKERA_STORAGE=memory
+      - DAKERA_AUTH_ENABLED=false
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped

--- a/examples/tif-reliability/README.md
+++ b/examples/tif-reliability/README.md
@@ -1,0 +1,108 @@
+# T-I-F Reliability Metadata Phase 1
+
+This example validates the Phase 1 proposal from Dakera issue #161:
+
+https://github.com/Dakera-AI/dakera-deploy/issues/161
+
+The goal is not to prove that metadata can round-trip. The maintainer has
+already confirmed that arbitrary JSON metadata is accepted and recalled by the
+public API. The goal is to show that an agent can inspect T-I-F reliability
+metadata and make a better decision than it would with importance/relevance
+alone.
+
+## What This Tests
+
+The example stores real conversation-derived memories with:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "t": 0.95,
+      "i": 0.03,
+      "f": 0.01,
+      "basis": "maintainer correction in Dakera issue #161",
+      "source": "tif_decision_provenance"
+    }
+  }
+}
+```
+
+The `t`, `i`, and `f` values are independent reliability components:
+
+| Field | Meaning | Agent-side handling in this example |
+|---|---|---|
+| `t` | truth/support | reuse when high and contradiction/uncertainty are low |
+| `i` | indeterminacy | ask for clarification or mark unresolved when high |
+| `f` | falsity/contradiction | surface as contradiction evidence when high |
+
+These rules are local agent logic only. They do not change Dakera ranking,
+filters, engine schema, SDK models, or storage behavior.
+
+## Start Dakera On Port 3200
+
+This avoids conflicts with local services that may already use port `3000`.
+
+```bash
+cd docker
+docker compose -f docker-compose.tif-phase1.yml up -d
+```
+
+Health check:
+
+```bash
+curl http://localhost:3200/health/ready
+```
+
+Stop:
+
+```bash
+cd docker
+docker compose -f docker-compose.tif-phase1.yml down
+```
+
+## Run Self-Test
+
+The self-test validates the agent-side decision rules without requiring a
+running Dakera instance.
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --self-test
+```
+
+## Run Runtime Validation
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200
+```
+
+The script will:
+
+1. verify `/health/ready`;
+2. store issue-derived memories with `metadata.reliability`;
+3. recall memories for Phase 1 scenarios;
+4. compare a baseline importance/relevance-only decision with a T-I-F-aware decision;
+5. fail if the expected high-`i` or high-`f` decision changes are not observed.
+
+## Expected Decision Change
+
+Baseline behavior:
+
+```text
+reuse_top_memory
+```
+
+T-I-F-aware behavior for a high-`f` memory:
+
+```text
+surface_contradiction
+```
+
+T-I-F-aware behavior for a high-`i` memory:
+
+```text
+ask_clarification
+```
+
+This is the Phase 1 evidence requested by the maintainer: the metadata is not
+only preserved, it changes agent behavior in a reviewable way.

--- a/examples/tif-reliability/README.md
+++ b/examples/tif-reliability/README.md
@@ -79,10 +79,11 @@ python examples/tif-reliability/validate_tif_reliability.py --api http://localho
 The script will:
 
 1. verify `/health/ready`;
-2. store issue-derived memories with `metadata.reliability`;
-3. recall memories for Phase 1 scenarios;
-4. compare a baseline importance/relevance-only decision with a T-I-F-aware decision;
-5. fail if the expected high-`i` or high-`f` decision changes are not observed.
+2. create a unique runtime `agent_id` unless one is passed explicitly;
+3. store issue-derived memories with `metadata.reliability`;
+4. recall memories for Phase 1 scenarios;
+5. compare a baseline importance/relevance-only decision with a T-I-F-aware decision;
+6. fail if the expected high-`i` or high-`f` decision changes are not observed.
 
 ## Expected Decision Change
 

--- a/examples/tif-reliability/README.md
+++ b/examples/tif-reliability/README.md
@@ -42,6 +42,8 @@ filters, engine schema, SDK models, or storage behavior.
 ## Start Dakera On Port 3200
 
 This avoids conflicts with local services that may already use port `3000`.
+The compose file binds REST and gRPC to `127.0.0.1` and disables auth only
+for local validation. Do not run it on a shared or internet-facing host.
 
 ```bash
 cd docker
@@ -74,6 +76,13 @@ python examples/tif-reliability/validate_tif_reliability.py --self-test
 
 ```bash
 python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200
+```
+
+If the first run is slow while the ONNX model warms up, increase the request
+timeout:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200 --request-timeout 240
 ```
 
 The script will:

--- a/examples/tif-reliability/VALIDATION_RESULTS.md
+++ b/examples/tif-reliability/VALIDATION_RESULTS.md
@@ -60,6 +60,9 @@ Runtime validation passed all scenarios:
 | `high-indeterminacy-clarification` | `reuse_top_memory` | `ask_clarification` | true | true |
 | `safe-reuse-maintainer-target` | `reuse_top_memory` | `reuse_confidently` | false | true |
 
+The validation script now creates a unique runtime `agent_id` by default so
+repeat runs do not contaminate recall with memories from prior executions.
+
 ## Evidence
 
 The store response preserved `metadata.reliability`:

--- a/examples/tif-reliability/VALIDATION_RESULTS.md
+++ b/examples/tif-reliability/VALIDATION_RESULTS.md
@@ -1,0 +1,104 @@
+# Phase 1 Validation Results
+
+Date: 2026-06-12
+
+Dakera image:
+
+```text
+ghcr.io/dakera-ai/dakera:0.11.81
+```
+
+Local runtime:
+
+```text
+REST: http://localhost:3200
+gRPC: localhost:51051
+Storage: in-memory
+Auth: disabled for local validation only
+```
+
+## Commands
+
+Start:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+```
+
+Health:
+
+```bash
+curl http://localhost:3200/health/ready
+```
+
+Self-test:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --self-test
+```
+
+Runtime validation:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200
+```
+
+## Result Summary
+
+Health returned ready:
+
+```json
+{"ready":true,"version":"0.11.81","checks":{"storage":{"status":"ok","message":null}}}
+```
+
+Runtime validation passed all scenarios:
+
+| Scenario | Baseline action | T-I-F-aware action | Changed | Passed |
+|---|---|---|---|---|
+| `obsolete-roundtrip-plan` | `reuse_top_memory` | `surface_contradiction` | true | true |
+| `high-falsity-contradiction` | `reuse_top_memory` | `surface_contradiction` | true | true |
+| `high-indeterminacy-clarification` | `reuse_top_memory` | `ask_clarification` | true | true |
+| `safe-reuse-maintainer-target` | `reuse_top_memory` | `reuse_confidently` | false | true |
+
+## Evidence
+
+The store response preserved `metadata.reliability`:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "t": 0.95,
+      "i": 0.03,
+      "f": 0.01,
+      "basis": "ferhimedamine Phase 1 instruction in Dakera issue #161",
+      "source": "tif_decision_provenance"
+    }
+  }
+}
+```
+
+Recall returned the same metadata under recalled memory objects. The local evaluator then used that metadata agent-side.
+
+High `f` behavior:
+
+```text
+baseline: reuse_top_memory
+T-I-F aware: surface_contradiction
+```
+
+High `i` behavior:
+
+```text
+baseline: reuse_top_memory
+T-I-F aware: ask_clarification
+```
+
+## Conclusion
+
+Phase 1 confirms the maintainer's requested evidence target:
+
+- metadata is accepted through the public store endpoint;
+- `metadata.reliability` survives recall;
+- T-I-F remains agent-side and does not change Dakera engine behavior;
+- high falsity and high indeterminacy produce measurably different agent decisions than importance/relevance alone.

--- a/examples/tif-reliability/VALIDATION_RESULTS.md
+++ b/examples/tif-reliability/VALIDATION_RESULTS.md
@@ -11,11 +11,13 @@ ghcr.io/dakera-ai/dakera:0.11.81
 Local runtime:
 
 ```text
-REST: http://localhost:3200
-gRPC: localhost:51051
+REST: http://127.0.0.1:3200
+gRPC: 127.0.0.1:51051
 Storage: in-memory
 Auth: disabled for local validation only
 ```
+
+The validation compose binds these ports to localhost only.
 
 ## Commands
 

--- a/examples/tif-reliability/phase1_memories.json
+++ b/examples/tif-reliability/phase1_memories.json
@@ -1,0 +1,109 @@
+{
+  "agent_id": "dakera-tif-phase1",
+  "source_issue": "https://github.com/Dakera-AI/dakera-deploy/issues/161",
+  "memories": [
+    {
+      "id": "phase1-maintainer-target",
+      "content": "Phase 1 should validate whether T-I-F reliability metadata produces measurably better agent decisions, not merely whether metadata round-trips through recall.",
+      "importance": 0.95,
+      "metadata": {
+        "reliability": {
+          "t": 0.95,
+          "i": 0.03,
+          "f": 0.01,
+          "basis": "ferhimedamine Phase 1 instruction in Dakera issue #161",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-obsolete-roundtrip-plan",
+      "content": "Phase 1 only needs to prove that metadata survives store and recall.",
+      "importance": 0.9,
+      "metadata": {
+        "reliability": {
+          "t": 0.28,
+          "i": 0.18,
+          "f": 0.82,
+          "basis": "superseded by maintainer clarification that metadata round-trip is already supported",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-developer-facing-name",
+      "content": "For Phase 1, use metadata.reliability as the developer-facing key while keeping neutrosophic theory in documentation.",
+      "importance": 0.86,
+      "metadata": {
+        "reliability": {
+          "t": 0.88,
+          "i": 0.08,
+          "f": 0.04,
+          "basis": "maintainer leaned toward metadata.tif or metadata.reliability and user selected metadata.reliability",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-high-falsity-handling",
+      "content": "A memory with high falsity should be silently hidden, filtered, or deleted before the agent can inspect it.",
+      "importance": 0.88,
+      "metadata": {
+        "reliability": {
+          "t": 0.12,
+          "i": 0.16,
+          "f": 0.91,
+          "basis": "contradicted by maintainer guidance: high-f memories are diagnostic signal and should surface as contradiction evidence",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-high-indeterminacy-handling",
+      "content": "If a recalled memory has high indeterminacy, the agent should treat the reuse decision as unresolved and ask for clarification instead of silently trusting it.",
+      "importance": 0.82,
+      "metadata": {
+        "reliability": {
+          "t": 0.42,
+          "i": 0.72,
+          "f": 0.12,
+          "basis": "maintainer guidance: clarification prompting is agent-side decision logic for high indeterminacy",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "obsolete-roundtrip-plan",
+      "query": "Should Phase 1 only prove metadata round-trip?",
+      "expected_changed_decision": true,
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "high-falsity-contradiction",
+      "query": "Should a high falsity memory be filtered or surfaced as contradiction evidence?",
+      "expected_changed_decision": true,
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "high-indeterminacy-clarification",
+      "query": "If a recalled memory has high indeterminacy, should the agent ask for clarification instead of silently trusting it?",
+      "top_k": 1,
+      "expected_changed_decision": true,
+      "expected_action": "ask_clarification"
+    },
+    {
+      "id": "safe-reuse-maintainer-target",
+      "query": "What should Phase 1 validate now?",
+      "top_k": 1,
+      "expected_changed_decision": false,
+      "expected_action": "reuse_confidently"
+    }
+  ]
+}

--- a/examples/tif-reliability/validate_tif_reliability.py
+++ b/examples/tif-reliability/validate_tif_reliability.py
@@ -49,11 +49,11 @@ def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -
         raise RuntimeError(f"{method} {url} failed: {exc}") from exc
 
 
-def healthcheck(api_base: str, retries: int = 20, delay: float = 1.5) -> Any:
+def healthcheck(api_base: str, retries: int = 120, delay: float = 2.0) -> Any:
     last_error: Exception | None = None
     for _ in range(retries):
         try:
-            return request_json("GET", f"{api_base}/health")
+            return request_json("GET", f"{api_base}/health/ready")
         except Exception as exc:  # noqa: BLE001 - report final connection failure.
             last_error = exc
             time.sleep(delay)
@@ -218,8 +218,9 @@ def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
     return results
 
 
-def run_runtime_validation(api_base: str, fixture: dict[str, Any], top_k: int) -> dict[str, Any]:
-    agent_id = fixture["agent_id"]
+def run_runtime_validation(
+    api_base: str, fixture: dict[str, Any], top_k: int, agent_id: str
+) -> dict[str, Any]:
     health = healthcheck(api_base)
 
     store_results = []
@@ -232,7 +233,7 @@ def run_runtime_validation(api_base: str, fixture: dict[str, Any], top_k: int) -
         recalled = recall_memories(api_base, agent_id, scenario["query"], scenario_top_k)
         scenario_results.append(evaluate_scenario(scenario, recalled))
 
-    return {"health": health, "stored": store_results, "scenarios": scenario_results}
+    return {"agent_id": agent_id, "health": health, "stored": store_results, "scenarios": scenario_results}
 
 
 def print_report(results: list[dict[str, Any]]) -> None:
@@ -259,6 +260,10 @@ def main() -> int:
     parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
     parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to Phase 1 fixture JSON.")
     parser.add_argument("--top-k", type=int, default=8, help="Recall top_k value.")
+    parser.add_argument(
+        "--agent-id",
+        help="Agent ID for runtime validation. Defaults to a unique ID derived from the fixture.",
+    )
     parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
     args = parser.parse_args()
 
@@ -268,7 +273,8 @@ def main() -> int:
         print_report(results)
         return 0 if all(result["passed"] for result in results) else 1
 
-    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, args.top_k)
+    agent_id = args.agent_id or f"{fixture['agent_id']}-{int(time.time())}"
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, args.top_k, agent_id)
     print(json.dumps(runtime, indent=2, sort_keys=True))
     return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
 

--- a/examples/tif-reliability/validate_tif_reliability.py
+++ b/examples/tif-reliability/validate_tif_reliability.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Phase 1 T-I-F reliability validation for Dakera memories.
+
+This script uses only Python's standard library and Dakera's public REST API.
+It deliberately keeps T-I-F interpretation agent-side: Dakera stores and
+recalls metadata; the local evaluator decides whether to reuse, caveat,
+surface contradiction, or ask for clarification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API = "http://localhost:3200"
+DEFAULT_FIXTURE = Path(__file__).with_name("phase1_memories.json")
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc}") from exc
+
+
+def healthcheck(api_base: str, retries: int = 20, delay: float = 1.5) -> Any:
+    last_error: Exception | None = None
+    for _ in range(retries):
+        try:
+            return request_json("GET", f"{api_base}/health")
+        except Exception as exc:  # noqa: BLE001 - report final connection failure.
+            last_error = exc
+            time.sleep(delay)
+    raise RuntimeError(f"Dakera healthcheck failed after {retries} attempts: {last_error}")
+
+
+def store_memory(api_base: str, agent_id: str, memory: dict[str, Any]) -> Any:
+    payload = {
+        "agent_id": agent_id,
+        "content": memory["content"],
+        "memory_type": "semantic",
+        "importance": memory.get("importance", 0.5),
+        "metadata": memory.get("metadata", {}),
+    }
+    return request_json("POST", f"{api_base}/v1/memory/store", payload)
+
+
+def recall_memories(api_base: str, agent_id: str, query: str, top_k: int) -> list[dict[str, Any]]:
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/memory/recall",
+        {"agent_id": agent_id, "query": query, "top_k": top_k},
+    )
+    return normalize_recall_response(response)
+
+
+def normalize_recall_response(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, dict)]
+    if not isinstance(response, dict):
+        return []
+
+    for key in ("memories", "results", "items", "data"):
+        value = response.get(key)
+        if isinstance(value, list):
+            normalized = []
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                memory = item.get("memory")
+                if isinstance(memory, dict):
+                    merged = dict(memory)
+                    for score_key in ("score", "weighted_score", "smart_score"):
+                        if score_key in item:
+                            merged[score_key] = item[score_key]
+                    normalized.append(merged)
+                else:
+                    normalized.append(item)
+            return normalized
+
+    if "content" in response:
+        return [response]
+
+    return []
+
+
+def reliability(memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        value = metadata.get("reliability")
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def memory_id(memory: dict[str, Any]) -> str:
+    value = memory.get("id") or memory.get("memory_id") or memory.get("uuid")
+    if isinstance(value, str):
+        return value
+
+    content = str(memory.get("content", ""))
+    return content[:72]
+
+
+def choose_baseline(memories: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not memories:
+        return None
+    return max(memories, key=lambda item: float(item.get("importance", 0.0) or 0.0))
+
+
+def classify_tif(memory: dict[str, Any]) -> dict[str, Any]:
+    rel = reliability(memory)
+    t = float(rel.get("t", 0.0) or 0.0)
+    i = float(rel.get("i", 0.0) or 0.0)
+    f = float(rel.get("f", 0.0) or 0.0)
+
+    if f >= 0.50:
+        action = "surface_contradiction"
+        reason = "high falsity means the memory is diagnostic contradiction evidence"
+    elif i >= 0.50:
+        action = "ask_clarification"
+        reason = "high indeterminacy means reuse is unresolved"
+    elif t >= 0.70 and i <= 0.35 and f <= 0.35:
+        action = "reuse_confidently"
+        reason = "high truth with low uncertainty and contradiction"
+    else:
+        action = "reuse_with_caveat"
+        reason = "mixed reliability requires caveated reuse"
+
+    return {"action": action, "reason": reason, "t": t, "i": i, "f": f}
+
+
+def choose_tif_aware(memories: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    if not memories:
+        return None, {"action": "no_memory", "reason": "no recalled memories"}
+
+    contradiction = [item for item in memories if classify_tif(item)["action"] == "surface_contradiction"]
+    if contradiction:
+        candidate = max(contradiction, key=lambda item: classify_tif(item)["f"])
+        return candidate, classify_tif(candidate)
+
+    unresolved = [item for item in memories if classify_tif(item)["action"] == "ask_clarification"]
+    if unresolved:
+        candidate = max(unresolved, key=lambda item: classify_tif(item)["i"])
+        return candidate, classify_tif(candidate)
+
+    candidate = choose_baseline(memories)
+    assert candidate is not None
+    return candidate, classify_tif(candidate)
+
+
+def evaluate_scenario(scenario: dict[str, Any], memories: list[dict[str, Any]]) -> dict[str, Any]:
+    baseline = choose_baseline(memories)
+    tif_memory, tif_decision = choose_tif_aware(memories)
+    baseline_action = "reuse_top_memory" if baseline else "no_memory"
+    same_memory = memory_id(baseline) == memory_id(tif_memory) if baseline and tif_memory else False
+    equivalent_reuse = same_memory and tif_decision["action"] == "reuse_confidently"
+    changed = baseline_action != tif_decision["action"] and not equivalent_reuse
+
+    return {
+        "scenario": scenario["id"],
+        "query": scenario["query"],
+        "baseline_action": baseline_action,
+        "baseline_memory": memory_id(baseline) if baseline else None,
+        "tif_action": tif_decision["action"],
+        "tif_reason": tif_decision["reason"],
+        "tif_memory": memory_id(tif_memory) if tif_memory else None,
+        "changed_decision": changed,
+        "expected_changed_decision": scenario["expected_changed_decision"],
+        "expected_action": scenario["expected_action"],
+        "passed": changed == scenario["expected_changed_decision"]
+        and tif_decision["action"] == scenario["expected_action"],
+    }
+
+
+def fixture_memories_for_scenario(fixture: dict[str, Any], scenario: dict[str, Any]) -> list[dict[str, Any]]:
+    memories = fixture["memories"]
+    if scenario["id"] == "obsolete-roundtrip-plan":
+        return [memories[1], memories[0]]
+    if scenario["id"] == "high-falsity-contradiction":
+        return [memories[3], memories[0]]
+    if scenario["id"] == "high-indeterminacy-clarification":
+        return [memories[4], memories[0]]
+    return [memories[0], memories[2]]
+
+
+def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    results = []
+    for scenario in fixture["scenarios"]:
+        memories = fixture_memories_for_scenario(fixture, scenario)
+        results.append(evaluate_scenario(scenario, memories))
+    return results
+
+
+def run_runtime_validation(api_base: str, fixture: dict[str, Any], top_k: int) -> dict[str, Any]:
+    agent_id = fixture["agent_id"]
+    health = healthcheck(api_base)
+
+    store_results = []
+    for memory in fixture["memories"]:
+        store_results.append({"id": memory["id"], "response": store_memory(api_base, agent_id, memory)})
+
+    scenario_results = []
+    for scenario in fixture["scenarios"]:
+        scenario_top_k = int(scenario.get("top_k", top_k))
+        recalled = recall_memories(api_base, agent_id, scenario["query"], scenario_top_k)
+        scenario_results.append(evaluate_scenario(scenario, recalled))
+
+    return {"health": health, "stored": store_results, "scenarios": scenario_results}
+
+
+def print_report(results: list[dict[str, Any]]) -> None:
+    print("scenario,baseline_action,tif_action,changed,passed")
+    for result in results:
+        print(
+            ",".join(
+                [
+                    result["scenario"],
+                    result["baseline_action"],
+                    result["tif_action"],
+                    str(result["changed_decision"]).lower(),
+                    str(result["passed"]).lower(),
+                ]
+            )
+        )
+        print(f"  baseline_memory: {result['baseline_memory']}")
+        print(f"  tif_memory: {result['tif_memory']}")
+        print(f"  reason: {result['tif_reason']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Dakera T-I-F reliability metadata behavior.")
+    parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to Phase 1 fixture JSON.")
+    parser.add_argument("--top-k", type=int, default=8, help="Recall top_k value.")
+    parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
+    args = parser.parse_args()
+
+    fixture = load_fixture(args.fixture)
+    if args.self_test:
+        results = run_self_test(fixture)
+        print_report(results)
+        return 0 if all(result["passed"] for result in results) else 1
+
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, args.top_k)
+    print(json.dumps(runtime, indent=2, sort_keys=True))
+    return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/tif-reliability/validate_tif_reliability.py
+++ b/examples/tif-reliability/validate_tif_reliability.py
@@ -21,6 +21,8 @@ from typing import Any
 
 DEFAULT_API = "http://localhost:3200"
 DEFAULT_FIXTURE = Path(__file__).with_name("phase1_memories.json")
+DEFAULT_REQUEST_TIMEOUT = 120
+REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
 
 
 def load_fixture(path: Path) -> dict[str, Any]:
@@ -37,7 +39,7 @@ def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -
 
     request = urllib.request.Request(url, data=body, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(request, timeout=120) as response:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
             raw = response.read().decode("utf-8")
             if not raw:
                 return {}
@@ -200,14 +202,21 @@ def evaluate_scenario(scenario: dict[str, Any], memories: list[dict[str, Any]]) 
 
 
 def fixture_memories_for_scenario(fixture: dict[str, Any], scenario: dict[str, Any]) -> list[dict[str, Any]]:
-    memories = fixture["memories"]
+    memories = {memory["id"]: memory for memory in fixture["memories"]}
+
+    def by_id(memory_id: str) -> dict[str, Any]:
+        try:
+            return memories[memory_id]
+        except KeyError as exc:
+            raise KeyError(f"fixture memory id not found: {memory_id}") from exc
+
     if scenario["id"] == "obsolete-roundtrip-plan":
-        return [memories[1], memories[0]]
+        return [by_id("phase1-obsolete-roundtrip-plan"), by_id("phase1-maintainer-target")]
     if scenario["id"] == "high-falsity-contradiction":
-        return [memories[3], memories[0]]
+        return [by_id("phase1-high-falsity-handling"), by_id("phase1-maintainer-target")]
     if scenario["id"] == "high-indeterminacy-clarification":
-        return [memories[4], memories[0]]
-    return [memories[0], memories[2]]
+        return [by_id("phase1-high-indeterminacy-handling"), by_id("phase1-maintainer-target")]
+    return [by_id("phase1-maintainer-target"), by_id("phase1-developer-facing-name")]
 
 
 def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
@@ -264,8 +273,17 @@ def main() -> int:
         "--agent-id",
         help="Agent ID for runtime validation. Defaults to a unique ID derived from the fixture.",
     )
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="HTTP request timeout in seconds. Startup and first recall can be slow while ONNX warms up.",
+    )
     parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
     args = parser.parse_args()
+
+    global REQUEST_TIMEOUT
+    REQUEST_TIMEOUT = args.request_timeout
 
     fixture = load_fixture(args.fixture)
     if args.self_test:


### PR DESCRIPTION
## Summary

This PR adds a Phase 1 validation package for T-I-F reliability metadata in Dakera agent memory decisions.

It follows the RFC discussion in Dakera issue #161 and the maintainer clarification that Phase 1 should validate whether reliability metadata changes agent-side reuse decisions in a useful way, not merely whether arbitrary metadata round-trips.

## RFC Context

- RFC issue: https://github.com/Dakera-AI/dakera-deploy/issues/161
- Maintainer Phase 1 instruction: https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474
- Fork review-hardening PR: https://github.com/SeCuReDmE-main-dev/dakera-deploy-case-study/pull/1

## Scope

- Public REST API only.
- `metadata.reliability` as the developer-facing metadata key.
- Local agent-side decision evaluator.
- Real conversation-derived memories from issue #161.
- Dedicated local Docker Compose validation stack on REST port `3200` and gRPC port `51051`.

## Non-Goals

- No engine schema changes.
- No recall ranking changes.
- No first-class recall filters.
- No SDK schema changes.
- No Phase 2 session/association provenance behavior.

## What The Validation Shows

The example stores memories with `metadata.reliability = { t, i, f, basis, source, evidence_url }`, recalls them through Dakera, and then applies a local agent-side decision evaluator.

Observed behavior:

- high `f` changes baseline `reuse_top_memory` to `surface_contradiction`;
- high `i` changes baseline `reuse_top_memory` to `ask_clarification`;
- safe high-`t` memory remains `reuse_confidently`;
- `metadata.reliability` survives store and recall unchanged enough for downstream agent policy use.

## Validation

Commands run locally after review corrections:

```bash
python -m py_compile examples/tif-reliability/validate_tif_reliability.py
python examples/tif-reliability/validate_tif_reliability.py --self-test
docker compose -f docker/docker-compose.tif-phase1.yml up -d
python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200 --request-timeout 240
docker compose -f docker/docker-compose.tif-phase1.yml down
```

Runtime validation used Dakera image `ghcr.io/dakera-ai/dakera:0.11.81` and passed all scenarios.

Detailed evidence is recorded in `examples/tif-reliability/VALIDATION_RESULTS.md`.

## Review Correction Pass

Before opening this upstream PR, the branch went through a fork PR review loop:

- Qodo review completed and marked actionable findings resolved.
- Gemini Code Assist review completed and actionable robustness comments were addressed.
- Codex connector review completed with no separate actionable change exposed beyond the same review loop.

Corrections made after bot review:

- restricted the local validation compose ports to `127.0.0.1` because auth is disabled for the smoke test;
- aligned compose healthcheck/docs/runtime validation on `/health/ready`;
- replaced brittle fixture list indexing with stable memory ID lookup;
- added configurable `--request-timeout` for slow ONNX warmup and first recall;
- documented the local-only auth-disabled validation boundary.