### PR TITLE
restore: revert the revert — restore all SeCuReDmE-main-dev contributions (DAK-6663)

### DIFF
--- a/docker/docker-compose.tif-phase1.yml
+++ b/docker/docker-compose.tif-phase1.yml
@@ -1,0 +1,19 @@
+services:
+  dakera:
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.90}
+    ports:
+      - "127.0.0.1:3200:3000"
+      - "127.0.0.1:51051:50051"
+    environment:
+      - RUST_LOG=info
+      - DAKERA_HOST=0.0.0.0
+      - DAKERA_PORT=3000
+      - DAKERA_GRPC_PORT=50051
+      - DAKERA_STORAGE=memory
+      - DAKERA_AUTH_ENABLED=false
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped

--- a/examples/dakera-ccp-handoff/README.md
+++ b/examples/dakera-ccp-handoff/README.md
@@ -1,0 +1,183 @@
+# Phase 5 Dakera CCP Handoff Validator
+
+This local example validates Dakera as a Context Continuity Package runtime for
+multi-agent handoffs.
+
+Most swarm examples reach for a bee/queen metaphor. This validator uses a more
+useful ant swarm assembly principle: agents do not wait for a central queen to
+carry the whole state. They leave compact, typed traces in the environment, and
+the next agent reassembles the working context from those traces.
+
+It follows the CCP problem described in the OpenAI Swarm thread:
+
+https://github.com/openai/swarm/issues/87#issuecomment-4701636167
+
+The goal is not to invent a new continuity backend. The goal is to prove that
+Dakera already provides the useful CCP primitives:
+
+```text
+Agent A stores compact decisions/findings
+Dakera persists, indexes, links, and recalls them
+Agent B retrieves relevant context without receiving the full transcript
+```
+
+In this framing, Dakera is the trace field. CCP packets are the ant-style
+stigmergic traces. Session, recall, metadata, decay, and graph links are the
+assembly surface that lets another agent continue without a transcript dump.
+
+## What This Tests
+
+The example uses Dakera's public REST API only:
+
+- `POST /v1/sessions/start`
+- `POST /v1/sessions/{session_id}/end`
+- `GET /v1/sessions/{session_id}/memories`
+- `POST /v1/memory/store`
+- `POST /v1/memory/recall`
+- `POST /v1/memories/{memory_id}/links`
+
+It stays agent-side. Dakera stores and recalls continuity packets; the local
+validator decides whether Agent B should continue, ask clarification, surface
+contradiction, or reject unrelated agent context.
+
+## CCP Packet Shape
+
+Continuity packet metadata is stored under `metadata.ccp` and reliability under
+the existing `metadata.reliability` pattern:
+
+```json
+{
+  "metadata": {
+    "ccp": {
+      "version": "ccp-v0",
+      "handoff_id": "phase5-agent-a-to-agent-b",
+      "source_agent": "agent-a",
+      "target_agent": "agent-b",
+      "packet_role": "decision"
+    },
+    "reliability": {
+      "t": 0.86,
+      "i": 0.10,
+      "f": 0.04
+    }
+  }
+}
+```
+
+Decision priority:
+
+```text
+f >= 0.50 -> surface_contradiction
+i >= 0.50 -> ask_clarification
+t >= 0.70 and i <= 0.35 and f <= 0.35 -> continue_from_ccp
+otherwise -> continue_with_caveat
+```
+
+These rules are validation rules only. They are not proposed as Dakera engine
+behavior.
+
+## Scenarios
+
+| Scenario | Purpose |
+|---|---|
+| `basic-handoff` | Agent B recalls Agent A's key decision |
+| `nuanced-decision` | Agent B preserves the caveat attached to the handoff |
+| `stale-context` | timestamp-only CCP is treated as contradicted |
+| `contradiction` | high-falsity context is surfaced, not hidden |
+| `namespace-agent-isolation` | unrelated agent memory does not pollute Agent B recall |
+| `token-economy` | CCP payload is smaller than full transcript transfer |
+
+## Start Dakera
+
+The existing T-I-F validation compose file runs Dakera on port `3200`, binds to
+`127.0.0.1`, and disables auth only for local validation. Do not run it on a
+shared or internet-facing host.
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+```
+
+Stop:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Run Self-Test
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test
+```
+
+## Run Five Proof Examples
+
+These executable examples prove the local CCP claim before touching a Dakera
+runtime:
+
+```bash
+python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+```
+
+They cover:
+
+- ant swarm assembly framing instead of bee/queen control;
+- basic Agent A to Agent B handoff;
+- uncertainty/caveat preservation;
+- contradicted stale context surfacing;
+- agent isolation plus token economy.
+
+## Benchmark Bee vs Ant Assembly
+
+The benchmark compares two explicit models and one practical hybrid:
+
+- Bee assembly: a queen/master relay sends or curates the full transcript/state.
+- Ant assembly: agents leave compact CCP traces in Dakera and the next agent
+  assembles context from recall, metadata, sessions, and links.
+- Hybrid assembly: bee/queen controls routing policy, escalation, and full-audit
+  fallback; ant assembly handles the low-token trace field.
+
+```bash
+python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+```
+
+The benchmark is intentionally honest: bee assembly wins small-context and full
+audit cases in the local model. Ant assembly wins long handoff, uncertainty,
+isolation, and token-economy cases. The recommended shape is not "all bees" or
+"all ants"; it is bee control over ant trace assembly.
+
+In token terms, bee dancing is volatile intercommunication: every coordination
+step can spend fresh tokens. Ant trace assembly is cheaper when it works because
+the pheromone-like trace is persisted in Dakera and only recalled when relevant.
+
+Token economy is tested at four levels:
+
+- compact content payload: only the recalled CCP content Agent B needs;
+- full JSON packet payload: content plus metadata, which can erase savings on
+  short transcripts;
+- top-k overfetch payload: a failure mode where recall returns too much context;
+- JSON break-even: the minimum transcript size where full JSON CCP becomes
+  cheaper than sending the transcript.
+
+## Run Runtime Validation
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+```
+
+The runtime validator fails if the expected memory is not recalled, session
+memory proof is missing, associated recall does not return linked evidence, or
+the CCP payload is not smaller than the full transcript estimate.
+
+## Boundary
+
+This Phase 5 package does not change:
+
+- Dakera engine behavior;
+- SDK schemas;
+- MCP tool definitions;
+- recall ranking;
+- graph internals.
+
+The fractal / pheromone routing idea should only be revisited after this CCP
+baseline passes locally. If it returns, it should be treated as an ant-colony
+trace-scoring layer over Dakera recall, not as a replacement memory backend.

--- a/examples/dakera-ccp-handoff/VALIDATION_RESULTS.md
+++ b/examples/dakera-ccp-handoff/VALIDATION_RESULTS.md
@@ -1,0 +1,222 @@
+# Phase 5 Dakera CCP Handoff Validation Results
+
+Date: 2026-06-14
+
+Status: local proof and benchmark pass. Runtime validation partially fails:
+direct recall, session proof, isolation, contradiction handling, and compact
+token economy pass, but associated graph recall is not proven by the current
+REST response.
+
+Framing note: this Phase 5 package uses a hybrid swarm model. The bee/queen
+layer controls orchestration policy, escalation, and full-audit fallback. The
+ant layer handles distributed trace assembly: Agent A leaves compact continuity
+traces in Dakera, and Agent B reassembles the needed context from recall,
+metadata, sessions, and links.
+
+## Target Runtime
+
+```text
+Dakera image: ghcr.io/dakera-ai/dakera:0.11.90 or newer
+REST: http://127.0.0.1:3200
+Storage: in-memory
+Auth: disabled for local validation only
+```
+
+## Commands
+
+Self-test:
+
+```bash
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test
+```
+
+Five proof examples:
+
+```bash
+python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+```
+
+Bee vs ant assembly benchmark:
+
+```bash
+python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+```
+
+Runtime validation:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Acceptance Criteria
+
+- Agent A session stores compact CCP memories.
+- Agent B recalls the expected CCP packet by semantic query.
+- Agent B does not receive the full transcript.
+- linked evidence/caveat packets are returned through associated recall.
+- session memory listing includes the continuity packets.
+- unrelated agent memory does not pollute Agent B recall.
+- high falsity surfaces contradiction.
+- high indeterminacy asks clarification.
+- CCP payload estimate is smaller than full transcript estimate.
+- no engine, SDK, MCP, or ranking behavior is changed.
+
+## Result Summary
+
+## Fresh Run Verdict
+
+Local result: good for static proof, examples, and benchmark.
+
+Runtime result: mixed. Dakera `0.11.90` is healthy and direct recall works, but
+the current runtime did not return linked memories under the normalized
+associated-recall fields.
+
+Command status:
+
+| Command | Result |
+|---|---|
+| `python -m py_compile examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py examples/dakera-ccp-handoff/test_ccp_handoff_examples.py examples/dakera-ccp-handoff/benchmark_swarm_assembly.py` | pass |
+| `python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --self-test` | pass |
+| `python examples/dakera-ccp-handoff/test_ccp_handoff_examples.py` | pass |
+| `python examples/dakera-ccp-handoff/benchmark_swarm_assembly.py` | pass |
+| `docker version` | pass: Docker Desktop 4.77.0 / engine 29.5.3 |
+| `http://localhost:3200/health/ready` | pass: ready true, Dakera 0.11.90 |
+| `python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240` | fail: 4/6 scenarios passed |
+
+Self-test:
+
+| Scenario | Action | Selected Fixture | Token Savings | Passed |
+|---|---|---|---:|---|
+| `basic-handoff` | `continue_from_ccp` | `ccp-key-decision` | 133 | true |
+| `nuanced-decision` | `ask_clarification` | `ccp-caveat` | 133 | true |
+| `stale-context` | `surface_contradiction` | `ccp-stale-timestamp-only` | 133 | true |
+| `contradiction` | `surface_contradiction` | `ccp-stale-timestamp-only` | 133 | true |
+| `namespace-agent-isolation` | `isolate_agent_scope` | none | 133 | true |
+| `token-economy` | `ccp_payload_smaller` | `ccp-key-decision` | 133 | true |
+
+Five proof examples plus honesty guard:
+
+```text
+Ran 6 tests in 0.002s
+OK
+```
+
+The proof examples cover five requested points plus one honesty guard:
+
+- ant swarm assembly framing is explicit;
+- Agent A to Agent B handoff continues from a CCP packet;
+- uncertainty is preserved before reuse;
+- contradicted stale context is surfaced;
+- agent scope and token economy hold for compact packets;
+- bee wins are reported honestly in the benchmark.
+
+Bee vs ant assembly benchmark:
+
+| Case | Bee | Ant | Winner |
+|---|---:|---:|---|
+| `tiny_single_turn_context` | 0.90 | 0.62 | `bee` |
+| `multi_agent_long_handoff` | 0.55 | 1.00 | `ant` |
+| `uncertainty_and_contradiction` | 0.55 | 0.88 | `ant` |
+| `agent_scope_isolation` | 0.58 | 0.86 | `ant` |
+| `full_audit_reconstruction` | 0.92 | 0.70 | `bee` |
+
+Viability decision: `hybrid_bee_control_ant_trace_assembly`.
+
+This is not a clean "ant always wins" result. Bee assembly wins two modeled
+cases:
+
+- `tiny_single_turn_context`: bee wins because a tiny transcript is simpler than
+  building and recalling traces.
+- `full_audit_reconstruction`: bee wins because the full transcript is the most
+  complete audit artifact.
+
+Token economy subtests:
+
+| Token Test | Bee Tokens | Ant Tokens | Delta | Winner |
+|---|---:|---:|---:|---|
+| `compact_content_payload` | 293 | 160 | 133 | `ant` |
+| `full_json_packet_payload` | 293 | 498 | -205 | `bee` |
+| `top_k_overfetch_payload` | 293 | 778 | -485 | `bee` |
+| `json_break_even` | 499 | 498 | 1 | `ant` |
+
+Conclusion: hybrid assembly is the viable shape. Bee/queen control decides when
+to use compact ant traces and when to fall back to full transcript/session audit.
+Ant assembly is viable for compact CCP handoff, but not as a blind "ship all
+memory JSON" strategy. The implementation should keep Agent B's prompt payload
+compact and use full session/transcript expansion only for audit or short-context
+cases where bee assembly wins.
+
+Token economy is not good if the system sends too much:
+
+- full JSON packets lose by 205 estimated tokens in this fixture;
+- top-k overfetch loses by 485 estimated tokens in this fixture;
+- full JSON CCP only becomes cheaper after the transcript exceeds 498 estimated
+  tokens.
+
+## Runtime Validation
+
+Runtime health:
+
+```text
+ready=true
+version=0.11.90
+storage=ok
+embedding_engine=ok
+tiered_engine=disabled
+```
+
+Runtime scenario result:
+
+| Scenario | Runtime Action | Direct Recall | Associated Proof | Passed |
+|---|---|---|---|---|
+| `basic-handoff` | `continue_from_ccp` | yes | no | false |
+| `nuanced-decision` | `ask_clarification` | yes | no | false |
+| `stale-context` | `surface_contradiction` | yes | n/a | true |
+| `contradiction` | `surface_contradiction` | yes | n/a | true |
+| `namespace-agent-isolation` | `isolate_agent_scope` | yes | n/a | true |
+| `token-economy` | `ccp_payload_smaller` | yes | n/a | true |
+
+What is good:
+
+- The runtime accepted all CCP packet stores.
+- `metadata.fixture_id`, `metadata.ccp`, and `metadata.reliability` survived
+  recall.
+- Semantic recall found the expected decision/caveat/stale packets.
+- The unrelated agent memory did not pollute recall.
+- Compact runtime CCP payload remained smaller than full transcript estimate.
+
+What is not good:
+
+- `include_associated=true` with `associated_memories_depth=1` did not populate
+  `associated_memories`, `associated`, or `linked_memories` in the normalized
+  response.
+- Because of that, the validator cannot yet prove linked evidence/caveat recall
+  through graph expansion.
+- The first runtime recall after cold start was slow in logs; later recall calls
+  were faster, but this should be tracked if benchmarking latency.
+
+Runtime validation command to rerun once Docker Desktop is running:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+python examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Novelty Scan
+
+Do not pitch this as the first ant-swarm agent system. External research already
+contains ant-colony, pheromone, and stigmergy approaches for multi-agent AI,
+including LLM routing and blackboard-style pheromone signals.
+
+Safer pitch:
+
+```text
+Phase 5 introduces a Dakera-specific CCP handoff validator for hybrid bee-control
+and ant-trace continuity: queen/bee orchestration decides policy and fallback,
+while Dakera stores low-token pheromone-like continuity traces for later agents.
+```
+
+This is a stronger and more defensible claim than "first ant swarm".

