### PR TITLE
fix(playground): replace em dash in workflow name to fix workflow_dispatch (DAK-6706)

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -1,4 +1,4 @@
-name: Playground — Provision CPX31
+name: Playground - Provision CPX31
 
 # Provisions a Hetzner CPX31 in fsn1 with Docker, Dakera, MinIO, Nginx+TLS.
 # This is a one-shot workflow; run it once per playground lifecycle.


### PR DESCRIPTION
## Root Cause

GitHub's workflow YAML parser **rejects non-ASCII characters in the `name:` field**. The em dash (U+2014, bytes `e2 80 94`) in:

```
name: Playground — Provision CPX31
```

caused GitHub to fail to parse workflow metadata — registering the workflow with the file path as its name and **not recognizing the `workflow_dispatch` trigger** (all dispatch attempts returned HTTP 422).

Evidence:
- `gh workflow list` showed name `.github/workflows/playground-provision.yml` instead of `Playground — Provision CPX31`
- All working workflows (Hetzner Provision Staging Server, Deploy to Production, etc.) use ASCII-only names

## Fix

One-character change: replace `—` (em dash, U+2014) with `-` (ASCII hyphen-minus). No logic changes.

## Test plan

- [ ] Merge → verify `gh workflow list` shows `Playground - Provision CPX31` as name
- [ ] `gh workflow run "Playground - Provision CPX31" --repo dakera-ai/dakera-deploy --ref main` succeeds (no 422)
- [ ] Provisioning workflow runs and provisions CPX31 in fsn1

🤖 Generated with [Claude Code](https://claude.com/claude-code)