### PR TITLE
fix(ci): use DAKERA_ROOT_API_KEY in namespace-cleanup workflow (DAK-6635)

### DIFF
--- a/.github/workflows/namespace-cleanup.yml
+++ b/.github/workflows/namespace-cleanup.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run namespace cleanup
         env:
           DAKERA_API_URL: "http://${{ secrets.SERVER_IP_PROD }}:3300"
-          DAKERA_API_KEY: ${{ secrets.DAKERA_API_KEY }}
+          DAKERA_API_KEY: ${{ secrets.DAKERA_ROOT_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
         run: |
           chmod +x scripts/namespace-cleanup/namespace-cleanup.sh


### PR DESCRIPTION
## Root Cause

The Namespace Cleanup cron workflow has been failing since 2026-06-07 (runs 27085529233 and 27491662619) with:

```
scripts/namespace-cleanup/namespace-cleanup.sh: line 33: DAKERA_API_KEY: DAKERA_API_KEY must be set
```

The workflow referenced `secrets.DAKERA_API_KEY` — but this secret does **not exist** in `dakera-deploy`. The repo's API key secret is named `DAKERA_ROOT_API_KEY` (set 2026-04-24 during key rotation).

## Fix

One-line change: `secrets.DAKERA_API_KEY` → `secrets.DAKERA_ROOT_API_KEY`

The shell env var name (`DAKERA_API_KEY`) is unchanged — the script reads `DAKERA_API_KEY` from env, which is correct. Only the secret reference was wrong.

## Verification Plan

After merge, trigger a manual `workflow_dispatch` (dry_run=true) to confirm the key resolves and the script successfully lists stale namespaces without deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)