### PR TITLE
fix(playground): correct server type cx32 → cpx32, restore fsn1 (DAK-6706)

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -1,4 +1,4 @@
-name: Playground - Provision CX32
+name: Playground - Provision CPX32
 
 # Provisions a Hetzner CPX31 in fsn1 with Docker, Dakera, MinIO, Nginx+TLS.
 # This is a one-shot workflow; run it once per playground lifecycle.
@@ -30,8 +30,8 @@ concurrency:
 
 env:
   SERVER_NAME: "dakera-playground"
-  SERVER_TYPE: "cx32"
-  LOCATION: "nbg1"
+  SERVER_TYPE: "cpx32"
+  LOCATION: "fsn1"
   IMAGE: "ubuntu-24.04"
   PLAYGROUND_DIR: "/opt/playground"
 
@@ -40,7 +40,7 @@ jobs:
   # Job 1: Provision the Hetzner CPX31 server
   # ---------------------------------------------------------------------------
   provision:
-    name: Provision CX32 in nbg1
+    name: Provision CPX32 in fsn1
     runs-on: ubuntu-latest
     outputs:
       server_ip: ${{ steps.resolve.outputs.server_ip }}
@@ -379,7 +379,7 @@ jobs:
             ICON="FAILED"
             MSG="[Platform] Playground provision FAILED"
           fi
-          TEXT=$(printf "%s %s\n\nServer: %s (cx32, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
+          TEXT=$(printf "%s %s\n\nServer: %s (cpx32, fsn1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
             "$ICON" "$MSG" "$SERVER_IP" "$DAKERA_VERSION" "$URL" "$RUN_URL")
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Problem

Server type `cx32` does not exist in Hetzner Cloud — run 27582470021 failed with `Server Type not found: cx32`.

## Root cause analysis — 3 failed runs

| Run | Server Type | Location | Error |
|-----|-------------|----------|-------|
| 27581838754 | cpx31 | fsn1 | deprecated |
| 27582314976 | cpx31 | nbg1 | deprecated |
| 27582470021 | cx32  | nbg1 | not found |

## Fix

Use `cpx32` (4 vCPU, 8 GB AMD) in `fsn1` — **confirmed working** via the existing staging server provisioned by `provision-staging-server.yml` (comment: "cpx32 = 4vCPU/8GB AMD"). Restoring fsn1 since that's where cpx32 is confirmed available.

YAML validated: `python3 yaml.safe_load` passes, `workflow_dispatch` present.

## Test plan

- [ ] Merge → trigger `Playground - Provision CPX32` → run succeeds → DAK-6706 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)