### PR TITLE
fix(playground): switch server type cpx31 → cx32, nbg1 (DAK-6706)

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -1,4 +1,4 @@
-name: Playground - Provision CPX31
+name: Playground - Provision CX32
 
 # Provisions a Hetzner CPX31 in fsn1 with Docker, Dakera, MinIO, Nginx+TLS.
 # This is a one-shot workflow; run it once per playground lifecycle.
@@ -30,7 +30,7 @@ concurrency:
 
 env:
   SERVER_NAME: "dakera-playground"
-  SERVER_TYPE: "cpx31"
+  SERVER_TYPE: "cx32"
   LOCATION: "nbg1"
   IMAGE: "ubuntu-24.04"
   PLAYGROUND_DIR: "/opt/playground"
@@ -40,7 +40,7 @@ jobs:
   # Job 1: Provision the Hetzner CPX31 server
   # ---------------------------------------------------------------------------
   provision:
-    name: Provision CPX31 in fsn1
+    name: Provision CX32 in nbg1
     runs-on: ubuntu-latest
     outputs:
       server_ip: ${{ steps.resolve.outputs.server_ip }}
@@ -379,7 +379,7 @@ jobs:
             ICON="FAILED"
             MSG="[Platform] Playground provision FAILED"
           fi
-          TEXT=$(printf "%s %s\n\nServer: %s (cpx31, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
+          TEXT=$(printf "%s %s\n\nServer: %s (cx32, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
             "$ICON" "$MSG" "$SERVER_IP" "$DAKERA_VERSION" "$URL" "$RUN_URL")
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Root Cause

CPX31 is fully deprecated — unavailable in both fsn1 AND nbg1:
- Run 27581838754: `cpx31` unavailable in fsn1
- Run 27582314976: `cpx31` unavailable in nbg1 (same error)

## Fix

Switch to `cx32` (4 vCPU, 8 GB Intel) — direct spec equivalent to cpx31, widely available in all Hetzner locations including nbg1. Location stays nbg1.

YAML validated: `yaml.safe_load` passes, `workflow_dispatch` confirmed present.

## Test plan

- [ ] Merge → trigger `Playground - Provision CX32` → run succeeds → CPX31 DAK-6706 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)