### PR TITLE
fix(playground): switch server type cx32 → cax21 (ARM, nbg1) — DAK-6706

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -1,6 +1,6 @@
-name: Playground - Provision CX32
+name: Playground - Provision CAX21
 
-# Provisions a Hetzner CPX31 in fsn1 with Docker, Dakera, MinIO, Nginx+TLS.
+# Provisions a Hetzner CAX21 (ARM) in nbg1 with Docker, Dakera, MinIO, Nginx+TLS.
 # This is a one-shot workflow; run it once per playground lifecycle.
 # To reprovision: set replace_existing=true.
 
@@ -30,7 +30,7 @@ concurrency:
 
 env:
   SERVER_NAME: "dakera-playground"
-  SERVER_TYPE: "cx32"
+  SERVER_TYPE: "cax21"
   LOCATION: "nbg1"
   IMAGE: "ubuntu-24.04"
   PLAYGROUND_DIR: "/opt/playground"
@@ -40,7 +40,7 @@ jobs:
   # Job 1: Provision the Hetzner CPX31 server
   # ---------------------------------------------------------------------------
   provision:
-    name: Provision CX32 in nbg1
+    name: Provision CAX21 in nbg1
     runs-on: ubuntu-latest
     outputs:
       server_ip: ${{ steps.resolve.outputs.server_ip }}
@@ -118,7 +118,7 @@ jobs:
           CLOUDINIT
           echo "Cloud-init written."
 
-      - name: Create CPX31 server
+      - name: Create CAX21 server
         if: steps.check.outputs.server_exists != 'true' || inputs.replace_existing == 'true'
         id: create
         env:
@@ -379,7 +379,7 @@ jobs:
             ICON="FAILED"
             MSG="[Platform] Playground provision FAILED"
           fi
-          TEXT=$(printf "%s %s\n\nServer: %s (cx32, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
+          TEXT=$(printf "%s %s\n\nServer: %s (cax21, nbg1)\nDakera: %s\nURL: %s\nRun: %s\n\nPlayground live. Nginx rate-limit: 10 req/min per IP. 5 demo scenarios seeded." \
             "$ICON" "$MSG" "$SERVER_IP" "$DAKERA_VERSION" "$URL" "$RUN_URL")
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Root Cause

Run 27582457442 failed with:
\`\`\`
hcloud: Server Type not found: cx32
\`\`\`

hcloud v1.65.0 (latest) doesn't recognize \`cx32\` in nbg1. This is likely because the new Intel CX-series isn't available in nbg1 yet (new gen Hetzner datacenter rollout is staggered).

## Fix

Switch to \`cax21\` — Ampere ARM, 4 vCPU / 8 GB — same specs as the original cpx31:
- Confirmed available in nbg1 (Hetzner cax-series is fully rolled out)
- Dakera ships multi-arch images (amd64+arm64), stack fully compatible
- Our own ARM CI runner (168.119.60.30) is a Hetzner cax-series — proven platform

## Test plan

- [ ] Merge → trigger `Playground - Provision CAX21` → provisioning run succeeds → [DAK-6706](/DAK/issues/DAK-6706) done

🤖 [Agent: CTO] Generated with [Claude Code](https://claude.com/claude-code)