### PR TITLE
fix(playground): fix YAML parse error — unindented Telegram TEXT breaks block scalar (DAK-6706)

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -365,31 +365,23 @@ jobs:
           DOMAIN: ${{ inputs.playground_domain }}
           DAKERA_VERSION: ${{ inputs.dakera_version }}
           STATUS: ${{ job.status }}
+          RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           if [ -n "$DOMAIN" ]; then
             URL="https://${DOMAIN}"
           else
             URL="https://${SERVER_IP} (self-signed)"
           fi
-
           if [ "$STATUS" = "success" ]; then
-            ICON="✅"
+            ICON="OK"
             MSG="[Platform] Playground provisioned"
           else
-            ICON="❌"
+            ICON="FAILED"
             MSG="[Platform] Playground provision FAILED"
           fi
-
-          TEXT="${ICON} ${MSG}
-
-Server: ${SERVER_IP} (cpx31, fsn1)
-Dakera: ${DAKERA_VERSION}
-URL: ${URL}
-Health: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-Dakera playground is live. Nginx rate-limiting: 10 req/min per IP. 5 demo scenarios seeded."
-
+          TEXT=$(printf "%s %s\n\nServer: %s (cpx31, fsn1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
+            "$ICON" "$MSG" "$SERVER_IP" "$DAKERA_VERSION" "$URL" "$RUN_URL")
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \
-            -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":$(echo "$TEXT" | jq -Rs .)}" \
+            -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":$(printf '%s' "$TEXT" | jq -Rs .)}" \
             > /dev/null || true


### PR DESCRIPTION
## Root Cause (definitive)

The \`playground-provision.yml\` workflow has a **YAML parse error** that has prevented \`workflow_dispatch\` from being recognized since day 1:

The Telegram notification step assigns a multiline bash variable:
\`\`\`bash
TEXT="${ICON} ${MSG}

Server: ${SERVER_IP} ...      # ← COLUMN 0 — exits YAML block scalar!
Health: https://.../${{ github.repository }}...
\`\`\`

Lines at column 0 exit the \`run: |\` block scalar (which started at column 10). YAML then parses \`Health:\`, \`Server:\` etc. as top-level document mappings. The \`Health:\` value contains \`\${{ github.repository }}\` — YAML flow indicator \`{\` in a plain scalar → **"mapping values are not allowed here" at line 393, col 29**.

GitHub fails to parse the workflow and does not register \`workflow_dispatch\`.

Previous fixes (em dash → PR#183) were chasing the wrong symptom.

## Fix

Rewrite Telegram message using \`printf\` with \`%s\` arguments — all lines stay within the 10-space block scalar indentation. Move \`\${{ github.repository }}\` to an \`env:\` key (\`RUN_URL\`) where template expressions are valid.

Validated: \`python3 -c "import yaml; yaml.safe_load(open(f))\"\` — no parse error; \`workflow_dispatch\` key present.

## Test plan

- [ ] Merge → \`gh workflow list\` shows \`Playground - Provision CPX31\` (not file path)
- [ ] \`gh workflow run "Playground - Provision CPX31"\` returns 200 (not 422)
- [ ] Provisioning workflow runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)