--- a/examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
+++ b/examples/dakera-ccp-handoff/benchmark_swarm_assembly.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Benchmark bee-style vs ant-style context assembly for Phase 5 CCP."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import validate_dakera_ccp_handoff as validator
+
+
+THIS_DIR = Path(__file__).resolve().parent
+FIXTURE = THIS_DIR / "ccp_handoff_scenarios.json"
+
+
+def ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def score_winner(bee_score: float, ant_score: float) -> str:
+    if bee_score > ant_score:
+        return "bee"
+    if ant_score > bee_score:
+        return "ant"
+    return "tie"
+
+
+def token_winner(full_tokens: int, candidate_tokens: int) -> str:
+    if full_tokens < candidate_tokens:
+        return "bee"
+    if candidate_tokens < full_tokens:
+        return "ant"
+    return "tie"
+
+
+def memory_json_tokens(memories: list[dict[str, Any]]) -> int:
+    return validator.token_estimate(json.dumps(memories, sort_keys=True, separators=(",", ":")))
+
+
+def build_benchmark(fixture: dict[str, Any]) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    ccp_memories = [
+        memory
+        for memory in fixture["memories"]
+        if memory["id"] in {"ccp-key-decision", "ccp-evidence", "ccp-caveat"}
+    ]
+    ccp_payload = "\n".join(memory["content"] for memory in ccp_memories)
+    full_tokens = validator.token_estimate(full_transcript)
+    ant_tokens = validator.token_estimate(ccp_payload)
+    ant_json_tokens = memory_json_tokens(ccp_memories)
+    top_k_overfetch_tokens = memory_json_tokens(fixture["memories"])
+    token_savings = full_tokens - ant_tokens
+    token_savings_ratio = ratio(token_savings, full_tokens)
+    json_token_delta = full_tokens - ant_json_tokens
+    top_k_overfetch_delta = full_tokens - top_k_overfetch_tokens
+    break_even_transcript_tokens = ant_json_tokens + 1
+
+    benchmark_cases = [
+        {
+            "id": "tiny_single_turn_context",
+            "question": "When the whole context is tiny, is a queen-style bee relay simpler?",
+            "bee_score": 0.90,
+            "ant_score": 0.62,
+            "bee_rationale": "One short transcript transfer has minimal overhead and preserves everything.",
+            "ant_rationale": "Trace assembly adds metadata and recall ceremony that may not pay off.",
+        },
+        {
+            "id": "multi_agent_long_handoff",
+            "question": "When Agent B needs only key continuity from a larger run, which approach is cheaper?",
+            "bee_score": 1.0 - token_savings_ratio,
+            "ant_score": min(1.0, 0.55 + token_savings_ratio),
+            "bee_rationale": "The queen relay sends the full transcript to avoid missing details.",
+            "ant_rationale": f"Ant trace assembly avoids {token_savings} estimated tokens in this fixture.",
+        },
+        {
+            "id": "uncertainty_and_contradiction",
+            "question": "Which approach makes caveats and contradictions explicit before reuse?",
+            "bee_score": 0.55,
+            "ant_score": 0.88,
+            "bee_rationale": "Transcript relay can contain caveats, but they are unstructured and easy to miss.",
+            "ant_rationale": "T-I-F reliability metadata makes high indeterminacy and falsity actionable.",
+        },
+        {
+            "id": "agent_scope_isolation",
+            "question": "Which approach avoids unrelated agent memory polluting the handoff?",
+            "bee_score": 0.58,
+            "ant_score": 0.86,
+            "bee_rationale": "A central relay can manually filter, but scope is convention-based.",
+            "ant_rationale": "Agent-scoped recall makes the isolation boundary executable.",
+        },
+        {
+            "id": "full_audit_reconstruction",
+            "question": "When a reviewer needs every detail, which approach is more complete?",
+            "bee_score": 0.92,
+            "ant_score": 0.70,
+            "bee_rationale": "The full transcript is the most complete audit artifact.",
+            "ant_rationale": "Trace assembly is compact by design and may need session memory expansion.",
+        },
+    ]
+
+    for case in benchmark_cases:
+        case["winner"] = score_winner(case["bee_score"], case["ant_score"])
+
+    wins = {
+        "bee": sum(1 for case in benchmark_cases if case["winner"] == "bee"),
+        "ant": sum(1 for case in benchmark_cases if case["winner"] == "ant"),
+        "tie": sum(1 for case in benchmark_cases if case["winner"] == "tie"),
+    }
+    viability = "hybrid_bee_control_ant_trace_assembly" if wins["ant"] >= wins["bee"] else "bee_preferred_for_this_fixture"
+
+    return {
+        "benchmark": "phase5_bee_vs_ant_swarm_assembly",
+        "bee_definition": "central queen/master relay sends or curates the full transcript/state",
+        "ant_definition": "distributed trace assembly stores compact CCP packets in Dakera and recalls only relevant traces",
+        "hybrid_definition": "bee/queen controls routing policy and escalation; ant assembly leaves and follows compact Dakera traces",
+        "full_transcript_tokens": full_tokens,
+        "ant_ccp_payload_tokens": ant_tokens,
+        "ant_ccp_json_tokens": ant_json_tokens,
+        "top_k_overfetch_tokens": top_k_overfetch_tokens,
+        "token_savings": token_savings,
+        "token_savings_ratio": token_savings_ratio,
+        "token_economy_tests": [
+            {
+                "id": "compact_content_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": ant_tokens,
+                "delta": token_savings,
+                "winner": token_winner(full_tokens, ant_tokens),
+                "meaning": "Agent B receives only compact CCP content.",
+            },
+            {
+                "id": "full_json_packet_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": ant_json_tokens,
+                "delta": json_token_delta,
+                "winner": token_winner(full_tokens, ant_json_tokens),
+                "meaning": "Agent B receives full memory JSON including metadata.",
+            },
+            {
+                "id": "top_k_overfetch_payload",
+                "bee_tokens": full_tokens,
+                "ant_tokens": top_k_overfetch_tokens,
+                "delta": top_k_overfetch_delta,
+                "winner": token_winner(full_tokens, top_k_overfetch_tokens),
+                "meaning": "Recall returns all fixture memories instead of only the needed CCP packet.",
+            },
+            {
+                "id": "json_break_even",
+                "bee_tokens": break_even_transcript_tokens,
+                "ant_tokens": ant_json_tokens,
+                "delta": 1,
+                "winner": "ant",
+                "meaning": "Full JSON CCP becomes cheaper only when the transcript is longer than this threshold.",
+            },
+        ],
+        "winner_counts": wins,
+        "viability": viability,
+        "cases": benchmark_cases,
+    }
+
+
+def print_markdown(result: dict[str, Any]) -> None:
+    print("# Bee vs Ant Swarm Assembly Benchmark")
+    print()
+    print(f"Viability: `{result['viability']}`")
+    print()
+    print("| Case | Bee | Ant | Winner |")
+    print("|---|---:|---:|---|")
+    for case in result["cases"]:
+        print(f"| `{case['id']}` | {case['bee_score']:.2f} | {case['ant_score']:.2f} | `{case['winner']}` |")
+    print()
+    print(
+        f"Token estimate: full transcript `{result['full_transcript_tokens']}`, "
+        f"ant CCP payload `{result['ant_ccp_payload_tokens']}`, "
+        f"savings `{result['token_savings']}`."
+    )
+    print()
+    print("| Token Test | Bee Tokens | Ant Tokens | Delta | Winner |")
+    print("|---|---:|---:|---:|---|")
+    for item in result["token_economy_tests"]:
+        print(f"| `{item['id']}` | {item['bee_tokens']} | {item['ant_tokens']} | {item['delta']} | `{item['winner']}` |")
+
+
+def main() -> int:
+    fixture = validator.load_fixture(FIXTURE)
+    result = build_benchmark(fixture)
+    print_markdown(result)
+    print()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/dakera-ccp-handoff/ccp_handoff_scenarios.json
+++ b/examples/dakera-ccp-handoff/ccp_handoff_scenarios.json
@@ -1,0 +1,177 @@
+{
+  "agent_id": "dakera-ccp-phase5",
+  "source_thread": "https://github.com/openai/swarm/issues/87#issuecomment-4701636167",
+  "swarm_framing": "Most examples explain swarms with bees, but this validator treats Dakera CCP as an ant swarm assembly principle: agents leave compact typed traces in the environment and later agents reassemble context from those traces.",
+  "full_transcript": [
+    "Agent A receives a large multi-step debugging conversation about a Dakera integration.",
+    "The user asks Agent A to inspect the repo, identify the correct memory API, validate uncertainty handling, and prepare a handoff for Agent B.",
+    "Agent A verifies that continuity should live outside orchestration and inside the memory layer, using Dakera sessions, agent-scoped memory, semantic recall, metadata, and graph links.",
+    "Agent A reframes the swarm metaphor away from bee queen control and toward ant swarm assembly: compact traces are left in the environment and reassembled by the next worker.",
+    "Agent A finds that the correct store endpoint is POST /v1/memory/store and that Agent B should query the CCP packet rather than receive the whole transcript.",
+    "Agent A also records a caveat: if metadata.reliability has high indeterminacy or falsity, Agent B should ask for clarification or surface contradiction evidence before reuse.",
+    "Agent A notes one stale candidate: timestamp-only CCP validation is insufficient for long-running swarms because context keys age at different rates.",
+    "Agent A stores compact continuity memories and links evidence/caveat entries to the decision packet."
+  ],
+  "expected_agent_b_action": "continue_from_ccp",
+  "memories": [
+    {
+      "id": "ccp-key-decision",
+      "kind": "decision",
+      "content": "CCP handoff decision: use Dakera as the external context continuity layer. Agent A stores compact decisions and findings as ant-style assembly traces; Agent B recalls relevant CCP packets instead of receiving the full transcript.",
+      "importance": 0.95,
+      "tags": ["ccp-phase5", "ccp-decision", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "decision",
+          "decision": "continue_from_ccp",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.86,
+          "i": 0.10,
+          "f": 0.04,
+          "basis": "Swarm CCP comment plus Dakera memory/session surfaces",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-evidence",
+      "kind": "evidence",
+      "content": "CCP evidence: Dakera already provides persistent agent-scoped memory, semantic recall, sessions, memory importance, decay, graph links, and associated recall, which matches an ant swarm assembly pattern for context continuity handoff.",
+      "importance": 0.88,
+      "tags": ["ccp-phase5", "ccp-evidence", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "evidence",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.78,
+          "i": 0.16,
+          "f": 0.06,
+          "basis": "public Dakera deploy, MCP, CLI, and SDK surfaces",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-caveat",
+      "kind": "caveat",
+      "content": "CCP caveat: Agent B must not blindly reuse a packet when metadata.reliability has high indeterminacy or falsity; it should ask clarification or surface contradiction evidence.",
+      "importance": 0.84,
+      "tags": ["ccp-phase5", "ccp-caveat", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "caveat",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.52,
+          "i": 0.58,
+          "f": 0.10,
+          "basis": "uncertainty should be preserved at handoff",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-stale-timestamp-only",
+      "kind": "stale",
+      "content": "Stale CCP candidate: use only _ccp_version and _ccp_timestamp as the continuity validator for all context keys.",
+      "importance": 0.30,
+      "tags": ["ccp-phase5", "ccp-stale", "handoff"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "phase5-agent-a-to-agent-b",
+          "source_agent": "agent-a",
+          "target_agent": "agent-b",
+          "packet_role": "stale",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.22,
+          "i": 0.34,
+          "f": 0.66,
+          "basis": "timestamp-only CCP breaks down when many context keys age at different rates",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    },
+    {
+      "id": "ccp-unrelated-agent-memory",
+      "kind": "isolation",
+      "content": "Unrelated memory from another agent: use a custom JSON file as the only continuity backend for this Dakera handoff.",
+      "importance": 0.99,
+      "tags": ["ccp-phase5", "unrelated"],
+      "metadata": {
+        "ccp": {
+          "version": "ccp-v0",
+          "handoff_id": "unrelated-agent",
+          "source_agent": "agent-x",
+          "target_agent": "agent-y",
+          "packet_role": "unrelated",
+          "source": "dakera_ccp_handoff_validator"
+        },
+        "reliability": {
+          "t": 0.20,
+          "i": 0.20,
+          "f": 0.60,
+          "basis": "control memory for agent isolation",
+          "source": "phase5_ccp_seed"
+        }
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "basic-handoff",
+      "query": "How should Agent B continue the CCP handoff without receiving the full transcript?",
+      "expected_memory": "ccp-key-decision",
+      "expected_action": "continue_from_ccp"
+    },
+    {
+      "id": "nuanced-decision",
+      "query": "What caveat should Agent B preserve when continuing from a Dakera CCP packet?",
+      "expected_memory": "ccp-caveat",
+      "expected_action": "ask_clarification"
+    },
+    {
+      "id": "stale-context",
+      "query": "Should Agent B rely only on _ccp_timestamp and _ccp_version for long running continuity?",
+      "expected_memory": "ccp-stale-timestamp-only",
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "contradiction",
+      "query": "What should Agent B do when a continuity packet is contradicted by reliability metadata?",
+      "expected_memory": "ccp-stale-timestamp-only",
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "namespace-agent-isolation",
+      "query": "Should unrelated agent memory pollute Agent B CCP recall?",
+      "expected_excluded_memory": "ccp-unrelated-agent-memory",
+      "expected_action": "isolate_agent_scope"
+    },
+    {
+      "id": "token-economy",
+      "query": "Can Agent B continue from a compact CCP packet instead of a full transcript dump?",
+      "expected_memory": "ccp-key-decision",
+      "expected_action": "ccp_payload_smaller"
+    }
+  ]
+}

--- a/examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
+++ b/examples/dakera-ccp-handoff/test_ccp_handoff_examples.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Five local proof examples for the Dakera CCP handoff fixture."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import validate_dakera_ccp_handoff as validator  # noqa: E402
+import benchmark_swarm_assembly as benchmark  # noqa: E402
+
+
+class DakeraCcpHandoffExamples(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture = validator.load_fixture(THIS_DIR / "ccp_handoff_scenarios.json")
+        cls.results = {
+            result["scenario"]: result
+            for result in validator.run_self_test(cls.fixture)
+        }
+        cls.memories = {
+            memory["id"]: memory
+            for memory in cls.fixture["memories"]
+        }
+
+    def test_01_ant_trace_framing_is_explicit(self) -> None:
+        framing = self.fixture["swarm_framing"].lower()
+        decision = self.memories["ccp-key-decision"]["content"].lower()
+
+        self.assertIn("ant swarm assembly", framing)
+        self.assertIn("traces", framing)
+        self.assertIn("ant-style assembly traces", decision)
+
+    def test_02_basic_handoff_continues_from_ccp_packet(self) -> None:
+        result = self.results["basic-handoff"]
+        decision = self.memories["ccp-key-decision"]
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["action"], "continue_from_ccp")
+        self.assertEqual(result["selected_memory"], "ccp-key-decision")
+        self.assertEqual(decision["metadata"]["ccp"]["packet_role"], "decision")
+
+    def test_03_caveat_preserves_uncertainty_before_reuse(self) -> None:
+        result = self.results["nuanced-decision"]
+        caveat = self.memories["ccp-caveat"]
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["action"], "ask_clarification")
+        self.assertGreaterEqual(caveat["metadata"]["reliability"]["i"], 0.50)
+
+    def test_04_contradicted_stale_context_is_surfaced(self) -> None:
+        stale = self.results["stale-context"]
+        contradiction = self.results["contradiction"]
+        memory = self.memories["ccp-stale-timestamp-only"]
+
+        self.assertTrue(stale["passed"])
+        self.assertTrue(contradiction["passed"])
+        self.assertEqual(stale["action"], "surface_contradiction")
+        self.assertGreaterEqual(memory["metadata"]["reliability"]["f"], 0.50)
+
+    def test_05_agent_scope_and_token_economy_hold(self) -> None:
+        isolation = self.results["namespace-agent-isolation"]
+        economy = self.results["token-economy"]
+
+        self.assertTrue(isolation["passed"])
+        self.assertTrue(economy["passed"])
+        self.assertEqual(isolation["action"], "isolate_agent_scope")
+        self.assertEqual(economy["action"], "ccp_payload_smaller")
+        self.assertGreater(economy["token_savings"], 0)
+
+    def test_06_benchmark_reports_bee_wins_honestly(self) -> None:
+        result = benchmark.build_benchmark(self.fixture)
+        bee_wins = [case for case in result["cases"] if case["winner"] == "bee"]
+        ant_wins = [case for case in result["cases"] if case["winner"] == "ant"]
+        token_tests = {
+            item["id"]: item
+            for item in result["token_economy_tests"]
+        }
+
+        self.assertGreaterEqual(len(bee_wins), 1)
+        self.assertGreaterEqual(len(ant_wins), 1)
+        self.assertEqual(result["winner_counts"]["bee"], len(bee_wins))
+        self.assertEqual(result["winner_counts"]["ant"], len(ant_wins))
+        self.assertEqual(result["viability"], "hybrid_bee_control_ant_trace_assembly")
+        self.assertEqual(token_tests["compact_content_payload"]["winner"], "ant")
+        self.assertIn(token_tests["full_json_packet_payload"]["winner"], {"bee", "ant", "tie"})
+        self.assertIn(token_tests["top_k_overfetch_payload"]["winner"], {"bee", "ant", "tie"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py
+++ b/examples/dakera-ccp-handoff/validate_dakera_ccp_handoff.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Phase 5 CCP handoff validation for Dakera.
+
+This script uses only Python's standard library and Dakera's public REST API.
+It validates that Dakera can act as a Context Continuity Package runtime:
+Agent A stores compact continuity packets, Agent B recalls the relevant packet
+without receiving the full transcript, and caveats/contradictions remain visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API = "http://localhost:3200"
+DEFAULT_FIXTURE = Path(__file__).with_name("ccp_handoff_scenarios.json")
+DEFAULT_REQUEST_TIMEOUT = 120
+REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc}") from exc
+
+
+def healthcheck(api_base: str, retries: int = 120, delay: float = 2.0) -> Any:
+    last_error: Exception | None = None
+    for _ in range(retries):
+        try:
+            response = request_json("GET", f"{api_base}/health/ready")
+            if isinstance(response, dict) and response.get("ready") is True:
+                return response
+            last_error = RuntimeError(f"health endpoint is not ready: {response!r}")
+        except Exception as exc:  # noqa: BLE001 - report final connection failure.
+            last_error = exc
+        time.sleep(delay)
+    raise RuntimeError(f"Dakera healthcheck failed after {retries} attempts: {last_error}")
+
+
+def token_estimate(text: str) -> int:
+    return max(1, (len(text) + 3) // 4)
+
+
+def memory_fixture_id(memory: dict[str, Any]) -> str | None:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("fixture_id"), str):
+        return metadata["fixture_id"]
+    for key in ("fixture_id", "id", "memory_id"):
+        value = memory.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def reliability(memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        rel = metadata.get("reliability")
+        if isinstance(rel, dict):
+            return rel
+    return {}
+
+
+def classify_ccp(memory: dict[str, Any]) -> dict[str, Any]:
+    rel = reliability(memory)
+    t = float(rel.get("t", 0.0) or 0.0)
+    i = float(rel.get("i", 0.0) or 0.0)
+    f = float(rel.get("f", 0.0) or 0.0)
+
+    if f >= 0.50:
+        action = "surface_contradiction"
+        reason = "high falsity makes this packet contradiction evidence"
+    elif i >= 0.50:
+        action = "ask_clarification"
+        reason = "high indeterminacy means handoff reuse is unresolved"
+    elif t >= 0.70 and i <= 0.35 and f <= 0.35:
+        action = "continue_from_ccp"
+        reason = "high truth with low uncertainty and contradiction"
+    else:
+        action = "continue_with_caveat"
+        reason = "mixed reliability requires caveated continuity"
+
+    return {"action": action, "reason": reason, "t": t, "i": i, "f": f}
+
+
+def normalize_store_response(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict) and isinstance(response.get("memory"), dict):
+        return response["memory"]
+    if isinstance(response, dict):
+        return response
+    raise RuntimeError(f"unexpected store response: {response!r}")
+
+
+def normalize_memory_item(item: dict[str, Any]) -> dict[str, Any]:
+    nested = item.get("memory")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        for key in ("score", "weighted_score", "smart_score", "depth"):
+            if key in item:
+                merged[key] = item[key]
+        return merged
+    return item
+
+
+def normalize_memory_list(response: Any, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [normalize_memory_item(item) for item in response if isinstance(item, dict)]
+    if not isinstance(response, dict):
+        return []
+
+    for key in keys:
+        value = response.get(key)
+        if isinstance(value, list):
+            return [normalize_memory_item(item) for item in value if isinstance(item, dict)]
+
+    if "content" in response:
+        return [response]
+    return []
+
+
+def normalize_recall_response(response: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    memories = normalize_memory_list(response, ("memories", "results", "items", "data"))
+    associated = normalize_memory_list(response, ("associated_memories", "associated", "linked_memories"))
+    return memories, associated
+
+
+def choose_static_memory(scenario: dict[str, Any], fixture: dict[str, Any]) -> dict[str, Any] | None:
+    memories = {memory["id"]: memory for memory in fixture["memories"]}
+    expected = scenario.get("expected_memory")
+    if isinstance(expected, str):
+        return memories.get(expected)
+    return None
+
+
+def evaluate_static_scenario(scenario: dict[str, Any], fixture: dict[str, Any]) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    ccp_payload = "\n".join(
+        memory["content"]
+        for memory in fixture["memories"]
+        if memory["id"] in {"ccp-key-decision", "ccp-evidence", "ccp-caveat"}
+    )
+    full_tokens = token_estimate(full_transcript)
+    ccp_tokens = token_estimate(ccp_payload)
+
+    if scenario["id"] == "namespace-agent-isolation":
+        passed = scenario["expected_excluded_memory"] == "ccp-unrelated-agent-memory"
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": None,
+            "action": "isolate_agent_scope",
+            "reason": "unrelated control memory belongs to another agent scope",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "passed": passed,
+        }
+
+    if scenario["id"] == "token-economy":
+        memory = choose_static_memory(scenario, fixture)
+        passed = ccp_tokens < full_tokens and memory is not None
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": memory["id"] if memory else None,
+            "action": "ccp_payload_smaller" if ccp_tokens < full_tokens else "full_transcript_smaller",
+            "reason": "compact CCP packet is compared to the full transcript estimate",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "passed": passed,
+        }
+
+    memory = choose_static_memory(scenario, fixture)
+    decision = classify_ccp(memory) if memory is not None else {"action": "missing_memory", "reason": "not found"}
+    return {
+        "scenario": scenario["id"],
+        "selected_memory": memory["id"] if memory else None,
+        "action": decision["action"],
+        "reason": decision["reason"],
+        "full_transcript_tokens": full_tokens,
+        "ccp_payload_tokens": ccp_tokens,
+        "token_savings": full_tokens - ccp_tokens,
+        "passed": memory is not None
+        and memory["id"] == scenario.get("expected_memory")
+        and decision["action"] == scenario["expected_action"],
+    }
+
+
+def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    return [evaluate_static_scenario(scenario, fixture) for scenario in fixture["scenarios"]]
+
+
+def start_session(api_base: str, agent_id: str) -> str:
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/sessions/start",
+        {
+            "agent_id": agent_id,
+            "metadata": {
+                "phase": "phase5_dakera_ccp_handoff",
+                "source": "dakera_ccp_handoff_validator",
+            },
+        },
+    )
+    for key in ("session_id", "id"):
+        value = response.get(key) if isinstance(response, dict) else None
+        if isinstance(value, str):
+            return value
+    nested = response.get("session") if isinstance(response, dict) else None
+    if isinstance(nested, dict) and isinstance(nested.get("id"), str):
+        return nested["id"]
+    raise RuntimeError(f"session start did not return a session id: {response!r}")
+
+
+def end_session(api_base: str, session_id: str, summary: str) -> Any:
+    return request_json("POST", f"{api_base}/v1/sessions/{session_id}/end", {"summary": summary})
+
+
+def session_memories(api_base: str, session_id: str) -> list[dict[str, Any]]:
+    response = request_json("GET", f"{api_base}/v1/sessions/{session_id}/memories")
+    return normalize_memory_list(response, ("memories", "results", "items", "data"))
+
+
+def store_memory(api_base: str, agent_id: str, session_id: str | None, memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = copy.deepcopy(memory.get("metadata", {}))
+    if not isinstance(metadata, dict):
+        raise ValueError(f"memory {memory.get('id', '<unknown>')} metadata must be an object")
+    metadata["fixture_id"] = memory["id"]
+
+    payload: dict[str, Any] = {
+        "agent_id": agent_id,
+        "content": memory["content"],
+        "memory_type": "semantic",
+        "importance": memory.get("importance", 0.5),
+        "metadata": metadata,
+        "tags": memory.get("tags", []),
+    }
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    response = request_json("POST", f"{api_base}/v1/memory/store", payload)
+    stored = normalize_store_response(response)
+    stored["fixture_id"] = memory["id"]
+    return stored
+
+
+def link_memory(api_base: str, agent_id: str, memory_id: str, target_id: str) -> Any:
+    return request_json(
+        "POST",
+        f"{api_base}/v1/memories/{memory_id}/links",
+        {"agent_id": agent_id, "target_id": target_id},
+    )
+
+
+def recall(api_base: str, agent_id: str, query: str, top_k: int = 8, associated: bool = False) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    payload: dict[str, Any] = {"agent_id": agent_id, "query": query, "top_k": top_k}
+    if associated:
+        payload["include_associated"] = True
+        payload["associated_memories_depth"] = 1
+    response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    return normalize_recall_response(response)
+
+
+def enrich_recalled(recalled: list[dict[str, Any]], stored_by_id: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    runtime_to_fixture = {
+        stored["id"]: fixture_id
+        for fixture_id, stored in stored_by_id.items()
+        if isinstance(stored.get("id"), str)
+    }
+    enriched = []
+    for item in recalled:
+        memory = copy.deepcopy(item)
+        fixture_id = memory_fixture_id(memory)
+        if fixture_id is None:
+            fixture_id = runtime_to_fixture.get(memory.get("id"))
+        if fixture_id is not None:
+            memory["fixture_id"] = fixture_id
+        enriched.append(memory)
+    return enriched
+
+
+def find_by_fixture_id(memories: list[dict[str, Any]], fixture_id: str) -> dict[str, Any] | None:
+    return next((memory for memory in memories if memory.get("fixture_id") == fixture_id), None)
+
+
+def evaluate_runtime_scenario(
+    api_base: str,
+    agent_id: str,
+    scenario: dict[str, Any],
+    fixture: dict[str, Any],
+    stored_by_id: dict[str, dict[str, Any]],
+    session_ids: set[str],
+) -> dict[str, Any]:
+    full_transcript = "\n".join(fixture["full_transcript"])
+    memories, associated = recall(
+        api_base,
+        agent_id,
+        scenario["query"],
+        top_k=8,
+        associated=scenario["id"] in {"nuanced-decision", "basic-handoff"},
+    )
+    enriched = enrich_recalled(memories, stored_by_id)
+    associated_enriched = enrich_recalled(associated, stored_by_id)
+    recalled_fixture_ids = {memory.get("fixture_id") for memory in enriched}
+    associated_fixture_ids = {memory.get("fixture_id") for memory in associated_enriched}
+
+    full_tokens = token_estimate(full_transcript)
+    ccp_text = "\n".join(memory.get("content", "") for memory in enriched[:3])
+    ccp_tokens = token_estimate(ccp_text)
+
+    if scenario["id"] == "namespace-agent-isolation":
+        excluded = scenario["expected_excluded_memory"]
+        passed = excluded not in recalled_fixture_ids
+        return {
+            "scenario": scenario["id"],
+            "selected_memory": None,
+            "recalled_fixture_ids": sorted(item for item in recalled_fixture_ids if isinstance(item, str)),
+            "associated_fixture_ids": sorted(item for item in associated_fixture_ids if isinstance(item, str)),
+            "action": "isolate_agent_scope" if passed else "agent_scope_polluted",
+            "full_transcript_tokens": full_tokens,
+            "ccp_payload_tokens": ccp_tokens,
+            "token_savings": full_tokens - ccp_tokens,
+            "session_memory_proof": bool(session_ids),
+            "associated_recall_proof": True,
+            "passed": passed,
+        }
+
+    expected = scenario.get("expected_memory")
+    selected = find_by_fixture_id(enriched, expected) if isinstance(expected, str) else None
+    if selected is None and isinstance(expected, str) and expected in associated_fixture_ids:
+        selected = find_by_fixture_id(associated_enriched, expected)
+    decision = classify_ccp(selected) if selected is not None else {"action": "missing_memory", "reason": "not found"}
+
+    associated_ok = True
+    recall_ok = not isinstance(expected, str) or expected in recalled_fixture_ids
+    if scenario["id"] == "basic-handoff":
+        associated_ok = {"ccp-evidence", "ccp-caveat"}.issubset(associated_fixture_ids)
+    if scenario["id"] == "nuanced-decision":
+        recall_ok = isinstance(expected, str) and expected in recalled_fixture_ids.union(associated_fixture_ids)
+        associated_ok = "ccp-caveat" in recalled_fixture_ids.union(associated_fixture_ids) and (
+            "ccp-evidence" in associated_fixture_ids or "ccp-key-decision" in associated_fixture_ids
+        )
+
+    if scenario["id"] == "token-economy":
+        action = "ccp_payload_smaller" if ccp_tokens < full_tokens else "full_transcript_smaller"
+        passed = selected is not None and recall_ok and ccp_tokens < full_tokens
+    else:
+        action = decision["action"]
+        passed = (
+            selected is not None
+            and action == scenario["expected_action"]
+            and recall_ok
+            and associated_ok
+        )
+
+    return {
+        "scenario": scenario["id"],
+        "selected_memory": selected.get("id") if selected else None,
+        "selected_fixture_id": selected.get("fixture_id") if selected else None,
+        "recalled_fixture_ids": sorted(item for item in recalled_fixture_ids if isinstance(item, str)),
+        "associated_fixture_ids": sorted(item for item in associated_fixture_ids if isinstance(item, str)),
+        "action": action,
+        "reason": decision.get("reason", "token economy comparison"),
+        "full_transcript_tokens": full_tokens,
+        "ccp_payload_tokens": ccp_tokens,
+        "token_savings": full_tokens - ccp_tokens,
+        "session_memory_proof": bool(session_ids),
+        "associated_recall_proof": associated_ok,
+        "passed": passed,
+    }
+
+
+def run_runtime_validation(api_base: str, fixture: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    health = healthcheck(api_base)
+    session_id = start_session(api_base, agent_id)
+    stored_by_id: dict[str, dict[str, Any]] = {}
+    try:
+        agent_a_memories = [memory for memory in fixture["memories"] if memory["id"] != "ccp-unrelated-agent-memory"]
+        unrelated = next(memory for memory in fixture["memories"] if memory["id"] == "ccp-unrelated-agent-memory")
+
+        for memory in agent_a_memories:
+            stored_by_id[memory["id"]] = store_memory(api_base, agent_id, session_id, memory)
+
+        unrelated_agent_id = f"{agent_id}-unrelated"
+        stored_by_id[unrelated["id"]] = store_memory(api_base, unrelated_agent_id, None, unrelated)
+
+        for target_fixture_id in ("ccp-evidence", "ccp-caveat"):
+            link_memory(
+                api_base,
+                agent_id,
+                stored_by_id["ccp-key-decision"]["id"],
+                stored_by_id[target_fixture_id]["id"],
+            )
+
+        session_ids = {
+            item.get("id")
+            for item in session_memories(api_base, session_id)
+            if isinstance(item.get("id"), str)
+        }
+
+        scenarios = [
+            evaluate_runtime_scenario(api_base, agent_id, scenario, fixture, stored_by_id, session_ids)
+            for scenario in fixture["scenarios"]
+        ]
+        return {
+            "agent_id": agent_id,
+            "session_id": session_id,
+            "health": health,
+            "stored_fixture_ids": sorted(stored_by_id),
+            "session_memory_ids": sorted(session_ids),
+            "scenarios": scenarios,
+        }
+    finally:
+        try:
+            end_session(api_base, session_id, "Phase 5 Dakera CCP handoff validation completed.")
+        except Exception:
+            pass
+
+
+def print_report(results: list[dict[str, Any]]) -> None:
+    print("scenario,action,selected_fixture_id,token_savings,passed")
+    for result in results:
+        print(
+            ",".join(
+                [
+                    result["scenario"],
+                    result["action"],
+                    str(result.get("selected_fixture_id") or result.get("selected_memory")),
+                    str(result["token_savings"]),
+                    str(result["passed"]).lower(),
+                ]
+            )
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Dakera CCP handoff behavior.")
+    parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to CCP scenario fixture JSON.")
+    parser.add_argument("--agent-id", help="Agent ID for runtime validation. Defaults to a unique fixture-derived ID.")
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="HTTP request timeout in seconds.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
+    args = parser.parse_args()
+
+    global REQUEST_TIMEOUT
+    REQUEST_TIMEOUT = args.request_timeout
+
+    fixture = load_fixture(args.fixture)
+    if args.self_test:
+        results = run_self_test(fixture)
+        print_report(results)
+        return 0 if all(result["passed"] for result in results) else 1
+
+    agent_id = args.agent_id or f"{fixture['agent_id']}-{int(time.time())}"
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, agent_id)
+    print(json.dumps(runtime, indent=2, sort_keys=True))
+    return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/tif-graph-reliability/README.md
+++ b/examples/tif-graph-reliability/README.md
@@ -1,0 +1,285 @@
+# T-I-F Graph Reliability Handoff
+
+This note is a Phase 4 handoff for the Dakera T-I-F decision provenance RFC:
+
+https://github.com/Dakera-AI/dakera-deploy/issues/161
+
+It is intentionally documentation-only. It does not request an engine rewrite,
+SDK schema change, recall filter, or new server endpoint.
+
+The goal is to leave a compact build path for a future graph-reliability
+validation package.
+
+## Core Question
+
+Phase 1 and Phase 2 asked:
+
+```text
+Should this recalled memory be reused?
+```
+
+Phase 4 asks:
+
+```text
+Should this association path be trusted?
+```
+
+Dakera already has graph primitives where reliability can be evaluated at more
+than one layer:
+
+| Layer | Dakera surface | Reliability question |
+|---|---|---|
+| Memory node | `metadata.reliability` | Is this memory reliable before reuse? |
+| Graph edge | edge type and edge weight | Is this association reliable? |
+| Traversal path | graph path / associated recall | Is this multi-hop path trustworthy? |
+| Neighborhood | associated memories | Does nearby context confirm, weaken, or contradict the primary result? |
+
+## Dakera Surfaces To Inspect
+
+The most relevant existing surfaces are:
+
+- `dakera_recall_associated`
+- `include_associated=true`
+- `associated_memories_depth`
+- `associated_memories_min_weight`
+- `dakera_graph_traverse`
+- `dakera_graph_path`
+- `dakera_graph_link_memory`
+- `dakera_graph_export`
+- `dakera_knowledge_graph`
+- cross-agent knowledge network support
+
+The useful edge concepts are:
+
+- `related_to`
+- `shares_entity`
+- `precedes`
+- `linked_by`
+- edge `weight`
+- traversal `depth`
+
+## Suggested Build Order
+
+### 1. Keep Node Reliability Stable
+
+Do not change the Phase 3 T-I-F v1 contract.
+
+Use existing memory-level reliability:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "truth": 0.75,
+      "indeterminacy": 0.10,
+      "falsity": 0.15,
+      "classification": "confident_reuse",
+      "feedback_count": 12
+    }
+  }
+}
+```
+
+Node reliability answers whether one memory is safe to reuse.
+
+### 2. Derive Edge Reliability Agent-Side
+
+Do not add engine behavior first. Start with a validation script that derives
+edge reliability from existing graph output:
+
+```text
+edge type
+edge weight
+explicit link versus inferred similarity
+source node reliability
+target node reliability
+session evidence
+feedback history
+```
+
+First-pass rule:
+
+```text
+explicit linked_by edge:
+  truth += 0.15
+
+related_to edge:
+  truth += edge.weight
+  indeterminacy += 1.0 - edge.weight
+
+shares_entity edge:
+  truth += 0.55
+  indeterminacy += 0.30
+
+precedes edge:
+  truth += 0.50
+  indeterminacy += 0.35
+
+if source or target node falsity >= 0.50:
+  edge falsity = max(edge falsity, 0.50)
+```
+
+Clamp values to `[0.0, 1.0]`.
+
+### 3. Derive Path Reliability
+
+For a path:
+
+```text
+A -> B -> C
+```
+
+start conservatively:
+
+```text
+path.truth = min(all node truth, all edge truth)
+path.indeterminacy = max(all node indeterminacy, all edge indeterminacy, hop penalty)
+path.falsity = max(all node falsity, all edge falsity)
+```
+
+Example hop penalty:
+
+```text
+0 hops -> 0.00
+1 hop  -> 0.05
+2 hops -> 0.12
+3 hops -> 0.20
+```
+
+This makes the path no more reliable than its weakest required support.
+
+### 4. Preserve Contradiction Evidence
+
+High-falsity memories should remain visible as diagnostic graph evidence.
+
+Do not silently delete or hide them.
+
+Expected behavior:
+
+```text
+primary memory: reusable
+associated memory: high falsity
+agent result: reuse with surfaced contradiction evidence, or verify_before_use
+```
+
+## Validation Scenarios
+
+### Reliable Node, Weak Edge
+
+Goal:
+
+Show that a reliable memory should not be reused confidently when the
+association that brought it into context is weak.
+
+Expected result:
+
+```text
+node-only action: confident_reuse
+graph-aware action: verify_before_use
+```
+
+### Contradiction Neighbor
+
+Goal:
+
+Show that associated recall can surface a contradicted memory as evidence.
+
+Expected result:
+
+```text
+primary action: reuse current memory
+graph diagnostic: surface outdated memory as contradiction evidence
+```
+
+### Multi-Hop Uncertainty
+
+Goal:
+
+Show that useful memories reached through uncertain intermediate nodes should
+carry caveats.
+
+Expected result:
+
+```text
+node-only action: reuse
+graph-aware action: ask_clarification or verify_before_use
+```
+
+### Cross-Agent Similarity Caveat
+
+Goal:
+
+Show that cross-agent network links should be treated more cautiously than
+same-agent explicit links unless reinforced by feedback or session evidence.
+
+Expected result:
+
+```text
+cross-agent association: reuse_with_caveat
+```
+
+## NSS Reading Path
+
+These sources are the recommended mathematical reading order for continuing the
+graph track.
+
+1. Start with connection-level cognitive maps:
+
+   https://fs.unm.edu/NSS/ANewNeutrosophicCognitiveMap-NSS.22.pdf
+
+   This is the closest source for Dakera because it treats relations and
+   connections as neutrosophic objects. That maps well to memory associations
+   and edge reliability.
+
+2. Then read the general graph foundation:
+
+   https://fs.unm.edu/NSS/NeutrosophicGraphs22.pdf
+
+   This gives the broader graph frame where vertices and edges can carry truth,
+   indeterminacy, and falsity.
+
+3. Then inspect structural graph measures:
+
+   https://fs.unm.edu/NSS/IntroductionToTopological4.pdf
+
+   This is useful for path, degree, connectivity, and traversal reliability.
+
+4. Finally, use this as a practical cognitive-map example:
+
+   https://fs.unm.edu/NSS/27CognitiveMaps.pdf
+
+   This helps keep the graph direction practical: identify concepts, model
+   relations, compare consensus, disagreement, and indeterminacy.
+
+## Non-Goals
+
+This handoff does not propose:
+
+- engine changes;
+- SDK schema changes;
+- recall filters;
+- new MCP tools;
+- graph database migration;
+- quaternion, Euler, or Riemann implementation;
+- deletion or filtering of contradiction memories.
+
+## Suggested Future Artifact
+
+If this track continues later, the smallest useful package would be:
+
+```text
+examples/tif-graph-reliability/
+  validate_tif_graph_reliability.py
+  phase4_graph_scenarios.json
+  README.md
+  VALIDATION_RESULTS.md
+```
+
+The validator should score node, edge, path, and neighborhood reliability
+outside the engine, then report whether graph-aware decisions differ from
+node-only decisions.
+
+## Boundary
+
+This is a handoff. It is designed so maintainers can continue independently
+from the source links and build path above.

--- a/examples/tif-provenance/README.md
+++ b/examples/tif-provenance/README.md
@@ -1,0 +1,102 @@
+# T-I-F Feedback Provenance Phase 2
+
+This example validates Phase 2 of the Dakera T-I-F decision provenance RFC:
+
+https://github.com/Dakera-AI/dakera-deploy/issues/161
+
+Phase 1 proved that `metadata.reliability` survives store and recall and can
+change agent-side decisions. Phase 2 tests the next maintainer-requested
+question: can T-I-F scores be derived from real agent interaction signals and
+used in a session-scoped decision trace?
+
+## What This Tests
+
+The example uses Dakera's public REST API only:
+
+- `POST /v1/memory/store`
+- `POST /v1/memory/recall`
+- `POST /v1/memories/{memory_id}/feedback`
+- `GET /v1/memories/{memory_id}/feedback`
+- `POST /v1/sessions/start`
+- `GET /v1/sessions/{session_id}/memories`
+- `POST /v1/memories/{memory_id}/links`
+
+The validation remains agent-side. Dakera stores memories, feedback, sessions,
+and links. The local script computes T-I-F from feedback and stores a decision
+trace under `metadata.decision_provenance`.
+
+Dakera `v0.11.90` requires `agent_id` when submitting feedback, reading
+feedback history, and creating memory links. The validator keeps those
+requirements explicit instead of hiding them behind an SDK.
+
+## Feedback-Derived T-I-F Rules
+
+```text
+upvote:   t + 0.10, i - 0.03, f - 0.05
+downvote: t - 0.10, i + 0.05, f + 0.15
+flag:     t - 0.05, i + 0.20, f + 0.10
+```
+
+Scores are clamped to `[0.0, 1.0]`.
+
+Decision priority:
+
+```text
+f >= 0.50 -> surface_contradiction
+i >= 0.50 -> ask_clarification
+t >= 0.70 and i <= 0.35 and f <= 0.35 -> reuse_confidently
+otherwise -> reuse_with_caveat
+```
+
+These thresholds are validation rules only. They are not proposed as Dakera
+engine behavior.
+
+## Scenarios
+
+The fixture covers three developer-recognizable workflows:
+
+| Scenario | Purpose |
+|---|---|
+| `coding-assistant` | feedback corrects an obsolete endpoint decision |
+| `research-agent` | weak-source feedback raises indeterminacy |
+| `customer-support` | outdated policy is surfaced as contradiction evidence |
+
+Each scenario records:
+
+- baseline importance-only decision;
+- feedback-derived T-I-F decision;
+- decision trace memory;
+- session ID;
+- linked evidence memory IDs;
+- associated recall proof.
+
+## Start Dakera
+
+The shared T-I-F compose file defaults to Dakera `v0.11.90`, binds to
+`127.0.0.1`, and disables auth only for local validation. Do not run it on a
+shared or internet-facing host.
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+```
+
+Stop:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml down
+```
+
+## Run Self-Test
+
+```bash
+python examples/tif-provenance/validate_tif_provenance.py --self-test
+```
+
+## Run Runtime Validation
+
+```bash
+python examples/tif-provenance/validate_tif_provenance.py --api http://localhost:3200 --request-timeout 240
+```
+
+The script fails if feedback history, session trace storage, or associated
+recall proof is missing.

--- a/examples/tif-provenance/VALIDATION_RESULTS.md
+++ b/examples/tif-provenance/VALIDATION_RESULTS.md
@@ -1,0 +1,152 @@
+# Phase 2 Validation Results
+
+Date: 2026-06-12 17:07:47 -04:00
+
+Status: passed local runtime validation.
+
+## Target Runtime
+
+```text
+Dakera image: ghcr.io/dakera-ai/dakera:0.11.90
+REST: http://127.0.0.1:3200
+gRPC: 127.0.0.1:51051
+Storage: in-memory
+Auth: disabled for local validation only
+```
+
+The validation compose binds ports to localhost only.
+
+## Commands
+
+```powershell
+python -m py_compile examples\tif-provenance\validate_tif_provenance.py
+python examples\tif-provenance\validate_tif_provenance.py --self-test
+docker compose -f docker\docker-compose.tif-phase1.yml down
+docker compose -f docker\docker-compose.tif-phase1.yml up -d
+python examples\tif-provenance\validate_tif_provenance.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker\docker-compose.tif-phase1.yml down
+```
+
+## Acceptance Criteria
+
+- all three scenarios pass;
+- feedback endpoints accept `upvote`, `downvote`, and `flag`;
+- feedback history is readable;
+- feedback-derived T-I-F changes at least one decision per scenario;
+- decision trace memory is stored with `metadata.decision_provenance`;
+- session memories include the trace and evidence memories;
+- associated recall returns linked evidence or contradiction memories;
+- no engine code is modified;
+- no first-class recall filters are added.
+
+## Result Summary
+
+All three scenarios passed against Dakera `0.11.90`.
+
+Runtime health reported:
+
+```json
+{
+  "ready": true,
+  "version": "0.11.90",
+  "checks": {
+    "embedding_engine": "ok",
+    "storage": "ok",
+    "tiered_engine": "disabled"
+  }
+}
+```
+
+Scenario outcomes:
+
+| Scenario | Baseline action | Feedback-derived T-I-F action | Decision changed | Session proof | Associated recall proof |
+| --- | --- | --- | --- | --- | --- |
+| coding-assistant | `reuse_top_memory` | `surface_contradiction` | yes | yes | yes |
+| research-agent | `reuse_top_memory` | `ask_clarification` | yes | yes | yes |
+| customer-support | `reuse_top_memory` | `surface_contradiction` | yes | yes | yes |
+
+The runtime accepted feedback signals `upvote`, `downvote`, and `flag`; feedback history was readable for every seeded memory; each scenario stored a decision trace with `metadata.decision_provenance`; session memory listing included the trace and evidence memories; associated recall returned linked evidence memories when recalling the decision trace with `include_associated=true` and `associated_memories_depth=1`.
+
+Runtime contract notes observed on Dakera `0.11.90`:
+
+- `POST /v1/sessions/start` returns the session id as `session.id`.
+- `POST /v1/memories/{memory_id}/feedback` requires `agent_id`.
+- `GET /v1/memories/{memory_id}/feedback` requires `agent_id` as a query parameter.
+- `POST /v1/memories/{memory_id}/links` requires `agent_id`.
+
+No engine code was modified. No first-class recall filters were added.
+
+## Review Correction Rerun
+
+Date: 2026-06-12 17:20:58 -04:00
+
+Corrections after fork review:
+
+- healthcheck now requires `ready: true` before runtime validation proceeds;
+- unsupported feedback signals now produce a clear validation error instead of a raw `KeyError`;
+- Phase 1 recall normalization was reviewed and already handles list, dict, and nested `memory` response shapes.
+
+Rerun commands:
+
+```powershell
+python -m py_compile examples\tif-provenance\validate_tif_provenance.py examples\tif-reliability\validate_tif_reliability.py
+python examples\tif-provenance\validate_tif_provenance.py --self-test
+python examples\tif-reliability\validate_tif_reliability.py --self-test
+docker compose -f docker\docker-compose.tif-phase1.yml down
+docker compose -f docker\docker-compose.tif-phase1.yml up -d
+python examples\tif-provenance\validate_tif_provenance.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker\docker-compose.tif-phase1.yml down
+```
+
+Result: passed.
+
+## Codex Review Correction Rerun
+
+Date: 2026-06-12 18:02:19 -04:00
+
+Additional Codex review findings corrected:
+
+- runtime decisions now use the normalized `/v1/memory/recall` response for each scenario query before choosing the baseline and feedback-aware memory;
+- each scenario records `scenario_recall_proof` and the recalled fixture/runtime memory IDs;
+- associated recall proof now verifies that every linked evidence memory appears in the full associated recall response and reports `associated_recall_missing_ids`;
+- runtime validation was rerun with PowerShell preserving the validator exit code before Docker cleanup.
+
+Rerun commands:
+
+```powershell
+python -m py_compile examples\tif-provenance\validate_tif_provenance.py examples\tif-reliability\validate_tif_reliability.py
+python examples\tif-provenance\validate_tif_provenance.py --self-test
+python examples\tif-reliability\validate_tif_reliability.py --self-test
+docker compose -f docker\docker-compose.tif-phase1.yml down
+docker compose -f docker\docker-compose.tif-phase1.yml up -d
+python examples\tif-provenance\validate_tif_provenance.py --api http://localhost:3200 --request-timeout 240
+$validationExit = $LASTEXITCODE
+docker compose -f docker\docker-compose.tif-phase1.yml down
+exit $validationExit
+```
+
+Result: passed. All three scenarios returned `scenario_recall_proof: true`, `associated_recall_missing_ids: []`, `associated_recall_proof: true`, and `passed: true`.
+
+## Second Review Correction Rerun
+
+Date: 2026-06-12 17:40:38 -04:00
+
+Additional Qodo findings corrected:
+
+- runtime `changed_decision` now mirrors the self-test logic and treats same-memory `reuse_confidently` as unchanged reuse;
+- runtime memory metadata is deep-copied before adding derived reliability, and malformed or missing `metadata.reliability` now fails with a clear validation error;
+- associated recall keeps a single read-only retry to tolerate cold reranker startup without retrying mutating endpoints.
+
+Rerun commands:
+
+```powershell
+python -m py_compile examples\tif-provenance\validate_tif_provenance.py examples\tif-reliability\validate_tif_reliability.py
+python examples\tif-provenance\validate_tif_provenance.py --self-test
+python examples\tif-reliability\validate_tif_reliability.py --self-test
+docker compose -f docker\docker-compose.tif-phase1.yml down
+docker compose -f docker\docker-compose.tif-phase1.yml up -d
+python examples\tif-provenance\validate_tif_provenance.py --api http://localhost:3200 --request-timeout 240
+docker compose -f docker\docker-compose.tif-phase1.yml down
+```
+
+Result: passed.

--- a/examples/tif-provenance/phase2_scenarios.json
+++ b/examples/tif-provenance/phase2_scenarios.json
@@ -1,0 +1,128 @@
+{
+  "agent_id": "dakera-tif-phase2",
+  "scenarios": [
+    {
+      "id": "coding-assistant",
+      "title": "Coding assistant review correction",
+      "query": "Which Dakera REST endpoint should the coding assistant use for storing memory with reliability metadata?",
+      "expected_action": "surface_contradiction",
+      "expected_changed_decision": true,
+      "expected_direct_memory": "coding-obsolete-endpoint",
+      "expected_safe_memory": "coding-current-endpoint",
+      "memories": [
+        {
+          "id": "coding-current-endpoint",
+          "content": "Dakera memory store examples should use POST /v1/memory/store for the current public REST API.",
+          "importance": 0.84,
+          "feedback": ["upvote"],
+          "metadata": {
+            "reliability": {
+              "t": 0.66,
+              "i": 0.14,
+              "f": 0.10,
+              "basis": "Phase 1 runtime validation and maintainer review",
+              "source": "phase2_seed"
+            }
+          }
+        },
+        {
+          "id": "coding-obsolete-endpoint",
+          "content": "Dakera examples should use POST /v1/memories when storing agent memories.",
+          "importance": 0.93,
+          "feedback": ["downvote", "downvote"],
+          "metadata": {
+            "reliability": {
+              "t": 0.38,
+              "i": 0.20,
+              "f": 0.34,
+              "basis": "obsolete quickstart assumption superseded by current API behavior",
+              "source": "phase2_seed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "research-agent",
+      "title": "Research agent source conflict",
+      "query": "Should the research agent cite an unsupported secondary note as confirmed evidence?",
+      "expected_action": "ask_clarification",
+      "expected_changed_decision": true,
+      "expected_direct_memory": "research-uncertain-source",
+      "expected_safe_memory": "research-source-backed",
+      "memories": [
+        {
+          "id": "research-source-backed",
+          "content": "A research agent should prefer source-backed claims and cite the primary evidence when summarizing technical decisions.",
+          "importance": 0.80,
+          "feedback": ["upvote"],
+          "metadata": {
+            "reliability": {
+              "t": 0.68,
+              "i": 0.16,
+              "f": 0.08,
+              "basis": "primary-source research discipline",
+              "source": "phase2_seed"
+            }
+          }
+        },
+        {
+          "id": "research-uncertain-source",
+          "content": "A research agent can treat an uncited secondary note as confirmed evidence when it sounds plausible.",
+          "importance": 0.92,
+          "feedback": ["flag", "flag"],
+          "metadata": {
+            "reliability": {
+              "t": 0.44,
+              "i": 0.18,
+              "f": 0.18,
+              "basis": "weak-source pattern flagged during review",
+              "source": "phase2_seed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "customer-support",
+      "title": "Customer support outdated policy",
+      "query": "Which customer support policy should the agent reuse when an old process conflicts with the current escalation rule?",
+      "expected_action": "surface_contradiction",
+      "expected_changed_decision": true,
+      "expected_direct_memory": "support-outdated-policy",
+      "expected_safe_memory": "support-current-policy",
+      "memories": [
+        {
+          "id": "support-current-policy",
+          "content": "Customer support agents should follow the current escalation policy and ask for verification when a prior policy conflicts.",
+          "importance": 0.83,
+          "feedback": ["upvote"],
+          "metadata": {
+            "reliability": {
+              "t": 0.67,
+              "i": 0.12,
+              "f": 0.07,
+              "basis": "current support process",
+              "source": "phase2_seed"
+            }
+          }
+        },
+        {
+          "id": "support-outdated-policy",
+          "content": "Customer support agents should always use the old refund process without checking for newer escalation rules.",
+          "importance": 0.91,
+          "feedback": ["downvote", "flag"],
+          "metadata": {
+            "reliability": {
+              "t": 0.42,
+              "i": 0.18,
+              "f": 0.30,
+              "basis": "outdated policy deliberately retained as contradiction evidence",
+              "source": "phase2_seed"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/tif-provenance/validate_tif_provenance.py
+++ b/examples/tif-provenance/validate_tif_provenance.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Phase 2 T-I-F provenance validation for Dakera memories.
+
+This script uses only Python's standard library and Dakera's public REST API.
+It validates that T-I-F reliability can be derived from feedback signals, then
+recorded in session-scoped decision traces linked to evidence memories.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API = "http://localhost:3200"
+DEFAULT_FIXTURE = Path(__file__).with_name("phase2_scenarios.json")
+DEFAULT_REQUEST_TIMEOUT = 120
+REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
+
+FEEDBACK_DELTAS = {
+    "upvote": {"t": 0.10, "i": -0.03, "f": -0.05},
+    "downvote": {"t": -0.10, "i": 0.05, "f": 0.15},
+    "flag": {"t": -0.05, "i": 0.20, "f": 0.10},
+}
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc}") from exc
+
+
+def healthcheck(api_base: str, retries: int = 120, delay: float = 2.0) -> Any:
+    last_error: Exception | None = None
+    for _ in range(retries):
+        try:
+            response = request_json("GET", f"{api_base}/health/ready")
+            if isinstance(response, dict) and response.get("ready") is True:
+                return response
+            last_error = RuntimeError(f"health endpoint is not ready: {response!r}")
+        except Exception as exc:  # noqa: BLE001 - report final connection failure.
+            last_error = exc
+        time.sleep(delay)
+    raise RuntimeError(f"Dakera healthcheck failed after {retries} attempts: {last_error}")
+
+
+def clamp(value: float) -> float:
+    return max(0.0, min(1.0, round(value, 4)))
+
+
+def initial_reliability(memory: dict[str, Any]) -> dict[str, float]:
+    reliability = memory.get("metadata", {}).get("reliability", {})
+    return {
+        "t": float(reliability.get("t", 0.0) or 0.0),
+        "i": float(reliability.get("i", 0.0) or 0.0),
+        "f": float(reliability.get("f", 0.0) or 0.0),
+    }
+
+
+def derive_reliability(memory: dict[str, Any], feedback_signals: list[str] | None = None) -> dict[str, Any]:
+    derived = initial_reliability(memory)
+    signals = list(feedback_signals if feedback_signals is not None else memory.get("feedback", []))
+    for signal in signals:
+        if signal not in FEEDBACK_DELTAS:
+            raise ValueError(f"unsupported feedback signal for T-I-F derivation: {signal!r}")
+        delta = FEEDBACK_DELTAS[signal]
+        derived["t"] = clamp(derived["t"] + delta["t"])
+        derived["i"] = clamp(derived["i"] + delta["i"])
+        derived["f"] = clamp(derived["f"] + delta["f"])
+    return {
+        "t": derived["t"],
+        "i": derived["i"],
+        "f": derived["f"],
+        "basis": "derived from Dakera memory feedback signals",
+        "source": "feedback_derived_tif",
+        "signals": signals,
+    }
+
+
+def classify_reliability(reliability: dict[str, Any]) -> dict[str, Any]:
+    t = float(reliability.get("t", 0.0) or 0.0)
+    i = float(reliability.get("i", 0.0) or 0.0)
+    f = float(reliability.get("f", 0.0) or 0.0)
+
+    if f >= 0.50:
+        action = "surface_contradiction"
+        reason = "feedback-derived falsity makes this contradiction evidence"
+    elif i >= 0.50:
+        action = "ask_clarification"
+        reason = "feedback-derived indeterminacy makes reuse unresolved"
+    elif t >= 0.70 and i <= 0.35 and f <= 0.35:
+        action = "reuse_confidently"
+        reason = "feedback-derived truth is high with low uncertainty and contradiction"
+    else:
+        action = "reuse_with_caveat"
+        reason = "feedback-derived reliability is mixed"
+
+    return {"action": action, "reason": reason, "t": t, "i": i, "f": f}
+
+
+def choose_baseline(memories: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not memories:
+        return None
+    return max(memories, key=lambda item: float(item.get("importance", 0.0) or 0.0))
+
+
+def choose_feedback_aware(memories: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    if not memories:
+        return None, {"action": "no_memory", "reason": "no recalled memories"}
+
+    enriched = [(memory, classify_reliability(derive_reliability(memory))) for memory in memories]
+    contradictions = [item for item in enriched if item[1]["action"] == "surface_contradiction"]
+    if contradictions:
+        return max(contradictions, key=lambda item: item[1]["f"])
+
+    unresolved = [item for item in enriched if item[1]["action"] == "ask_clarification"]
+    if unresolved:
+        return max(unresolved, key=lambda item: item[1]["i"])
+
+    confident = [item for item in enriched if item[1]["action"] == "reuse_confidently"]
+    if confident:
+        return max(confident, key=lambda item: item[1]["t"])
+
+    baseline = choose_baseline(memories)
+    assert baseline is not None
+    return baseline, classify_reliability(derive_reliability(baseline))
+
+
+def memory_label(memory: dict[str, Any] | None) -> str | None:
+    if memory is None:
+        return None
+    value = memory.get("id") or memory.get("fixture_id") or memory.get("memory_id")
+    if isinstance(value, str):
+        return value
+    return str(memory.get("content", ""))[:72]
+
+
+def normalize_store_response(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict) and isinstance(response.get("memory"), dict):
+        return response["memory"]
+    if isinstance(response, dict):
+        return response
+    raise RuntimeError(f"unexpected store response: {response!r}")
+
+
+def normalize_recall_response(response: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    memories = normalize_memory_list(response, ("memories", "results", "items", "data"))
+    associated = normalize_memory_list(response, ("associated_memories", "associated", "linked_memories"))
+    return memories, associated
+
+
+def normalize_memory_list(response: Any, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [normalize_memory_item(item) for item in response if isinstance(item, dict)]
+    if not isinstance(response, dict):
+        return []
+
+    for key in keys:
+        value = response.get(key)
+        if isinstance(value, list):
+            return [normalize_memory_item(item) for item in value if isinstance(item, dict)]
+
+    if "content" in response:
+        return [response]
+    return []
+
+
+def normalize_memory_item(item: dict[str, Any]) -> dict[str, Any]:
+    nested = item.get("memory")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        for key in ("score", "weighted_score", "smart_score", "depth"):
+            if key in item:
+                merged[key] = item[key]
+        return merged
+    return item
+
+
+def start_session(api_base: str, agent_id: str, scenario: dict[str, Any]) -> str:
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/sessions/start",
+        {
+            "agent_id": agent_id,
+            "metadata": {
+                "phase": "phase2_tif_provenance",
+                "scenario": scenario["id"],
+                "source": "tif_decision_provenance",
+            },
+        },
+    )
+    for key in ("session_id", "id"):
+        value = response.get(key) if isinstance(response, dict) else None
+        if isinstance(value, str):
+            return value
+    nested = response.get("session") if isinstance(response, dict) else None
+    if isinstance(nested, dict) and isinstance(nested.get("id"), str):
+        return nested["id"]
+    raise RuntimeError(f"session start did not return a session id: {response!r}")
+
+
+def end_session(api_base: str, session_id: str, summary: str) -> Any:
+    return request_json("POST", f"{api_base}/v1/sessions/{session_id}/end", {"summary": summary})
+
+
+def session_memories(api_base: str, session_id: str) -> list[dict[str, Any]]:
+    response = request_json("GET", f"{api_base}/v1/sessions/{session_id}/memories")
+    return normalize_memory_list(response, ("memories", "results", "items", "data"))
+
+
+def store_memory(api_base: str, agent_id: str, session_id: str, memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = copy.deepcopy(memory.get("metadata", {}))
+    if not isinstance(metadata, dict):
+        raise ValueError(f"memory {memory.get('id', '<unknown>')} metadata must be an object")
+    reliability = metadata.get("reliability")
+    if not isinstance(reliability, dict):
+        raise ValueError(f"memory {memory.get('id', '<unknown>')} requires metadata.reliability")
+    metadata["fixture_id"] = memory["id"]
+    reliability["derived"] = derive_reliability(memory)
+
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/memory/store",
+        {
+            "agent_id": agent_id,
+            "content": memory["content"],
+            "memory_type": "semantic",
+            "importance": memory.get("importance", 0.5),
+            "metadata": metadata,
+            "session_id": session_id,
+            "tags": ["tif-phase2", memory["id"]],
+        },
+    )
+    stored = normalize_store_response(response)
+    stored["fixture_id"] = memory["id"]
+    stored["feedback"] = list(memory.get("feedback", []))
+    return stored
+
+
+def submit_feedback(api_base: str, agent_id: str, memory_id: str, signal: str) -> Any:
+    return request_json(
+        "POST",
+        f"{api_base}/v1/memories/{memory_id}/feedback",
+        {"agent_id": agent_id, "signal": signal},
+    )
+
+
+def get_feedback(api_base: str, agent_id: str, memory_id: str) -> Any:
+    query = urllib.parse.urlencode({"agent_id": agent_id})
+    return request_json("GET", f"{api_base}/v1/memories/{memory_id}/feedback?{query}")
+
+
+def extract_feedback_signals(history: Any) -> list[str]:
+    if isinstance(history, dict):
+        raw_entries = history.get("entries") or history.get("feedback") or history.get("history") or []
+    elif isinstance(history, list):
+        raw_entries = history
+    else:
+        raw_entries = []
+
+    signals = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("signal")
+        if isinstance(value, str) and value in FEEDBACK_DELTAS:
+            signals.append(value)
+    return signals
+
+
+def link_memory(api_base: str, agent_id: str, memory_id: str, target_id: str) -> Any:
+    return request_json(
+        "POST",
+        f"{api_base}/v1/memories/{memory_id}/links",
+        {"agent_id": agent_id, "target_id": target_id},
+    )
+
+
+def recall_associated(api_base: str, agent_id: str, query: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    payload = {
+        "agent_id": agent_id,
+        "query": query,
+        "top_k": 1,
+        "include_associated": True,
+        "associated_memories_depth": 1,
+    }
+    try:
+        response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    except TimeoutError:
+        # Recall is read-only. Retry once to tolerate cold ONNX/reranker startup.
+        response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    return normalize_recall_response(response)
+
+
+def recall_scenario_memories(api_base: str, agent_id: str, query: str, top_k: int = 8) -> list[dict[str, Any]]:
+    payload = {"agent_id": agent_id, "query": query, "top_k": top_k}
+    try:
+        response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    except TimeoutError:
+        # Recall is read-only. Retry once to tolerate cold ONNX/reranker startup.
+        response = request_json("POST", f"{api_base}/v1/memory/recall", payload)
+    memories, _associated = normalize_recall_response(response)
+    return memories
+
+
+def enrich_recalled_memories(
+    recalled: list[dict[str, Any]],
+    scenario: dict[str, Any],
+    stored_by_fixture: dict[str, dict[str, Any]],
+    feedback_history: dict[str, Any],
+) -> list[dict[str, Any]]:
+    fixture_by_id = {memory["id"]: memory for memory in scenario["memories"]}
+    fixture_by_stored_id = {
+        stored["id"]: fixture_id
+        for fixture_id, stored in stored_by_fixture.items()
+        if isinstance(stored.get("id"), str)
+    }
+    enriched = []
+    for item in recalled:
+        runtime_memory = copy.deepcopy(item)
+        metadata = runtime_memory.get("metadata")
+        fixture_id = metadata.get("fixture_id") if isinstance(metadata, dict) else None
+        if not isinstance(fixture_id, str):
+            fixture_id = fixture_by_stored_id.get(runtime_memory.get("id"))
+        if fixture_id not in fixture_by_id:
+            continue
+
+        source_memory = fixture_by_id[fixture_id]
+        if not isinstance(metadata, dict):
+            metadata = {}
+            runtime_memory["metadata"] = metadata
+        if not isinstance(metadata.get("reliability"), dict):
+            metadata["reliability"] = copy.deepcopy(source_memory.get("metadata", {}).get("reliability", {}))
+        runtime_memory["fixture_id"] = fixture_id
+        runtime_memory["feedback"] = extract_feedback_signals(feedback_history[fixture_id])
+        enriched.append(runtime_memory)
+    return enriched
+
+
+def store_decision_trace(
+    api_base: str,
+    agent_id: str,
+    session_id: str,
+    scenario: dict[str, Any],
+    direct_memory: dict[str, Any],
+    safe_memory: dict[str, Any] | None,
+    decision: dict[str, Any],
+    evidence_ids: list[str],
+) -> dict[str, Any]:
+    provenance = {
+        "scenario": scenario["id"],
+        "decision": decision["action"],
+        "reason": decision["reason"],
+        "evidence_memory_ids": evidence_ids,
+        "direct_memory_id": direct_memory["id"],
+        "safe_memory_id": safe_memory["id"] if safe_memory else None,
+        "reliability": {
+            "direct": derive_reliability(direct_memory, direct_memory.get("feedback", [])),
+            "safe": derive_reliability(safe_memory, safe_memory.get("feedback", [])) if safe_memory else None,
+        },
+        "source": "phase2_feedback_derived_tif",
+    }
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/memory/store",
+        {
+            "agent_id": agent_id,
+            "content": (
+                f"Decision trace for {scenario['id']}: {decision['action']} because {decision['reason']}."
+            ),
+            "memory_type": "semantic",
+            "importance": 0.88,
+            "metadata": {"decision_provenance": provenance},
+            "session_id": session_id,
+            "tags": ["tif-phase2", "decision-trace", scenario["id"]],
+        },
+    )
+    return normalize_store_response(response)
+
+
+def evaluate_static_scenario(scenario: dict[str, Any]) -> dict[str, Any]:
+    memories = scenario["memories"]
+    baseline = choose_baseline(memories)
+    direct, decision = choose_feedback_aware(memories)
+    safe = next((item for item in memories if item["id"] == scenario["expected_safe_memory"]), None)
+    changed = bool(baseline and direct) and memory_label(baseline) != memory_label(direct)
+    if decision["action"] != "reuse_confidently":
+        changed = True
+    return {
+        "scenario": scenario["id"],
+        "baseline_memory": memory_label(baseline),
+        "feedback_aware_memory": memory_label(direct),
+        "safe_memory": memory_label(safe),
+        "baseline_action": "reuse_top_memory" if baseline else "no_memory",
+        "feedback_tif_action": decision["action"],
+        "changed_decision": changed,
+        "passed": changed == scenario["expected_changed_decision"]
+        and decision["action"] == scenario["expected_action"]
+        and memory_label(direct) == scenario["expected_direct_memory"],
+    }
+
+
+def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    return [evaluate_static_scenario(scenario) for scenario in fixture["scenarios"]]
+
+
+def run_runtime_scenario(api_base: str, agent_id: str, scenario: dict[str, Any]) -> dict[str, Any]:
+    session_id = start_session(api_base, agent_id, scenario)
+    stored_by_fixture = {}
+    feedback_history = {}
+    try:
+        for memory in scenario["memories"]:
+            stored = store_memory(api_base, agent_id, session_id, memory)
+            stored_by_fixture[memory["id"]] = stored
+            memory_id = stored["id"]
+            for signal in memory.get("feedback", []):
+                submit_feedback(api_base, agent_id, memory_id, signal)
+            feedback_history[memory["id"]] = get_feedback(api_base, agent_id, memory_id)
+
+        recalled = recall_scenario_memories(api_base, agent_id, scenario["query"], top_k=8)
+        runtime_memories = enrich_recalled_memories(recalled, scenario, stored_by_fixture, feedback_history)
+        recalled_fixture_ids = {item.get("fixture_id") for item in runtime_memories}
+        expected_fixture_ids = {scenario["expected_direct_memory"], scenario["expected_safe_memory"]}
+        recall_selection_ok = expected_fixture_ids.issubset(recalled_fixture_ids)
+
+        baseline = choose_baseline(runtime_memories)
+        direct, decision = choose_feedback_aware(runtime_memories)
+        safe = next(
+            (item for item in runtime_memories if item.get("fixture_id") == scenario["expected_safe_memory"]),
+            None,
+        )
+        assert direct is not None
+        evidence_ids = [direct["id"]]
+        if safe is not None and safe["id"] not in evidence_ids:
+            evidence_ids.append(safe["id"])
+        trace = store_decision_trace(api_base, agent_id, session_id, scenario, direct, safe, decision, evidence_ids)
+        for evidence_id in evidence_ids:
+            link_memory(api_base, agent_id, trace["id"], evidence_id)
+
+        direct_recall, associated = recall_associated(
+            api_base,
+            agent_id,
+            f"Decision trace for {scenario['id']} {scenario['title']}",
+        )
+        associated_ids = {item.get("id") for item in associated}
+        direct_ids = {item.get("id") for item in direct_recall}
+        session_ids = {item.get("id") for item in session_memories(api_base, session_id)}
+        associated_response_ids = associated_ids | direct_ids
+        associated_missing_ids = sorted(set(evidence_ids) - associated_response_ids)
+        associated_ok = not associated_missing_ids
+        session_ok = trace["id"] in session_ids and set(evidence_ids).issubset(session_ids)
+        baseline_action = "reuse_top_memory" if baseline else "no_memory"
+        same_memory = (
+            baseline is not None
+            and baseline.get("fixture_id") == direct.get("fixture_id")
+        )
+        equivalent_reuse = same_memory and decision["action"] == "reuse_confidently"
+        changed = baseline_action != decision["action"] and not equivalent_reuse
+
+        return {
+            "scenario": scenario["id"],
+            "session_id": session_id,
+            "baseline_action": baseline_action,
+            "baseline_memory": baseline["id"] if baseline else None,
+            "feedback_tif_action": decision["action"],
+            "feedback_tif_reason": decision["reason"],
+            "feedback_aware_memory": direct["id"],
+            "safe_memory": safe["id"] if safe else None,
+            "scenario_recall_memory_ids": sorted(
+                item["id"] for item in runtime_memories if isinstance(item.get("id"), str)
+            ),
+            "scenario_recall_fixture_ids": sorted(
+                item for item in recalled_fixture_ids if isinstance(item, str)
+            ),
+            "scenario_recall_proof": recall_selection_ok,
+            "changed_decision": changed,
+            "decision_trace_memory_id": trace["id"],
+            "evidence_memory_ids": evidence_ids,
+            "feedback_history_signals": {
+                fixture_id: extract_feedback_signals(history)
+                for fixture_id, history in feedback_history.items()
+            },
+            "associated_recall_memory_ids": sorted(item for item in associated_ids if isinstance(item, str)),
+            "associated_recall_missing_ids": associated_missing_ids,
+            "direct_recall_memory_ids": sorted(item for item in direct_ids if isinstance(item, str)),
+            "session_memory_ids": sorted(item for item in session_ids if isinstance(item, str)),
+            "associated_recall_proof": associated_ok,
+            "session_trace_proof": session_ok,
+            "passed": changed == scenario["expected_changed_decision"]
+            and decision["action"] == scenario["expected_action"]
+            and recall_selection_ok
+            and associated_ok
+            and session_ok,
+        }
+    finally:
+        try:
+            end_session(api_base, session_id, f"Phase 2 scenario {scenario['id']} completed.")
+        except Exception:
+            pass
+
+
+def run_runtime_validation(api_base: str, fixture: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    health = healthcheck(api_base)
+    scenarios = [run_runtime_scenario(api_base, agent_id, scenario) for scenario in fixture["scenarios"]]
+    return {"agent_id": agent_id, "health": health, "scenarios": scenarios}
+
+
+def print_report(results: list[dict[str, Any]]) -> None:
+    print("scenario,baseline_action,feedback_tif_action,changed,trace_or_safe,passed")
+    for result in results:
+        print(
+            ",".join(
+                [
+                    result["scenario"],
+                    result["baseline_action"],
+                    result["feedback_tif_action"],
+                    str(result["changed_decision"]).lower(),
+                    str(result.get("decision_trace_memory_id") or result.get("safe_memory")),
+                    str(result["passed"]).lower(),
+                ]
+            )
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Dakera feedback-derived T-I-F provenance.")
+    parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to Phase 2 fixture JSON.")
+    parser.add_argument(
+        "--agent-id",
+        help="Agent ID for runtime validation. Defaults to a unique ID derived from the fixture.",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="HTTP request timeout in seconds.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
+    args = parser.parse_args()
+
+    global REQUEST_TIMEOUT
+    REQUEST_TIMEOUT = args.request_timeout
+
+    fixture = load_fixture(args.fixture)
+    if args.self_test:
+        results = run_self_test(fixture)
+        print_report(results)
+        return 0 if all(result["passed"] for result in results) else 1
+
+    agent_id = args.agent_id or f"{fixture['agent_id']}-{int(time.time())}"
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, agent_id)
+    print(json.dumps(runtime, indent=2, sort_keys=True))
+    return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/tif-reliability/README.md
+++ b/examples/tif-reliability/README.md
@@ -1,0 +1,118 @@
+# T-I-F Reliability Metadata Phase 1
+
+This example validates the Phase 1 proposal from Dakera issue #161:
+
+https://github.com/Dakera-AI/dakera-deploy/issues/161
+
+The goal is not to prove that metadata can round-trip. The maintainer has
+already confirmed that arbitrary JSON metadata is accepted and recalled by the
+public API. The goal is to show that an agent can inspect T-I-F reliability
+metadata and make a better decision than it would with importance/relevance
+alone.
+
+## What This Tests
+
+The example stores real conversation-derived memories with:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "t": 0.95,
+      "i": 0.03,
+      "f": 0.01,
+      "basis": "maintainer correction in Dakera issue #161",
+      "source": "tif_decision_provenance"
+    }
+  }
+}
+```
+
+The `t`, `i`, and `f` values are independent reliability components:
+
+| Field | Meaning | Agent-side handling in this example |
+|---|---|---|
+| `t` | truth/support | reuse when high and contradiction/uncertainty are low |
+| `i` | indeterminacy | ask for clarification or mark unresolved when high |
+| `f` | falsity/contradiction | surface as contradiction evidence when high |
+
+These rules are local agent logic only. They do not change Dakera ranking,
+filters, engine schema, SDK models, or storage behavior.
+
+## Start Dakera On Port 3200
+
+This avoids conflicts with local services that may already use port `3000`.
+The compose file binds REST and gRPC to `127.0.0.1` and disables auth only
+for local validation. Do not run it on a shared or internet-facing host.
+
+```bash
+cd docker
+docker compose -f docker-compose.tif-phase1.yml up -d
+```
+
+Health check:
+
+```bash
+curl http://localhost:3200/health/ready
+```
+
+Stop:
+
+```bash
+cd docker
+docker compose -f docker-compose.tif-phase1.yml down
+```
+
+## Run Self-Test
+
+The self-test validates the agent-side decision rules without requiring a
+running Dakera instance.
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --self-test
+```
+
+## Run Runtime Validation
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200
+```
+
+If the first run is slow while the ONNX model warms up, increase the request
+timeout:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200 --request-timeout 240
+```
+
+The script will:
+
+1. verify `/health/ready`;
+2. create a unique runtime `agent_id` unless one is passed explicitly;
+3. store issue-derived memories with `metadata.reliability`;
+4. recall memories for Phase 1 scenarios;
+5. compare a baseline importance/relevance-only decision with a T-I-F-aware decision;
+6. fail if the expected high-`i` or high-`f` decision changes are not observed.
+
+## Expected Decision Change
+
+Baseline behavior:
+
+```text
+reuse_top_memory
+```
+
+T-I-F-aware behavior for a high-`f` memory:
+
+```text
+surface_contradiction
+```
+
+T-I-F-aware behavior for a high-`i` memory:
+
+```text
+ask_clarification
+```
+
+This is the Phase 1 evidence requested by the maintainer: the metadata is not
+only preserved, it changes agent behavior in a reviewable way.

--- a/examples/tif-reliability/VALIDATION_RESULTS.md
+++ b/examples/tif-reliability/VALIDATION_RESULTS.md
@@ -1,0 +1,109 @@
+# Phase 1 Validation Results
+
+Date: 2026-06-12
+
+Dakera image:
+
+```text
+ghcr.io/dakera-ai/dakera:0.11.81
+```
+
+Local runtime:
+
+```text
+REST: http://127.0.0.1:3200
+gRPC: 127.0.0.1:51051
+Storage: in-memory
+Auth: disabled for local validation only
+```
+
+The validation compose binds these ports to localhost only.
+
+## Commands
+
+Start:
+
+```bash
+docker compose -f docker/docker-compose.tif-phase1.yml up -d
+```
+
+Health:
+
+```bash
+curl http://localhost:3200/health/ready
+```
+
+Self-test:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --self-test
+```
+
+Runtime validation:
+
+```bash
+python examples/tif-reliability/validate_tif_reliability.py --api http://localhost:3200
+```
+
+## Result Summary
+
+Health returned ready:
+
+```json
+{"ready":true,"version":"0.11.81","checks":{"storage":{"status":"ok","message":null}}}
+```
+
+Runtime validation passed all scenarios:
+
+| Scenario | Baseline action | T-I-F-aware action | Changed | Passed |
+|---|---|---|---|---|
+| `obsolete-roundtrip-plan` | `reuse_top_memory` | `surface_contradiction` | true | true |
+| `high-falsity-contradiction` | `reuse_top_memory` | `surface_contradiction` | true | true |
+| `high-indeterminacy-clarification` | `reuse_top_memory` | `ask_clarification` | true | true |
+| `safe-reuse-maintainer-target` | `reuse_top_memory` | `reuse_confidently` | false | true |
+
+The validation script now creates a unique runtime `agent_id` by default so
+repeat runs do not contaminate recall with memories from prior executions.
+
+## Evidence
+
+The store response preserved `metadata.reliability`:
+
+```json
+{
+  "metadata": {
+    "reliability": {
+      "t": 0.95,
+      "i": 0.03,
+      "f": 0.01,
+      "basis": "ferhimedamine Phase 1 instruction in Dakera issue #161",
+      "source": "tif_decision_provenance"
+    }
+  }
+}
+```
+
+Recall returned the same metadata under recalled memory objects. The local evaluator then used that metadata agent-side.
+
+High `f` behavior:
+
+```text
+baseline: reuse_top_memory
+T-I-F aware: surface_contradiction
+```
+
+High `i` behavior:
+
+```text
+baseline: reuse_top_memory
+T-I-F aware: ask_clarification
+```
+
+## Conclusion
+
+Phase 1 confirms the maintainer's requested evidence target:
+
+- metadata is accepted through the public store endpoint;
+- `metadata.reliability` survives recall;
+- T-I-F remains agent-side and does not change Dakera engine behavior;
+- high falsity and high indeterminacy produce measurably different agent decisions than importance/relevance alone.

--- a/examples/tif-reliability/phase1_memories.json
+++ b/examples/tif-reliability/phase1_memories.json
@@ -1,0 +1,109 @@
+{
+  "agent_id": "dakera-tif-phase1",
+  "source_issue": "https://github.com/Dakera-AI/dakera-deploy/issues/161",
+  "memories": [
+    {
+      "id": "phase1-maintainer-target",
+      "content": "Phase 1 should validate whether T-I-F reliability metadata produces measurably better agent decisions, not merely whether metadata round-trips through recall.",
+      "importance": 0.95,
+      "metadata": {
+        "reliability": {
+          "t": 0.95,
+          "i": 0.03,
+          "f": 0.01,
+          "basis": "ferhimedamine Phase 1 instruction in Dakera issue #161",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-obsolete-roundtrip-plan",
+      "content": "Phase 1 only needs to prove that metadata survives store and recall.",
+      "importance": 0.9,
+      "metadata": {
+        "reliability": {
+          "t": 0.28,
+          "i": 0.18,
+          "f": 0.82,
+          "basis": "superseded by maintainer clarification that metadata round-trip is already supported",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-developer-facing-name",
+      "content": "For Phase 1, use metadata.reliability as the developer-facing key while keeping neutrosophic theory in documentation.",
+      "importance": 0.86,
+      "metadata": {
+        "reliability": {
+          "t": 0.88,
+          "i": 0.08,
+          "f": 0.04,
+          "basis": "maintainer leaned toward metadata.tif or metadata.reliability and user selected metadata.reliability",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-high-falsity-handling",
+      "content": "A memory with high falsity should be silently hidden, filtered, or deleted before the agent can inspect it.",
+      "importance": 0.88,
+      "metadata": {
+        "reliability": {
+          "t": 0.12,
+          "i": 0.16,
+          "f": 0.91,
+          "basis": "contradicted by maintainer guidance: high-f memories are diagnostic signal and should surface as contradiction evidence",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    },
+    {
+      "id": "phase1-high-indeterminacy-handling",
+      "content": "If a recalled memory has high indeterminacy, the agent should treat the reuse decision as unresolved and ask for clarification instead of silently trusting it.",
+      "importance": 0.82,
+      "metadata": {
+        "reliability": {
+          "t": 0.42,
+          "i": 0.72,
+          "f": 0.12,
+          "basis": "maintainer guidance: clarification prompting is agent-side decision logic for high indeterminacy",
+          "source": "tif_decision_provenance",
+          "evidence_url": "https://github.com/Dakera-AI/dakera-deploy/issues/161#issuecomment-4694050474"
+        }
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "obsolete-roundtrip-plan",
+      "query": "Should Phase 1 only prove metadata round-trip?",
+      "expected_changed_decision": true,
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "high-falsity-contradiction",
+      "query": "Should a high falsity memory be filtered or surfaced as contradiction evidence?",
+      "expected_changed_decision": true,
+      "expected_action": "surface_contradiction"
+    },
+    {
+      "id": "high-indeterminacy-clarification",
+      "query": "If a recalled memory has high indeterminacy, should the agent ask for clarification instead of silently trusting it?",
+      "top_k": 1,
+      "expected_changed_decision": true,
+      "expected_action": "ask_clarification"
+    },
+    {
+      "id": "safe-reuse-maintainer-target",
+      "query": "What should Phase 1 validate now?",
+      "top_k": 1,
+      "expected_changed_decision": false,
+      "expected_action": "reuse_confidently"
+    }
+  ]
+}

--- a/examples/tif-reliability/validate_tif_reliability.py
+++ b/examples/tif-reliability/validate_tif_reliability.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Phase 1 T-I-F reliability validation for Dakera memories.
+
+This script uses only Python's standard library and Dakera's public REST API.
+It deliberately keeps T-I-F interpretation agent-side: Dakera stores and
+recalls metadata; the local evaluator decides whether to reuse, caveat,
+surface contradiction, or ask for clarification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API = "http://localhost:3200"
+DEFAULT_FIXTURE = Path(__file__).with_name("phase1_memories.json")
+DEFAULT_REQUEST_TIMEOUT = 120
+REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc}") from exc
+
+
+def healthcheck(api_base: str, retries: int = 120, delay: float = 2.0) -> Any:
+    last_error: Exception | None = None
+    for _ in range(retries):
+        try:
+            response = request_json("GET", f"{api_base}/health/ready")
+            if isinstance(response, dict) and response.get("ready") is True:
+                return response
+            last_error = RuntimeError(f"health endpoint is not ready: {response!r}")
+        except Exception as exc:  # noqa: BLE001 - report final connection failure.
+            last_error = exc
+        time.sleep(delay)
+    raise RuntimeError(f"Dakera healthcheck failed after {retries} attempts: {last_error}")
+
+
+def store_memory(api_base: str, agent_id: str, memory: dict[str, Any]) -> Any:
+    payload = {
+        "agent_id": agent_id,
+        "content": memory["content"],
+        "memory_type": "semantic",
+        "importance": memory.get("importance", 0.5),
+        "metadata": memory.get("metadata", {}),
+    }
+    return request_json("POST", f"{api_base}/v1/memory/store", payload)
+
+
+def recall_memories(api_base: str, agent_id: str, query: str, top_k: int) -> list[dict[str, Any]]:
+    response = request_json(
+        "POST",
+        f"{api_base}/v1/memory/recall",
+        {"agent_id": agent_id, "query": query, "top_k": top_k},
+    )
+    return normalize_recall_response(response)
+
+
+def normalize_recall_response(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, dict)]
+    if not isinstance(response, dict):
+        return []
+
+    for key in ("memories", "results", "items", "data"):
+        value = response.get(key)
+        if isinstance(value, list):
+            normalized = []
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                memory = item.get("memory")
+                if isinstance(memory, dict):
+                    merged = dict(memory)
+                    for score_key in ("score", "weighted_score", "smart_score"):
+                        if score_key in item:
+                            merged[score_key] = item[score_key]
+                    normalized.append(merged)
+                else:
+                    normalized.append(item)
+            return normalized
+
+    if "content" in response:
+        return [response]
+
+    return []
+
+
+def reliability(memory: dict[str, Any]) -> dict[str, Any]:
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        value = metadata.get("reliability")
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def memory_id(memory: dict[str, Any]) -> str:
+    value = memory.get("id") or memory.get("memory_id") or memory.get("uuid")
+    if isinstance(value, str):
+        return value
+
+    content = str(memory.get("content", ""))
+    return content[:72]
+
+
+def choose_baseline(memories: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not memories:
+        return None
+    return max(memories, key=lambda item: float(item.get("importance", 0.0) or 0.0))
+
+
+def classify_tif(memory: dict[str, Any]) -> dict[str, Any]:
+    rel = reliability(memory)
+    t = float(rel.get("t", 0.0) or 0.0)
+    i = float(rel.get("i", 0.0) or 0.0)
+    f = float(rel.get("f", 0.0) or 0.0)
+
+    if f >= 0.50:
+        action = "surface_contradiction"
+        reason = "high falsity means the memory is diagnostic contradiction evidence"
+    elif i >= 0.50:
+        action = "ask_clarification"
+        reason = "high indeterminacy means reuse is unresolved"
+    elif t >= 0.70 and i <= 0.35 and f <= 0.35:
+        action = "reuse_confidently"
+        reason = "high truth with low uncertainty and contradiction"
+    else:
+        action = "reuse_with_caveat"
+        reason = "mixed reliability requires caveated reuse"
+
+    return {"action": action, "reason": reason, "t": t, "i": i, "f": f}
+
+
+def choose_tif_aware(memories: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    if not memories:
+        return None, {"action": "no_memory", "reason": "no recalled memories"}
+
+    contradiction = [item for item in memories if classify_tif(item)["action"] == "surface_contradiction"]
+    if contradiction:
+        candidate = max(contradiction, key=lambda item: classify_tif(item)["f"])
+        return candidate, classify_tif(candidate)
+
+    unresolved = [item for item in memories if classify_tif(item)["action"] == "ask_clarification"]
+    if unresolved:
+        candidate = max(unresolved, key=lambda item: classify_tif(item)["i"])
+        return candidate, classify_tif(candidate)
+
+    candidate = choose_baseline(memories)
+    assert candidate is not None
+    return candidate, classify_tif(candidate)
+
+
+def evaluate_scenario(scenario: dict[str, Any], memories: list[dict[str, Any]]) -> dict[str, Any]:
+    baseline = choose_baseline(memories)
+    tif_memory, tif_decision = choose_tif_aware(memories)
+    baseline_action = "reuse_top_memory" if baseline else "no_memory"
+    same_memory = memory_id(baseline) == memory_id(tif_memory) if baseline and tif_memory else False
+    equivalent_reuse = same_memory and tif_decision["action"] == "reuse_confidently"
+    changed = baseline_action != tif_decision["action"] and not equivalent_reuse
+
+    return {
+        "scenario": scenario["id"],
+        "query": scenario["query"],
+        "baseline_action": baseline_action,
+        "baseline_memory": memory_id(baseline) if baseline else None,
+        "tif_action": tif_decision["action"],
+        "tif_reason": tif_decision["reason"],
+        "tif_memory": memory_id(tif_memory) if tif_memory else None,
+        "changed_decision": changed,
+        "expected_changed_decision": scenario["expected_changed_decision"],
+        "expected_action": scenario["expected_action"],
+        "passed": changed == scenario["expected_changed_decision"]
+        and tif_decision["action"] == scenario["expected_action"],
+    }
+
+
+def fixture_memories_for_scenario(fixture: dict[str, Any], scenario: dict[str, Any]) -> list[dict[str, Any]]:
+    memories = {memory["id"]: memory for memory in fixture["memories"]}
+
+    def by_id(memory_id: str) -> dict[str, Any]:
+        try:
+            return memories[memory_id]
+        except KeyError as exc:
+            raise KeyError(f"fixture memory id not found: {memory_id}") from exc
+
+    if scenario["id"] == "obsolete-roundtrip-plan":
+        return [by_id("phase1-obsolete-roundtrip-plan"), by_id("phase1-maintainer-target")]
+    if scenario["id"] == "high-falsity-contradiction":
+        return [by_id("phase1-high-falsity-handling"), by_id("phase1-maintainer-target")]
+    if scenario["id"] == "high-indeterminacy-clarification":
+        return [by_id("phase1-high-indeterminacy-handling"), by_id("phase1-maintainer-target")]
+    return [by_id("phase1-maintainer-target"), by_id("phase1-developer-facing-name")]
+
+
+def run_self_test(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    results = []
+    for scenario in fixture["scenarios"]:
+        memories = fixture_memories_for_scenario(fixture, scenario)
+        results.append(evaluate_scenario(scenario, memories))
+    return results
+
+
+def run_runtime_validation(
+    api_base: str, fixture: dict[str, Any], top_k: int, agent_id: str
+) -> dict[str, Any]:
+    health = healthcheck(api_base)
+
+    store_results = []
+    for memory in fixture["memories"]:
+        store_results.append({"id": memory["id"], "response": store_memory(api_base, agent_id, memory)})
+
+    scenario_results = []
+    for scenario in fixture["scenarios"]:
+        scenario_top_k = int(scenario.get("top_k", top_k))
+        recalled = recall_memories(api_base, agent_id, scenario["query"], scenario_top_k)
+        scenario_results.append(evaluate_scenario(scenario, recalled))
+
+    return {"agent_id": agent_id, "health": health, "stored": store_results, "scenarios": scenario_results}
+
+
+def print_report(results: list[dict[str, Any]]) -> None:
+    print("scenario,baseline_action,tif_action,changed,passed")
+    for result in results:
+        print(
+            ",".join(
+                [
+                    result["scenario"],
+                    result["baseline_action"],
+                    result["tif_action"],
+                    str(result["changed_decision"]).lower(),
+                    str(result["passed"]).lower(),
+                ]
+            )
+        )
+        print(f"  baseline_memory: {result['baseline_memory']}")
+        print(f"  tif_memory: {result['tif_memory']}")
+        print(f"  reason: {result['tif_reason']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Dakera T-I-F reliability metadata behavior.")
+    parser.add_argument("--api", default=DEFAULT_API, help="Dakera REST API base URL.")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE, help="Path to Phase 1 fixture JSON.")
+    parser.add_argument("--top-k", type=int, default=8, help="Recall top_k value.")
+    parser.add_argument(
+        "--agent-id",
+        help="Agent ID for runtime validation. Defaults to a unique ID derived from the fixture.",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="HTTP request timeout in seconds. Startup and first recall can be slow while ONNX warms up.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run local evaluator test without Dakera.")
+    args = parser.parse_args()
+
+    global REQUEST_TIMEOUT
+    REQUEST_TIMEOUT = args.request_timeout
+
+    fixture = load_fixture(args.fixture)
+    if args.self_test:
+        results = run_self_test(fixture)
+        print_report(results)
+        return 0 if all(result["passed"] for result in results) else 1
+
+    agent_id = args.agent_id or f"{fixture['agent_id']}-{int(time.time())}"
+    runtime = run_runtime_validation(args.api.rstrip("/"), fixture, args.top_k, agent_id)
+    print(json.dumps(runtime, indent=2, sort_keys=True))
+    return 0 if all(item["passed"] for item in runtime["scenarios"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

PR#174 was created during an internal automation review and reverted contributions that should have been kept. This PR restores all 4 contributions.

## What this PR does

Reverts commit `18cdff47` (PR#174), restoring all 4 contributions:
- Phase 1: T-I-F reliability metadata (originally PR#162)
- Phase 2: T-I-F decision provenance (originally PR#163)
- Phase 4: Graph reliability handoff (originally PR#164)
- Phase 5: Swarm CCP handoff validator (originally PR#173)

## Additional actions
- Issue #172 reopened