### PR TITLE
docs: bump server image version 0.11.66→0.11.90 (DAK-6614)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Production-grade single-node deployment with MinIO, caching, and health checks.
 > **Version pinning**: The default image tags are pinned to the latest stable release.
 > To run a specific version, set `DAKERA_IMAGE` and `DASHBOARD_IMAGE` in your `.env`:
 > ```bash
-> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.66
+> DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.90
 > DASHBOARD_IMAGE=ghcr.io/dakera-ai/dakera-dashboard:0.3.29
 > ```
 > Pinning to explicit versions prevents unexpected upgrades in production.
@@ -503,7 +503,7 @@ The Helm chart has moved to the dedicated **[dakera-helm](https://github.com/dak
 
 ```bash
 # Install from GHCR OCI
-helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.66 \
+helm install dakera oci://ghcr.io/dakera-ai/dakera-helm/dakera --version 0.11.90 \
   --namespace dakera --create-namespace \
   --set dakera.rootApiKey=$(openssl rand -hex 32) \
   --set minio.rootPassword=$(openssl rand -hex 16)


### PR DESCRIPTION
## Summary
- `README.md` line 136: `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:0.11.66` → `0.11.90`
- `README.md` line 506: `helm --version 0.11.66` → `0.11.90`
- `DASHBOARD_IMAGE=0.3.29` unchanged (current)

Part of DAK-6614 / founder directive DAK-6613 factual accuracy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)