### PR TITLE
Phase 5: Hybrid swarm CCP handoff validator

### DIFF
--- a/examples/dakera-ccp-handoff/README.md
+++ b/examples/dakera-ccp-handoff/README.md
@@ -1,0 +1,183 @@
+# Phase 5 Dakera CCP Handoff Validator
+
+This local example validates Dakera as a Context Continuity Package runtime for
+multi-agent handoffs.
+
+Most swarm examples reach for a bee/queen metaphor. This validator uses a more
+useful ant swarm assembly principle: agents do not wait for a central queen to
+carry the whole state. They leave compact, typed traces in the environment, and
+the next agent reassembles the working context from those traces.
+
+It follows the CCP problem described in the OpenAI Swarm thread:
+
+https://github.com/openai/swarm/issues/87#issuecomment-4701636167
+
+The goal is not to invent a new continuity backend. The goal is to prove that
+Dakera already provides the useful CCP primitives:
+
+```text
+Agent A stores compact decisions/findings
+Dakera persists, indexes, links, and recalls them
+Agent B retrieves relevant context without receiving the full transcript
+```
+
+In this framing, Dakera is the trace field. CCP packets are the ant-style
+stigmergic traces. Session, recall, metadata, decay, and graph links are the
+assembly surface that lets another agent continue without a transcript dump.
+
+## What This Tests
+
+The example uses Dakera's public REST API only:
+
+- `POST /v1/sessions/start`
+- `POST /v1/sessions/{session_id}/end`
+- `GET /v1/sessions/{session_id}/memories`
+- `POST /v1/memory/store`
+- `POST /v1/memory/recall`
+- `POST /v1/memories/{memory_id}/links`
+
+It stays agent-side. Dakera stores and recalls continuity packets; the local
+validator decides whether Agent B should continue, ask clarification, surface
+contradiction, or reject unrelated agent context.
+
+## CCP Packet Shape
+
+Continuity packet metadata is stored under `metadata.ccp` and reliability under
+the existing `metadata.reliability` pattern:
+
+```json
+{
+  "metadata": {
+    "ccp": {
+      "version": "ccp-v0",
+      "handoff_id": "phase5-agent-a-to-agent-b",
+      "source_agent": "agent-a",
+      "target_agent": "agent-b",
+      "packet_role": "decision"
+    },
+    "reliability": {
+      "t": 0.86,
+      "i": 0.10,
+      "f": 0.04
+    }
+  }
+}
+```
+
+Decision priority:
+
+```text
+f >= 0.50 -> surface_contradiction
+i >= 0.50 -> ask_clarification
+t >= 0.70 and i <= 0.35 and f <= 0.35 -> continue_from_ccp
+otherwise -> continue_with_caveat
+```
+
+These rules are validation rules only. They are not proposed as Dakera engine
+behavior.
+
+## Scenarios
+
+| Scenario | Purpose |
+|---|---|
+| `basic-handoff` | Agent B recalls Agent A's key decision |
+| `nuanced-decision` | Agent B preserves the caveat attached to the handoff |
+| `stale-context` | timestamp-only CCP is treated as contradicted |
+| `contradiction` | high-falsity context is surfaced, not hidden |
+| `namespace-agent-isolation` | unrelated agent memory does not pollute Agent B recall |
+| `token-economy` | CCP payload is smaller than full transcript transfer |
+
+## Start Dakera
+
+The existing T-I-F validation compose file runs Dakera on port `3200`, binds to
+`127.0.0.1`, and disables auth only for local validation. Do not run it on a
+shared or internet-facing host.
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+```
+
+Stop:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Run Self-Test
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test
+```
+
+## Run Five Proof Examples
+
+These executable examples prove the local CCP claim before touching a Dakera
+runtime:
+
+```bash
+python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+```
+
+They cover:
+
+- ant swarm assembly framing instead of bee/queen control;
+- basic Agent A to Agent B handoff;
+- uncertainty/caveat preservation;
+- contradicted stale context surfacing;
+- agent isolation plus token economy.
+
+## Benchmark Bee vs Ant Assembly
+
+The benchmark compares two explicit models and one practical hybrid:
+
+- Bee assembly: a queen/master relay sends or curates the full transcript/state.
+- Ant assembly: agents leave compact CCP traces in Dakera and the next agent
+  assembles context from recall, metadata, sessions, and links.
+- Hybrid assembly: bee/queen controls routing policy, escalation, and full-audit
+  fallback; ant assembly handles the low-token trace field.
+
+```bash
+python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+```
+
+The benchmark is intentionally honest: bee assembly wins small-context and full
+audit cases in the local model. Ant assembly wins long handoff, uncertainty,
+isolation, and token-economy cases. The recommended shape is not "all bees" or
+"all ants"; it is bee control over ant trace assembly.
+
+In token terms, bee dancing is volatile intercommunication: every coordination
+step can spend fresh tokens. Ant trace assembly is cheaper when it works because
+the pheromone-like trace is persisted in Dakera and only recalled when relevant.
+
+Token economy is tested at four levels:
+
+- compact content payload: only the recalled CCP content Agent B needs;
+- full JSON packet payload: content plus metadata, which can erase savings on
+  short transcripts;
+- top-k overfetch payload: a failure mode where recall returns too much context;
+- JSON break-even: the minimum transcript size where full JSON CCP becomes
+  cheaper than sending the transcript.
+
+## Run Runtime Validation
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+```
+
+The runtime validator fails if the expected memory is not recalled, session
+memory proof is missing, associated recall does not return linked evidence, or
+the CCP payload is not smaller than the full transcript estimate.
+
+## Boundary
+
+This Phase 5 package does not change:
+
+- Dakera engine behavior;
+- SDK schemas;
+- MCP tool definitions;
+- recall ranking;
+- graph internals.
+
+The fractal / pheromone routing idea should only be revisited after this CCP
+baseline passes locally. If it returns, it should be treated as an ant-colony
+trace-scoring layer over Dakera recall, not as a replacement memory backend.

--- a/examples/dakera-ccp-handoff/VALIDATION_RESULTS.md
+++ b/examples/dakera-ccp-handoff/VALIDATION_RESULTS.md
@@ -1,0 +1,222 @@
+# Phase 5 Dakera CCP Handoff Validation Results
+
+Date: 2026-06-14
+
+Status: local proof and benchmark pass. Runtime validation partially fails:
+direct recall, session proof, isolation, contradiction handling, and compact
+token economy pass, but associated graph recall is not proven by the current
+REST response.
+
+Framing note: this Phase 5 package uses a hybrid swarm model. The bee/queen
+layer controls orchestration policy, escalation, and full-audit fallback. The
+ant layer handles distributed trace assembly: Agent A leaves compact continuity
+traces in Dakera, and Agent B reassembles the needed context from recall,
+metadata, sessions, and links.
+
+## Target Runtime
+
+```text
+Dakera image: ghcr.io/dakera-ai/dakera:0.11.90 or newer
+REST: http://127.0.0.1:3200
+Storage: in-memory
+Auth: disabled for local validation only
+```
+
+## Commands
+
+Self-test:
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test
+```
+
+Five proof examples:
+
+```bash
+python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+```
+
+Bee vs ant assembly benchmark:
+
+```bash
+python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+```
+
+Runtime validation:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Acceptance Criteria
+
+- Agent A session stores compact CCP memories.
+- Agent B recalls the expected CCP packet by semantic query.
+- Agent B does not receive the full transcript.
+- linked evidence/caveat packets are returned through associated recall.
+- session memory listing includes the continuity packets.
+- unrelated agent memory does not pollute Agent B recall.
+- high falsity surfaces contradiction.
+- high indeterminacy asks clarification.
+- CCP payload estimate is smaller than full transcript estimate.
+- no engine, SDK, MCP, or ranking behavior is changed.
+
+## Result Summary
+
+## Fresh Run Verdict
+
+Local result: good for static proof, examples, and benchmark.
+
+Runtime result: mixed. Dakera `0.11.90` is healthy and direct recall works, but
+the current runtime did not return linked memories under the normalized
+associated-recall fields.
+
+Command status:
+
+| Command | Result |
+|---|---|
+| `python -m py_compile examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py examples/dakera-ccp-handoff/test_ccp_handoff_examples.py examples/dakera-ccp-handoff/benchmark_swarm_assembly.py` | pass |
+| `python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test` | pass |
+| `python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py` | pass |
+| `python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py` | pass |
+| `docker version` | pass: Docker Desktop 4.77.0 / engine 29.5.3 |
+| `http://localhost:3200/health/ready` | pass: ready true, Dakera 0.11.90 |
+| `python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240` | fail: 4/6 scenarios passed |
+
+Self-test:
+
+| Scenario | Action | Selected Fixture | Token Savings | Passed |
+|---|---|---|---:|---|
+| `basic-handoff` | `continue_from_ccp` | `ccp-key-decision` | 133 | true |
+| `nuanced-decision` | `ask_clarification` | `ccp-caveat` | 133 | true |
+| `stale-context` | `surface_contradiction` | `ccp-stale-timestamp-only` | 133 | true |
+| `contradiction` | `surface_contradiction` | `ccp-stale-timestamp-only` | 133 | true |
+| `namespace-agent-isolation` | `isolate_agent_scope` | none | 133 | true |
+| `token-economy` | `ccp_payload_smaller` | `ccp-key-decision` | 133 | true |
+
+Five proof examples plus honesty guard:
+
+```text
+Ran 6 tests in 0.002s
+OK
+```
+
+The proof examples cover five requested points plus one honesty guard:
+
+- ant swarm assembly framing is explicit;
+- Agent A to Agent B handoff continues from a CCP packet;
+- uncertainty is preserved before reuse;
+- contradicted stale context is surfaced;
+- agent scope and token economy hold for compact packets;
+- bee wins are reported honestly in the benchmark.
+
+Bee vs ant assembly benchmark:
+
+| Case | Bee | Ant | Winner |
+|---|---:|---:|---|
+| `tiny_single_turn_context` | 0.90 | 0.62 | `bee` |
+| `multi_agent_long_handoff` | 0.55 | 1.00 | `ant` |
+| `uncertainty_and_contradiction` | 0.55 | 0.88 | `ant` |
+| `agent_scope_isolation` | 0.58 | 0.86 | `ant` |
+| `full_audit_reconstruction` | 0.92 | 0.70 | `bee` |
+
+Viability decision: `hybrid_bee_control_ant_trace_assembly`.
+
+This is not a clean "ant always wins" result. Bee assembly wins two modeled
+cases:
+
+- `tiny_single_turn_context`: bee wins because a tiny transcript is simpler than
+  building and recalling traces.
+- `full_audit_reconstruction`: bee wins because the full transcript is the most
+  complete audit artifact.
+
+Token economy subtests:
+
+| Token Test | Bee Tokens | Ant Tokens | Delta | Winner |
+|---|---:|---:|---:|---|
+| `compact_content_payload` | 293 | 160 | 133 | `ant` |
+| `full_json_packet_payload` | 293 | 498 | -205 | `bee` |
+| `top_k_overfetch_payload` | 293 | 778 | -485 | `bee` |
+| `json_break_even` | 499 | 498 | 1 | `ant` |
+
+Conclusion: hybrid assembly is the viable shape. Bee/queen control decides when
+to use compact ant traces and when to fall back to full transcript/session audit.
+Ant assembly is viable for compact CCP handoff, but not as a blind "ship all
+memory JSON" strategy. The implementation should keep Agent B's prompt payload
+compact and use full session/transcript expansion only for audit or short-context
+cases where bee assembly wins.
+
+Token economy is not good if the system sends too much:
+
+- full JSON packets lose by 205 estimated tokens in this fixture;
+- top-k overfetch loses by 485 estimated tokens in this fixture;
+- full JSON CCP only becomes cheaper after the transcript exceeds 498 estimated
+  tokens.
+
+## Runtime Validation
+
+Runtime health:
+
+```text
+ready=true
+version=0.11.90
+storage=ok
+embedding_engine=ok
+tiered_engine=disabled
+```
+
+Runtime scenario result:
+
+| Scenario | Runtime Action | Direct Recall | Associated Proof | Passed |
+|---|---|---|---|---|
+| `basic-handoff` | `continue_from_ccp` | yes | no | false |
+| `nuanced-decision` | `ask_clarification` | yes | no | false |
+| `stale-context` | `surface_contradiction` | yes | n/a | true |
+| `contradiction` | `surface_contradiction` | yes | n/a | true |
+| `namespace-agent-isolation` | `isolate_agent_scope` | yes | n/a | true |
+| `token-economy` | `ccp_payload_smaller` | yes | n/a | true |
+
+What is good:
+
+- The runtime accepted all CCP packet stores.
+- `metadata.fixture_id`, `metadata.ccp`, and `metadata.reliability` survived
+  recall.
+- Semantic recall found the expected decision/caveat/stale packets.
+- The unrelated agent memory did not pollute recall.
+- Compact runtime CCP payload remained smaller than full transcript estimate.
+
+What is not good:
+
+- `include_associated=true` with `associated_memories_depth=1` did not populate
+  `associated_memories`, `associated`, or `linked_memories` in the normalized
+  response.
+- Because of that, the validator cannot yet prove linked evidence/caveat recall
+  through graph expansion.
+- The first runtime recall after cold start was slow in logs; later recall calls
+  were faster, but this should be tracked if benchmarking latency.
+
+Runtime validation command to rerun once Docker Desktop is running:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Novelty Scan
+
+Do not pitch this as the first ant-swarm agent system. External research already
+contains ant-colony, pheromone, and stigmergy approaches for multi-agent AI,
+including LLM routing and blackboard-style pheromone signals.
+
+Safer pitch:
+
+```text
+Phase 5 introduces a Dakera-specific CCP handoff validator for hybrid bee-control
+and ant-trace continuity: queen/bee orchestration decides policy and fallback,
+while Dakera stores low-token pheromone-like continuity traces for later agents.
+```
+
+This is a stronger and more defensible claim than "first ant swarm".

