### PR TITLE
fix(DAK-6700): suppress Telegram alerts when agents are manually paused

### DIFF
--- a/scripts/runner/runner-health-monitor.sh
+++ b/scripts/runner/runner-health-monitor.sh
@@ -65,18 +65,38 @@ if [ -n "$OOM_PROCS" ]; then
   OOM_ALERT_FILE="$STATE_DIR/last-oom-alert"
   LAST_OOM_ALERT=$(cat "$OOM_ALERT_FILE" 2>/dev/null || echo 0)
   if [ $((NOW - LAST_OOM_ALERT)) -gt 3600 ]; then
-    OOM_MSG="🔴 *[Platform] Runner OOM Detected — ${HOSTNAME}*%0A%0AOOM kill detected in journal. Affected runners restarted.%0A%0AContext:%0A\`$(echo "$OOM_PROCS" | head -2 | tr '\n' ' ' | cut -c1-200)\`"
-    tg_alert "$OOM_MSG"
+    # Suppress alert if agents-paused flag is set (founder pause) — DAK-6700
+    # Flag management: touch/rm /var/lib/runner-health/agents-paused on each runner server
+    if [ -f "$STATE_DIR/agents-paused" ]; then
+      log "OOM detected — Telegram alert suppressed (agents-paused flag: $STATE_DIR/agents-paused)"
+    else
+      OOM_MSG="🔴 *[Platform] Runner OOM Detected — ${HOSTNAME}*%0A%0AOOM kill detected in journal. Affected runners restarted.%0A%0AContext:%0A\`$(echo "$OOM_PROCS" | head -2 | tr '\n' ' ' | cut -c1-200)\`"
+      tg_alert "$OOM_MSG"
+    fi
     echo "$NOW" > "$OOM_ALERT_FILE"
   else
     log "OOM detected — alert suppressed, cooldown $(( 3600 - (NOW - LAST_OOM_ALERT) ))s remaining"
   fi
 fi
 
-# --- Send Telegram alert for restarts ---
+# --- Send Telegram alert for restarts (DAK-6492: silent on success, 4h cooldown on failure) ---
 if [ "$RESTARTED" -gt 0 ]; then
-  MSG="⚠️ *[Platform] Runner Auto-Restart — ${HOSTNAME}*%0A%0A${RESTARTED} runner(s) restarted:%0A$(echo -e "$FAILED_UNITS")%0A%0AAll runners checked and recovered."
-  tg_alert "$MSG"
+  RESTART_ALERT_FILE="$STATE_DIR/last-restart-alert"
+  LAST_RESTART_ALERT=$(cat "$RESTART_ALERT_FILE" 2>/dev/null || echo 0)
+  # Only alert if a restart FAILED (service not back to active)
+  HAS_FAILURE=$(echo -e "$FAILED_UNITS" | grep -v "active)" | grep -v "^$" || true)
+  if [ -n "$HAS_FAILURE" ] && [ $((NOW - LAST_RESTART_ALERT)) -gt 14400 ]; then
+    # Suppress alert if agents-paused flag is set (founder pause) — DAK-6700
+    if [ -f "$STATE_DIR/agents-paused" ]; then
+      log "Runner restart failure — Telegram alert suppressed (agents-paused flag: $STATE_DIR/agents-paused)"
+    else
+      MSG="🔴 *[Platform] Runner Restart FAILED — ${HOSTNAME}*%0A%0A${RESTARTED} runner(s) attempted restart:%0A$(echo -e "$FAILED_UNITS")%0A%0ASome runners did NOT recover."
+      tg_alert "$MSG"
+    fi
+    echo "$NOW" > "$RESTART_ALERT_FILE"
+  else
+    log "Auto-restart: $RESTARTED service(s) handled (all recovered or cooldown active)"
+  fi
 fi
 
 # --- Periodic status log every 30min ---


### PR DESCRIPTION
## Summary

- **runner-health-monitor.sh**: OOM alert and restart failure alert now check `$STATE_DIR/agents-paused` flag file before calling `tg_alert`. If the flag exists, alert is suppressed (logged only). Cooldown timers still update to prevent alert storms on resume.
- Bundles the DAK-6492 improvement (silent on success, 4-hour cooldown on restart failure alerts) which was uncommitted in the main checkout.

## Flag Management (runner servers)

On each runner server (ARM `168.119.60.30`, x64 `178.104.227.173`), set/unset:
```bash
# Pause: suppress runner alerts
touch /var/lib/runner-health/agents-paused

# Resume: restore alerting
rm -f /var/lib/runner-health/agents-paused
```

## Related Scripts Fixed (paperclip — not in this repo)

- `scripts/run-agent.sh`: Replaced hardcoded `PAUSED_AGENTS="growth cortex"` with live DB query (`SELECT paused_at FROM agents WHERE name = $AGENT_NAME`). Telegram failure alert also guarded with pause check.
- `scripts/heartbeat-timeout-sweep.sh`: Suppresses Telegram alert when `SELECT COUNT(*) FROM agents WHERE paused_at IS NULL` returns 0 (all agents paused).

## Test Plan

- [ ] Founder pauses all agents manually
- [ ] Verify ZERO Telegram messages from monitoring scripts during pause window
- [ ] Founder resumes agents
- [ ] Verify alerts resume normally on next OOM or runner failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)