### PR TITLE
fix(playground): change location fsn1 → nbg1 (cpx31 unavailable in fsn1) — DAK-6706

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   SERVER_NAME: "dakera-playground"
   SERVER_TYPE: "cpx31"
-  LOCATION: "fsn1"
+  LOCATION: "nbg1"
   IMAGE: "ubuntu-24.04"
   PLAYGROUND_DIR: "/opt/playground"
 
@@ -379,7 +379,7 @@ jobs:
             ICON="FAILED"
             MSG="[Platform] Playground provision FAILED"
           fi
-          TEXT=$(printf "%s %s\n\nServer: %s (cpx31, fsn1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
+          TEXT=$(printf "%s %s\n\nServer: %s (cpx31, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
             "$ICON" "$MSG" "$SERVER_IP" "$DAKERA_VERSION" "$URL" "$RUN_URL")
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Root Cause

Run 27581838754 failed with:

```
Attention: Server Type "cpx31" is unavailable in "fsn1" and can no longer be ordered.
hcloud: unsupported location for server type (invalid_input, d58e8f995ab64423e8ac32c7586a5030)
```

CPX31 is deprecated in fsn1. nbg1 (Nuremberg) still supports it.

## Fix

Change `LOCATION: "fsn1"` → `LOCATION: "nbg1"` in workflow env block, and update the Telegram message string. Two-line change.

## Test plan

- [ ] Merge → trigger `Playground - Provision CPX31` → run succeeds → server provisioned in nbg1 → health endpoint reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)