### PR TITLE
fix(deploy): remove compose-named dakera containers before force-recreate

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -91,9 +91,11 @@ jobs:
             COMPOSE_DIR=$(docker inspect "$CONTAINER" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || echo "")
             if [ -n "$COMPOSE_DIR" ] && [ -d "$COMPOSE_DIR" ]; then
               cd "$COMPOSE_DIR"
-              # Remove stale container before recreate to prevent Docker naming conflicts
-              # (container_name + compose project-hash alias can collide on --force-recreate)
-              docker rm -f dakera 2>/dev/null || true
+              # Remove ALL stale dakera containers before recreate to prevent Docker naming
+              # conflicts. docker-compose names containers as <project-hash>_<service>, so
+              # "docker rm -f dakera" misses containers named e.g. "fdbaa06c2bb4_dakera".
+              # Force-remove every container whose name contains "dakera" (excludes minio).
+              docker ps -a --filter "name=dakera" --format "{{.Names}}" | grep -vE 'minio|minio-setup' | xargs -r docker rm -f 2>/dev/null || true
               # Force-recreate minio so new resource limits (cpus/memory) take effect
               DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:${{ inputs.version }} docker compose up -d --force-recreate minio minio-setup dakera
             else


### PR DESCRIPTION
## Problem

Deploy to Production fails with container naming conflict when redeploy is triggered:

```
Container dakera Error response from daemon: Conflict. The container name
"/fdbaa06c2bb4_dakera" is already in use...
```

Root cause: `docker rm -f dakera` only removes a container with the **exact** name `dakera`, but docker-compose generates names as `<project-hash>_<service>` (e.g. `fdbaa06c2bb4_dakera`). The old compose-named container is never removed, so `docker compose up --force-recreate` fails with a name conflict.

Confirmed from: https://github.com/Dakera-AI/dakera-deploy/actions/runs/27398860486

## Fix

Replace the targeted `docker rm -f dakera` with:
```bash
docker ps -a --filter "name=dakera" --format "{{.Names}}" | grep -vE 'minio|minio-setup' | xargs -r docker rm -f 2>/dev/null || true
```

This enumerates and removes ALL containers whose name contains `dakera` (excluding minio services), regardless of the compose project hash prefix.

## Test Plan

- [ ] Next deploy should not hit container conflict error
- [ ] minio and minio-setup containers are preserved (grep -vE guard)
- [ ] If no dakera container exists, `xargs -r` skips gracefully (no error)

🤖 [Agent: CTO]