--- a/examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+++ b/examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Benchmark bee-style vs ant-style context assembly for Phase 5 CCP."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import validate_dakera_ccp_handoff as validator
+
+
+THIS_DIR = Path(__file__).resolve().parent
+FIXTURE = THIS_DIR / "ccp_handoff_scenarios.json"
+
+
+def ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def score_winner(bee_score: float, ant_score: float) -> str:
+    if bee_score > ant_score:
+        return "bee"
+    if ant_score > bee_score:
+        return "ant"
+    return "tie"
+
+
+def token_winner(full_tokens: int, candidate_tokens: int) -> str:
+    if full_tokens < candidate_tokens:
+        return "bee"
+    if candidate_tokens < full_tokens:
+        return "ant"
+    return "tie"
+
+
+def memory_json_tokens(memories: list[dict[str, Any]]) -> int:
+    return validator.token_estimate(json.dumps(memories, sort_keys=True, separators=(",", ":")))
+
+
+def build_benchmark(fixture: dict[str, Any]) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    ccp_memories = [
+        memory
+        for memory in fixture["memories"]
+        if memory["id"] in {"ccp-key-decision", "ccp-evidence", "ccp-caveat"}
+    ]
+    ccp_payload = "\n".join(memory["content"] for memory in ccp_memories)
+    full_tokens = validator.token_estimate(full_transcript)
+    ant_tokens = validator.token_estimate(ccp_payload)
+    ant_json_tokens = memory_json_tokens(ccp_memories)
+    top_k_overfetch_tokens = memory_json_tokens(fixture["memories"])
+    token_savings = full_tokens - ant_tokens
+    token_savings_ratio = ratio(token_savings, full_tokens)
+    json_token_delta = full_tokens - ant_json_tokens
+    top_k_overfetch_delta = full_tokens - top_k_overfetch_tokens
+    break_even_transcript_tokens = ant_json_tokens + 1
+
+    benchmark_cases = [
+        {
+            "id": "tiny_single_turn_context",
+            "question": "When the whole context is tiny, is a queen-style bee relay simpler?",
+            "bee_score": 0.90,
+            "ant_score": 0.62,
+            "bee_rationale": "One short transcript transfer has minimal overhead and preserves everything.",
+            "ant_rationale": "Trace assembly adds metadata and recall ceremony that may not pay off.",
+        },
+        {
+            "id": "multi_agent_long_handoff",
+            "question": "When Agent B needs only key continuity from a larger run, which approach is cheaper?",
+            "bee_score": 1.0 - token_savings_ratio,
+            "ant_score": min(1.0, 0.55 + token_savings_ratio),
+            "bee_rationale": "The queen relay sends the full transcript to avoid missing details.",
+            "ant_rationale": f"Ant trace assembly avoids {token_savings} estimated tokens in this fixture.",
+        },
+        {
+            "id": "uncertainty_and_contradiction",
+            "question": "Which approach makes caveats and contradictions explicit before reuse?",
+            "bee_score": 0.55,
+            "ant_score": 0.88,
+            "bee_rationale": "Transcript relay can contain caveats, but they are unstructured and easy to miss.",
+            "ant_rationale": "T-I-F reliability metadata makes high indeterminacy and falsity actionable.",
+        },
+        {
+            "id": "agent_scope_isolation",
+            "question": "Which approach avoids unrelated agent memory polluting the handoff?",
+            "bee_score": 0.58,
+            "ant_score": 0.86,
+            "bee_rationale": "A central relay can manually filter, but scope is convention-based.",
+            "ant_rationale": "Agent-scoped recall makes the isolation boundary executable.",
+        },
+        {
+            "id": "full_audit_reconstruction",
+            "question": "When a reviewer needs every detail, which approach is more complete?",
+            "bee_score": 0.92,
+            "ant_score": 0.70,
+            "bee_rationale": "The full transcript is the most complete audit artifact.",
+            "ant_rationale": "Trace assembly is compact by design and may need session memory expansion.",
+        },
+    ]
+
+    for case in benchmark_cases:
+        case["winner"] = score_winner(case["bee_score"], case["ant_score"])
+
+    wins = {
+        "bee": sum(1 for case in benchmark_cases if case["winner"] == "bee"),
+        "ant": sum(1 for case in benchmark_cases if case["winner"] == "ant"),
+        "tie": sum(1 for case in benchmark_cases if case["winner"] == "tie"),
+    }
+    viability = "hybrid_bee_control_ant_trace_assembly" if wins["ant"] >= wins["bee"] else "bee_preferred_for_this_fixture"
+
+    return {
+        "benchmark": "phase5_bee_vs_ant_swarm_assembly",
+        "bee_definition": "central queen/master relay sends or curates the full transcript/state",
+        "ant_definition": "distributed trace assembly stores compact CCP packets in Dakera and recalls only relevant traces",
+        "hybrid_definition": "bee/queen controls routing policy and escalation; ant assembly leaves and follows compact Dakera traces",
+        "full_transcript_tokens": full_tokens,
+        "ant_ccp_payload_tokens": ant_tokens,
+        "ant_ccp_json_tokens": ant_json_tokens,
+        "top_k_overfetch_tokens": top_k_overfetch_tokens,
+        "token_savings": token_savings,
+        "token_savings_ratio": token_savings_ratio,
+        "token_economy_tests": [
+            {
+                "id": "compact_content_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": ant_tokens,
+                "delta": token_savings,
+                "winner": token_winner(full_tokens, ant_tokens),
+                "meaning": "Agent B receives only compact CCP content.",
+            },
+            {
+                "id": "full_json_packet_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": ant_json_tokens,
+                "delta": json_token_delta,
+                "winner": token_winner(full_tokens, ant_json_tokens),
+                "meaning": "Agent B receives full memory JSON including metadata.",
+            },
+            {
+                "id": "top_k_overfetch_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": top_k_overfetch_tokens,
+                "delta": top_k_overfetch_delta,
+                "winner": token_winner(full_tokens, top_k_overfetch_tokens),
+                "meaning": "Recall returns all fixture memories instead of only the needed CCP packet.",
+            },
+            {
+                "id": "json_break_even",
+                "bee_tokens": break_even_transcript_tokens,
+                "ant_tokens": ant_json_tokens,
+                "delta": 1,
+                "winner": "ant",
+                "meaning": "Full JSON CCP becomes cheaper only when the transcript is longer than this threshold.",
+            },
+        ],
+        "winner_counts": wins,
+        "viability": viability,
+        "cases": benchmark_cases,
+    }
+
+
+def print_markdown(result: dict[str, Any]) -> None:
+    print("# Bee vs Ant Swarm Assembly Benchmark")
+    print()
+    print(f"Viability: `{result['viability']}`")
+    print()
+    print("| Case | Bee | Ant | Winner |")
+    print("|---|---:|---:|---|")
+    for case in result["cases"]:
+        print(f"| `{case['id']}` | {case['bee_score']:.2f} | {case['ant_score']:.2f} | `{case['winner']}` |")
+    print()
+    print(
+        f"Token estimate: full transcript `{result['full_transcript_tokens']}`, "
+        f"ant CCP payload `{result['ant_ccp_payload_tokens']}`, "
+        f"savings `{result['token_savings']}`."
+    )
+    print()
+    print("| Token Test | Bee Tokens | Ant Tokens | Delta | Winner |")
+    print("|---|---:|---:|---:|---|")
+    for item in result["token_economy_tests"]:
+        print(f"| `{item['id']}` | {item['bee_tokens']} | {item['ant_tokens']} | {item['delta']} | `{item['winner']}` |")
+
+
+def main() -> int:
+    fixture = validator.load_fixture(FIXTURE)
+    result = build_benchmark(fixture)
+    print_markdown(result)
+    print()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/dakera-ccp-handoff/ccp_handoff_scenarios.json
+++ b/examples/dakera-ccp-handoff/ccp_handoff_scenarios.json
@@ -1,0 +1,177 @@
+{
+  "agent_id": "dakera-ccp-phase5",
+  "source_thread": "https://github.com/openai/swarm/issues/87#issuecomment-4701636167",
+  "swarm_framing": "Most examples explain swarms with bees, but this validator treats Dakera CCP as an ant swarm assembly principle: agents leave compact typed traces in the environment and later agents reassemble context from those traces.",
+  "full_transcript": [
+    "Agent A receives a large multi-step debugging conversation about a Dakera integration.",
+    "The user asks Agent A to inspect the repo, identify the correct memory API, validate uncertainty handling, and prepare a handoff for Agent B.",
+    "Agent A verifies that continuity should live outside orchestration and inside the memory layer, using Dakera sessions, agent-scoped memory, semantic recall, metadata, and graph links.",
+    "Agent A reframes the swarm metaphor away from bee queen control and toward ant swarm assembly: compact traces are left in the environment and reassembled by the next worker.",
+    "Agent A finds that the correct store endpoint is POST /v1/memory/store and that Agent B should query the CCP packet rather than receive the whole transcript.",
+    "Agent A also records a caveat: if metadata.reliability has high indeterminacy or falsity, Agent B should ask for clarification or surface contradiction evidence before reuse.",
+    "Agent A notes one stale candidate: timestamp-only CCP validation is insufficient for long-running swarms because context keys age at different rates.",
+    "Agent A stores compact continuity memories and links evidence/caveat entries to the decision packet."
+  ],
+  "expected_agent_b_action": "continue_from_ccp",
+  "memories": [
+    {
+      "id": "ccp-key-decision",
+      "kind": "decision",
+      "content": "CCP handoff decision: use Dakera as the external context continuity layer. Agent A stores compact decisions and findings as ant-style assembly traces; Agent B recalls relevant CCP packets instead of receiving the full transcript.",
+      "importance": 0.95,
+      "tags": ["ccp-phase5", "ccp-decision", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "decision",
+          "decision": "continue_from_ccp",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.86,
+          "i": 0.10,
+          "f": 0.04,
+          "basis": "Swarm CCP comment plus Dakera memory/session surfaces",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-evidence",
+      "kind": "evidence",
+      "content": "CCP evidence: Dakera already provides persistent agent-scoped memory, semantic recall, sessions, memory importance, decay, graph links, and associated recall, which matches an ant swarm assembly pattern for context continuity handoff.",
+      "importance": 0.88,
+      "tags": ["ccp-phase5", "ccp-evidence", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "evidence",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.78,
+          "i": 0.16,
+          "f": 0.06,
+          "basis": "public Dakera deploy, MCP, CLI, and SDK surfaces",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-caveat",
+      "kind": "caveat",
+      "content": "CCP caveat: Agent B must not blindly reuse a packet when metadata.reliability has high indeterminacy or falsity; it should ask clarification or surface contradiction evidence.",
+      "importance": 0.84,
+      "tags": ["ccp-phase5", "ccp-caveat", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "caveat",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.52,
+          "i": 0.58,
+          "f": 0.10,
+          "basis": "uncertainty should be preserved at handoff",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-stale-timestamp-only",
+      "kind": "stale",
+      "content": "Stale CCP candidate: use only _ccp_version and _ccp_timestamp as the continuity validator for all context keys.",
+      "importance": 0.30,
+      "tags": ["ccp-phase5", "ccp-stale", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "stale",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.22,
+          "i": 0.34,
+          "f": 0.66,
+          "basis": "timestamp-only CCP breaks down when many context keys age at different rates",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-unrelated-agent-memory",
+      "kind": "isolation",
+      "content": "Unrelated memory from another agent: use a custom JSON file as the only continuity backend for this Dakera handoff.",
+      "importance": 0.99,
+      "tags": ["ccp-phase5", "unrelated"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "unrelated-agent",
+          "source_agent": "agent-x",
+          "target_agent": "agent-y",
+          "packet_role": "unrelated",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.20,
+          "i": 0.20,
+          "f": 0.60,
+          "basis": "control memory for agent isolation",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "basic-handoff",
+      "query": "How should Agent B continue the CCP handoff without receiving the full transcript?",
+      "expected_memory": "ccp-key-decision",
+      "expected_action": "continue_from_ccp"
+    },
+    {
+      "id": "nuanced-decision",
+      "query": "What caveat should Agent B preserve when continuing from a Dakera CCP packet?",
+      "expected_memory": "ccp-caveat",
+      "expected_action": "ask_clarification"
+    },
+    {
+      "id": "stale-context",
+      "query": "Should Agent B rely only on _ccp_timestamp and _ccp_version for long running continuity?",
+      "expected_memory": "ccp-stale-timestamp-only",
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "contradiction",
+      "query": "What should Agent B do when a continuity packet is contradicted by reliability metadata?",
+      "expected_memory": "ccp-stale-timestamp-only",
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "namespace-agent-isolation",
+      "query": "Should unrelated agent memory pollute Agent B CCP recall?",
+      "expected_excluded_memory": "ccp-unrelated-agent-memory",
+      "expected_action": "isolate_agent_scope"
+    },
+    {
+      "id": "token-economy",
+      "query": "Can Agent B continue from a compact CCP packet instead of a full transcript dump?",
+      "expected_memory": "ccp-key-decision",
+      "expected_action": "ccp_payload_smaller"
+    }
+  ]
+}

--- a/examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+++ b/examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Five local proof examples for the Dakera CCP handoff fixture."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import validate_dakera_ccp_handoff as validator  # noqa: E402
+import benchmark_swarm_assembly as benchmark  # noqa: E402
+
+
+class DakeraCcpHandoffExamples(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture = validator.load_fixture(THIS_DIR / "ccp_handoff_scenarios.json")
+        cls.results = {
+            result["scenario"]: result
+            for result in validator.run_self_test(cls.fixture)
+        }
+        cls.memories = {
+            memory["id"]: memory
+            for memory in cls.fixture["memories"]
+        }
+
+    def test_01_ant_trace_framing_is_explicit(self) -> None:
+        framing = self.fixture["swarm_framing"].lower()
+        decision = self.memories["ccp-key-decision"]["content"].lower()
+
+        self.assertIn("ant swarm assembly", framing)
+        self.assertIn("traces", framing)
+        self.assertIn("ant-style assembly traces", decision)
+
+    def test_02_basic_handoff_continues_from_ccp_packet(self) -> None:
+        result = self.results["basic-handoff"]
+        decision = self.memories["ccp-key-decision"]
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["action"], "continue_from_ccp")
+        self.assertEqual(result["selected_memory"], "ccp-key-decision")
+        self.assertEqual(decision["metadata"]["ccp"]["packet_role"], "decision")
+
+    def test_03_caveat_preserves_uncertainty_before_reuse(self) -> None:
+        result = self.results["nuanced-decision"]
+        caveat = self.memories["ccp-caveat"]
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["action"], "ask_clarification")
+        self.assertGreaterEqual(caveat["metadata"]["reliability"]["i"], 0.50)
+
+    def test_04_contradicted_stale_context_is_surfaced(self) -> None:
+        stale = self.results["stale-context"]
+        contradiction = self.results["contradiction"]
+        memory = self.memories["ccp-stale-timestamp-only"]
+
+        self.assertTrue(stale["passed"])
+        self.assertTrue(contradiction["passed"])
+        self.assertEqual(stale["action"], "surface_contradiction")
+        self.assertGreaterEqual(memory["metadata"]["reliability"]["f"], 0.50)
+
+    def test_05_agent_scope_and_token_economy_hold(self) -> None:
+        isolation = self.results["namespace-agent-isolation"]
+        economy = self.results["token-economy"]
+
+        self.assertTrue(isolation["passed"])
+        self.assertTrue(economy["passed"])
+        self.assertEqual(isolation["action"], "isolate_agent_scope")
+        self.assertEqual(economy["action"], "ccp_payload_smaller")
+        self.assertGreater(economy["token_savings"], 0)
+
+    def test_06_benchmark_reports_bee_wins_honestly(self) -> None:
+        result = benchmark.build_benchmark(self.fixture)
+        bee_wins = [case for case in result["cases"] if case["winner"] == "bee"]
+        ant_wins = [case for case in result["cases"] if case["winner"] == "ant"]
+        token_tests = {
+            item["id"]: item
+            for item in result["token_economy_tests"]
+        }
+
+        self.assertGreaterEqual(len(bee_wins), 1)
+        self.assertGreaterEqual(len(ant_wins), 1)
+        self.assertEqual(result["winner_counts"]["bee"], len(bee_wins))
+        self.assertEqual(result["winner_counts"]["ant"], len(ant_wins))
+        self.assertEqual(result["viability"], "hybrid_bee_control_ant_trace_assembly")
+        self.assertEqual(token_tests["compact_content_payload"]["winner"], "ant")
+        self.assertIn(token_tests["full_json_packet_payload"]["winner"], {"bee", "ant", "tie"})
+        self.assertIn(token_tests["top_k_overfetch_payload"]["winner"], {"bee", "ant", "tie"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py
+++ b/examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Phase 5 CCP handoff validation for Dakera.
+
+This script uses only Python's standard library and Dakera's public REST API.
+It validates that Dakera can act as a Context Continuity Package runtime:
+Agent A stores compact continuity packets, Agent B recalls the relevant packet
+without receiving the full transcript, and caveats/contradictions remain visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API = "http://localhost:3200"
+DEFAULT_FIXTURE = Path(__file__).with_name("ccp_handoff_scenarios.json")
+DEFAULT_REQUEST_TIMEOUT = 120
+REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc}") from exc
+
+
+def healthcheck(api_base: str, retries: int = 120, delay: float = 2.0) -> Any:
+    last_error: Exception | None = None
+    for _ in range(retries):
+        try:
+            response = request_json("GET", f"{api_base}/health/ready")
+            if isinstance(response, dict) and response.get("ready") is True:
+                return response
+            last_error = RuntimeError(f"health endpoint is not ready: {response!r}")
+        except Exception as exc:  # noqa: BLE001 - report final connection failure.
+            last_error = exc
+        time.sleep(delay)
+    raise RuntimeError(f"Dakera healthcheck failed after {retries} attempts: {last_error}")
+
+
+def token_estimate(text: str) -> int:
+    return max(1, (len(text) + 3) // 4)
+
+
+def memory_fixture_id(memory: dict[str, Any]) -> str | None:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("fixture_id"), str):
+        return metadata["fixture_id"]
+    for key in ("fixture_id", "id", "memory_id"):
+        value = memory.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def reliability(memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        rel = metadata.get("reliability")
+        if isinstance(rel, dict):
+            return rel
+    return {}
+
+
+def classify_ccp(memory: dict[str, Any]) -> dict[str, Any]:
+    rel = reliability(memory)
+    t = float(rel.get("t", 0.0) or 0.0)
+    i = float(rel.get("i", 0.0) or 0.0)
+    f = float(rel.get("f", 0.0) or 0.0)
+
+    if f >= 0.50:
+        action = "surface_contradiction"
+        reason = "high falsity makes this packet contradiction evidence"
+    elif i >= 0.50:
+        action = "ask_clarification"
+        reason = "high indeterminacy means handoff reuse is unresolved"
+    elif t >= 0.70 and i <= 0.35 and f <= 0.35:
+        action = "continue_from_ccp"
+        reason = "high truth with low uncertainty and contradiction"
+    else:
+        action = "continue_with_caveat"
+        reason = "mixed reliability requires caveated continuity"
+
+    return {"action": action, "reason": reason, "t": t, "i": i, "f": f}
+
+
+def normalize_store_response(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict) and isinstance(response.get("memory"), dict):
+        return response["memory"]
+    if isinstance(response, dict):
+        return response
+    raise RuntimeError(f"unexpected store response: {response!r}")
+
+
+def normalize_memory_item(item: dict[str, Any]) -> dict[str, Any]:
+    nested = item.get("memory")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        for key in ("score", "weighted_score", "smart_score", "depth"):
+            if key in item:
+                merged[key] = item[key]
+        return merged
+    return item
+
+
+def normalize_memory_list(response: Any, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [normalize_memory_item(item) for item in response if isinstance(item, dict)]
+    if not isinstance(response, dict):
+        return []
+
+    for key in keys:
+        value = response.get(key)
+        if isinstance(value, list):
+            return [normalize_memory_item(item) for item in value if isinstance(item, dict)]
+
+    if "content" in response:
+        return [response]
+    return []
+
+
+def normalize_recall_response(response: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    memories = normalize_memory_list(response, ("memories", "results", "items", "data"))
+    associated = normalize_memory_list(response, ("associated_memories", "associated", "linked_memories"))
+    return memories, associated
+
+
+def choose_static_memory(scenario: dict[str, Any], fixture: dict[str, Any]) -> dict[str, Any] | None:
+    memories = {memory["id"]: memory for memory in fixture["memories"]}
+    expected = scenario.get("expected_memory")
+    if isinstance(expected, str):
+        return memories.get(expected)
+    return None
+
+
+def evaluate_static_scenario(scenario: dict[str, Any], fixture: dict[str, Any]) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    ccp_payload = "\n".join(
+        memory["content"]
+        for memory in fixture["memories"]
+        if memory["id"] in {"ccp-key-decision", "ccp-evidence", "ccp-caveat"}
+    )
+    full_tokens = token_estimate(full_transcript)
+    ccp_tokens = token_estimate(ccp_payload)
+
+    if scenario["id"] == "namespace-agent-isolation":
+        passed = scenario["expected_excluded_memory"] == "ccp-unrelated-agent-memory"
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": None,
+            "action": "isolate_agent_scope",
+            "reason": "unrelated control memory belongs to another agent scope",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "passed": passed,
+        }
+
+    if scenario["id"] == "token-economy":
+        memory = choose_static_memory(scenario, fixture)
+        passed = ccp_tokens < full_tokens and memory is not None
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": memory["id"] if memory else None,
+            "action": "ccp_payload_smaller" if ccp_tokens < full_tokens else "full_transcript_smaller",
+            "reason": "compact CCP packet is compared to the full transcript estimate",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "passed": passed,
+        }
+
+    memory = choose_static_memory(scenario, fixture)
+    decision = classify_ccp(memory) if memory is not None else {"action": "missing_memory", "reason": "not found"}
+    return {
+        "scenario": scenario["id"],
+        "selected_memory": memory["id"] if memory else None,
+        "action": decision["action"],
+        "reason": decision["reason"],
+        "full_transcript_tokens": full_tokens,
+        "ccp_payload_tokens": ccp_tokens,
+        "token_savings": full_tokens - ccp_tokens,
+        "passed": memory is not None
+        and memory["id"] == scenario.get("expected_memory")
+        and decision["action"] == scenario["expected_action"],
+    }
+
+
+def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    return [evaluate_static_scenario(scenario, fixture) for scenario in fixture["scenarios"]]
+
+
+def start_session(api_base: str, agent_id: str) -> str:
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/sessions/start",
+        {
+            "agent_id": agent_id,
+            "metadata": {
+                "phase": "phase5_dakera_ccp_handoff",
+                "source": "dakera_ccp_handoff_validator",
+            },
+        },
+    )
+    for key in ("session_id", "id"):
+        value = response.get(key) if isinstance(response, dict) else None
+        if isinstance(value, str):
+            return value
+    nested = response.get("session") if isinstance(response, dict) else None
+    if isinstance(nested, dict) and isinstance(nested.get("id"), str):
+        return nested["id"]
+    raise RuntimeError(f"session start did not return a session id: {response!r}")
+
+
+def end_session(api_base: str, session_id: str, summary: str) -> Any:
+    return request_json("POST", f"{api_base}/v1/sessions/{session_id}/end", {"summary": summary})
+
+
+def session_memories(api_base: str, session_id: str) -> list[dict[str, Any]]:
+    response = request_json("GET", f"{api_base}/v1/sessions/{session_id}/memories")
+    return normalize_memory_list(response, ("memories", "results", "items", "data"))
+
+
+def store_memory(api_base: str, agent_id: str, session_id: str | None, memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = copy.deepcopy(memory.get("metadata", {}))
+    if not isinstance(metadata, dict):
+        raise ValueError(f"memory {memory.get('id', '<unknown>')} metadata must be an object")
+    metadata["fixture_id"] = memory["id"]
+
+    payload: dict[str, Any] = {
+        "agent_id": agent_id,
+        "content": memory["content"],
+        "memory_type": "semantic",
+        "importance": memory.get("importance", 0.5),
+        "metadata": metadata,
+        "tags": memory.get("tags", []),
+    }
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    response = request_json("POST", f"{api_base}/v1/memory/store", payload)
+    stored = normalize_store_response(response)
+    stored["fixture_id"] = memory["id"]
+    return stored
+
+
+def link_memory(api_base: str, agent_id: str, memory_id: str, target_id: str) -> Any:
+    return request_json(
+        "POST",
+        f"{api_base}/v1/memories/{memory_id}/links",
+        {"agent_id": agent_id, "target_id": target_id},
+    )
+
+
+def recall(api_base: str, agent_id: str, query: str, top_k: int = 8, associated: bool = False) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    payload: dict[str, Any] = {"agent_id": agent_id, "query": query, "top_k": top_k}
+    if associated:
+        payload["include_associated"] = True
+        payload["associated_memories_depth"] = 1
+    response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    return normalize_recall_response(response)
+
+
+def enrich_recalled(recalled: list[dict[str, Any]], stored_by_id: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    runtime_to_fixture = {
+        stored["id"]: fixture_id
+        for fixture_id, stored in stored_by_id.items()
+        if isinstance(stored.get("id"), str)
+    }
+    enriched = []
+    for item in recalled:
+        memory = copy.deepcopy(item)
+        fixture_id = memory_fixture_id(memory)
+        if fixture_id is None:
+            fixture_id = runtime_to_fixture.get(memory.get("id"))
+        if fixture_id is not None:
+            memory["fixture_id"] = fixture_id
+        enriched.append(memory)
+    return enriched
+
+
+def find_by_fixture_id(memories: list[dict[str, Any]], fixture_id: str) -> dict[str, Any] | None:
+    return next((memory for memory in memories if memory.get("fixture_id") == fixture_id), None)
+
+
+def evaluate_runtime_scenario(
+    api_base: str,
+    agent_id: str,
+    scenario: dict[str, Any],
+    fixture: dict[str, Any],
+    stored_by_id: dict[str, dict[str, Any]],
+    session_ids: set[str],
+) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    memories, associated = recall(
+        api_base,
+        agent_id,
+        scenario["query"],
+        top_k=8,
+        associated=scenario["id"] in {"nuanced-decision", "basic-handoff"},
+    )
+    enriched = enrich_recalled(memories, stored_by_id)
+    associated_enriched = enrich_recalled(associated, stored_by_id)
+    recalled_fixture_ids = {memory.get("fixture_id") for memory in enriched}
+    associated_fixture_ids = {memory.get("fixture_id") for memory in associated_enriched}
+
+    full_tokens = token_estimate(full_transcript)
+    ccp_text = "\n".join(memory.get("content", "") for memory in enriched[:3])
+    ccp_tokens = token_estimate(ccp_text)
+
+    if scenario["id"] == "namespace-agent-isolation":
+        excluded = scenario["expected_excluded_memory"]
+        passed = excluded not in recalled_fixture_ids
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": None,
+            "recalled_fixture_ids": sorted(item for item in recalled_fixture_ids if isinstance(item, str)),
+            "associated_fixture_ids": sorted(item for item in associated_fixture_ids if isinstance(item, str)),
+            "action": "isolate_agent_scope" if passed else "agent_scope_polluted",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "session_memory_proof": bool(session_ids),
+            "associated_recall_proof": True,
+            "passed": passed,
+        }
+
+    expected = scenario.get("expected_memory")
+    selected = find_by_fixture_id(enriched, expected) if isinstance(expected, str) else None
+    if selected is None and isinstance(expected, str) and expected in associated_fixture_ids:
+        selected = find_by_fixture_id(associated_enriched, expected)
+    decision = classify_ccp(selected) if selected is not None else {"action": "missing_memory", "reason": "not found"}
+
+    associated_ok = True
+    recall_ok = not isinstance(expected, str) or expected in recalled_fixture_ids
+    if scenario["id"] == "basic-handoff":
+        associated_ok = {"ccp-evidence", "ccp-caveat"}.issubset(associated_fixture_ids)
+    if scenario["id"] == "nuanced-decision":
+        recall_ok = isinstance(expected, str) and expected in recalled_fixture_ids.union(associated_fixture_ids)
+        associated_ok = "ccp-caveat" in recalled_fixture_ids.union(associated_fixture_ids) and (
+            "ccp-evidence" in associated_fixture_ids or "ccp-key-decision" in associated_fixture_ids
+        )
+
+    if scenario["id"] == "token-economy":
+        action = "ccp_payload_smaller" if ccp_tokens < full_tokens else "full_transcript_smaller"
+        passed = selected is not None and recall_ok and ccp_tokens < full_tokens
+    else:
+        action = decision["action"]
+        passed = (
+            selected is not None
+            and action == scenario["expected_action"]
+            and recall_ok
+            and associated_ok
+        )
+
+    return {
+        "scenario": scenario["id"],
+        "selected_memory": selected.get("id") if selected else None,
+        "selected_fixture_id": selected.get("fixture_id") if selected else None,
+        "recalled_fixture_ids": sorted(item for item in recalled_fixture_ids if isinstance(item, str)),
+        "associated_fixture_ids": sorted(item for item in associated_fixture_ids if isinstance(item, str)),
+        "action": action,
+        "reason": decision.get("reason", "token economy comparison"),
+        "full_transcript_tokens": full_tokens,
+        "ccp_payload_tokens": ccp_tokens,
+        "token_savings": full_tokens - ccp_tokens,
+        "session_memory_proof": bool(session_ids),
+        "associated_recall_proof": associated_ok,
+        "passed": passed,
+    }
+
+
+def run_runtime_validation(api_base: str, fixture: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    health = healthcheck(api_base)
+    session_id = start_session(api_base, agent_id)
+    stored_by_id: dict[str, dict[str, Any]] = {}
+    try:
+        agent_a_memories = [memory for memory in fixture["memories"] if memory["id"] != "ccp-unrelated-agent-memory"]
+        unrelated = next(memory for memory in fixture["memories"] if memory["id"] == "ccp-unrelated-agent-memory")
+
+        for memory in agent_a_memories:
+            stored_by_id[memory["id"]] = store_memory(api_base, agent_id, session_id, memory)
+
+        unrelated_agent_id = f"{agent_id}-unrelated"
+        stored_by_id[unrelated["id"]] = store_memory(api_base, unrelated_agent_id, None, unrelated)
+
+        for target_fixture_id in ("ccp-evidence", "ccp-caveat"):
+            link_memory(
+                api_base,
+                agent_id,
+                stored_by_id["ccp-key-decision"]["id"],
+                stored_by_id[target_fixture_id]["id"],
+            )
+
+        session_ids = {
+            item.get("id")
+            for item in session_memories(api_base, session_id)
+            if isinstance(item.get("id"), str)
+        }
+
+        scenarios = [
+            evaluate_runtime_scenario(api_base, agent_id, scenario, fixture, stored_by_id, session_ids)
+            for scenario in fixture["scenarios"]
+        ]
+        return {
+            "agent_id": agent_id,
+            "session_id": session_id,
+            "health": health,
+            "stored_fixture_ids": sorted(stored_by_id),
+            "session_memory_ids": sorted(session_ids),
+            "scenarios": scenarios,
+        }
+    finally:
+        try:
+            end_session(api_base, session_id, "Phase 5 Dakera CCP handoff validation completed.")
+        except Exception:
+            pass
+
+
+def print_report(results: list[dict[str, Any]]) -> None:
+    print("scenario,action,selected_fixture_id,token_savings,passed")
+    for result in results:
+        print(
+            ",".join(
+                [
+                    result["scenario"],
+                    result["action"],
+                    str(result.get("selected_fixture_id") or result.get("selected_memory")),
+                    str(result["token_savings"]),
+                    str(result["passed"]).lower(),
+                ]
+            )
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Dakera CCP handoff behavior.")
+    parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to CCP scenario fixture JSON.")
+    parser.add_argument("--agent-id", help="Agent ID for runtime validation. Defaults to a unique fixture-derived ID.")
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="HTTP request timeout in seconds.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
+    args = parser.parse_args()
+
+    global REQUEST_TIMEOUT
+    REQUEST_TIMEOUT = args.request_timeout
+
+    fixture = load_fixture(args.fixture)
+    if args.self_test:
+        results = run_self_test(fixture)
+        print_report(results)
+        return 0 if all(result["passed"] for result in results) else 1
+
+    agent_id = args.agent_id or f"{fixture['agent_id']}-{int(time.time())}"
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, agent_id)
+    print(json.dumps(runtime, indent=2, sort_keys=True))
+    return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/tif-graph-reliability/README.md
+++ b/examples/tif-graph-reliability/README.md
@@ -1,0 +1,285 @@
+# T-I-F Graph Reliability Handoff
+
+This note is a Phase 4 handoff for the Dakera T-I-F decision provenance RFC:
+
+https://github.com/Dakera-AI/dakera-deploy/issues/161
+
+It is intentionally documentation-only. It does not request an engine rewrite,
+SDK schema change, recall filter, or new server endpoint.
+
+The goal is to leave a compact build path for a future graph-reliability
+validation package.
+
+## Core Question
+
+Phase 1 and Phase 2 asked:
+
+```text
+Should this recalled memory be reused?
+```
+
+Phase 4 asks:
+
+```text
+Should this association path be trusted?
+```
+
+Dakera already has graph primitives where reliability can be evaluated at more
+than one layer:
+
+| Layer | Dakera surface | Reliability question |
+|---|---|---|
+| Memory node | `metadata.reliability` | Is this memory reliable before reuse? |
+| Graph edge | edge type and edge weight | Is this association reliable? |
+| Traversal path | graph path / associated recall | Is this multi-hop path trustworthy? |
+| Neighborhood | associated memories | Does nearby context confirm, weaken, or contradict the primary result? |
+
+## Dakera Surfaces To Inspect
+
+The most relevant existing surfaces are:
+
+- `dakera_recall_associated`
+- `include_associated=true`
+- `associated_memories_depth`
+- `associated_memories_min_weight`
+- `dakera_graph_traverse`
+- `dakera_graph_path`
+- `dakera_graph_link_memory`
+- `dakera_graph_export`
+- `dakera_knowledge_graph`
+- cross-agent knowledge network support
+
+The useful edge concepts are:
+
+- `related_to`
+- `shares_entity`
+- `precedes`
+- `linked_by`
+- edge `weight`
+- traversal `depth`
+
+## Suggested Build Order
+
+### 1. Keep Node Reliability Stable
+
+Do not change the Phase 3 T-I-F v1 contract.
+
+Use existing memory-level reliability:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "truth": 0.75,
+      "indeterminacy": 0.10,
+      "falsity": 0.15,
+      "classification": "confident_reuse",
+      "feedback_count": 12
+    }
+  }
+}
+```
+
+Node reliability answers whether one memory is safe to reuse.
+
+### 2. Derive Edge Reliability Agent-Side
+
+Do not add engine behavior first. Start with a validation script that derives
+edge reliability from existing graph output:
+
+```text
+edge type
+edge weight
+explicit link versus inferred similarity
+source node reliability
+target node reliability
+session evidence
+feedback history
+```
+
+First-pass rule:
+
+```text
+explicit linked_by edge:
+  truth += 0.15
+
+related_to edge:
+  truth += edge.weight
+  indeterminacy += 1.0 - edge.weight
+
+shares_entity edge:
+  truth += 0.55
+  indeterminacy += 0.30
+
+precedes edge:
+  truth += 0.50
+  indeterminacy += 0.35
+
+if source or target node falsity >= 0.50:
+  edge falsity = max(edge falsity, 0.50)
+```
+
+Clamp values to `[0.0, 1.0]`.
+
+### 3. Derive Path Reliability
+
+For a path:
+
+```text
+A -> B -> C
+```
+
+start conservatively:
+
+```text
+path.truth = min(all node truth, all edge truth)
+path.indeterminacy = max(all node indeterminacy, all edge indeterminacy, hop penalty)
+path.falsity = max(all node falsity, all edge falsity)
+```
+
+Example hop penalty:
+
+```text
+0 hops -> 0.00
+1 hop  -> 0.05
+2 hops -> 0.12
+3 hops -> 0.20
+```
+
+This makes the path no more reliable than its weakest required support.
+
+### 4. Preserve Contradiction Evidence
+
+High-falsity memories should remain visible as diagnostic graph evidence.
+
+Do not silently delete or hide them.
+
+Expected behavior:
+
+```text
+primary memory: reusable
+associated memory: high falsity
+agent result: reuse with surfaced contradiction evidence, or verify_before_use
+```
+
+## Validation Scenarios
+
+### Reliable Node, Weak Edge
+
+Goal:
+
+Show that a reliable memory should not be reused confidently when the
+association that brought it into context is weak.
+
+Expected result:
+
+```text
+node-only action: confident_reuse
+graph-aware action: verify_before_use
+```
+
+### Contradiction Neighbor
+
+Goal:
+
+Show that associated recall can surface a contradicted memory as evidence.
+
+Expected result:
+
+```text
+primary action: reuse current memory
+graph diagnostic: surface outdated memory as contradiction evidence
+```
+
+### Multi-Hop Uncertainty
+
+Goal:
+
+Show that useful memories reached through uncertain intermediate nodes should
+carry caveats.
+
+Expected result:
+
+```text
+node-only action: reuse
+graph-aware action: ask_clarification or verify_before_use
+```
+
+### Cross-Agent Similarity Caveat
+
+Goal:
+
+Show that cross-agent network links should be treated more cautiously than
+same-agent explicit links unless reinforced by feedback or session evidence.
+
+Expected result:
+
+```text
+cross-agent association: reuse_with_caveat
+```
+
+## NSS Reading Path
+
+These sources are the recommended mathematical reading order for continuing the
+graph track.
+
+1. Start with connection-level cognitive maps:
+
+   https://fs.unm.edu/NSS/ANewNeutrosophicCognitiveMap-NSS.22.pdf
+
+   This is the closest source for Dakera because it treats relations and
+   connections as neutrosophic objects. That maps well to memory associations
+   and edge reliability.
+
+2. Then read the general graph foundation:
+
+   https://fs.unm.edu/NSS/NeutrosophicGraphs22.pdf
+
+   This gives the broader graph frame where vertices and edges can carry truth,
+   indeterminacy, and falsity.
+
+3. Then inspect structural graph measures:
+
+   https://fs.unm.edu/NSS/IntroductionToTopological4.pdf
+
+   This is useful for path, degree, connectivity, and traversal reliability.
+
+4. Finally, use this as a practical cognitive-map example:
+
+   https://fs.unm.edu/NSS/27CognitiveMaps.pdf
+
+   This helps keep the graph direction practical: identify concepts, model
+   relations, compare consensus, disagreement, and indeterminacy.
+
+## Non-Goals
+
+This handoff does not propose:
+
+- engine changes;
+- SDK schema changes;
+- recall filters;
+- new MCP tools;
+- graph database migration;
+- quaternion, Euler, or Riemann implementation;
+- deletion or filtering of contradiction memories.
+
+## Suggested Future Artifact
+
+If this track continues later, the smallest useful package would be:
+
+```text
+examples/tif-graph-reliability/
+  validate_tif_graph_reliability.py
+  phase4_graph_scenarios.json
+  README.md
+  VALIDATION_RESULTS.md
+```
+
+The validator should score node, edge, path, and neighborhood reliability
+outside the engine, then report whether graph-aware decisions differ from
+node-only decisions.
+
+## Boundary
+
+This is a handoff. It is designed so maintainers can continue independently
+from the source links and build path above.


### PR DESCRIPTION
## Linked Issue

Refs #172

## Summary

This PR adds a local examples-only validator for testing Dakera as a Context Continuity Package runtime for multi-agent handoffs.

The example uses a hybrid swarm framing: bee/queen control for orchestration policy and full-audit fallback, plus ant-style traces for compact continuity through Dakera memory.

No engine, SDK, MCP, graph, or default recall behavior is changed.

## Scope

Adds `examples/dakera-ccp-handoff/` with a CCP handoff fixture, stdlib-only validator, local proof tests, bee-vs-ant benchmark, and validation report.

## Validation

```powershell
python -m py_compile examples\dakera-ccp-handoff\validate_dakera_ccp_handoff.py examples\dakera-ccp-handoff\test_ccp_handoff_examples.py examples\dakera-ccp-handoff\benchmark_swarm_assembly.py
python examples\dakera-ccp-handoff\validate_dakera_ccp_handoff.py --self-test
python examples\dakera-ccp-handoff\test_ccp_handoff_examples.py
python examples\dakera-ccp-handoff\benchmark_swarm_assembly.py
docker compose -f docker\docker-compose.tif-phase1.yml up -d
python examples\dakera-ccp-handoff\validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
```

Result:

```text
local checks: pass
runtime validation: mixed, 4/6 scenarios passed
```

## Known Limitation

Direct recall works, but associated graph recall is not proven yet. The failing associated-recall scenarios are documented in `VALIDATION_RESULTS.md`.

## Reviewer Notes

This is intentionally conservative: examples/docs only, no runtime behavior change, no new dependency, no claim that ant assembly always wins, and no claim that this is the first ant-swarm agent system.