### PR TITLE
fix(playground): set default server type ccx23/nbg1 (confirmed working) — DAK-6706

### DIFF
--- a/.github/workflows/playground-provision.yml
+++ b/.github/workflows/playground-provision.yml
@@ -16,13 +16,13 @@ on:
         required: false
         default: "latest"
       server_type:
-        description: "Hetzner server type (e.g. cax21, cax31, cpx41, ccx23)"
+        description: "Hetzner server type (e.g. ccx23, ccx33, cax21, cax31)"
         required: false
-        default: "cax21"
+        default: "ccx23"
       location:
         description: "Hetzner datacenter location (nbg1, hel1, ash)"
         required: false
-        default: "hel1"
+        default: "nbg1"
       replace_existing:
         description: "Delete existing playground server before creating"
         required: false
@@ -38,8 +38,8 @@ concurrency:
 
 env:
   SERVER_NAME: "dakera-playground"
-  SERVER_TYPE: "${{ inputs.server_type || 'cax21' }}"
-  LOCATION: "${{ inputs.location || 'hel1' }}"
+  SERVER_TYPE: "${{ inputs.server_type || 'ccx23' }}"
+  LOCATION: "${{ inputs.location || 'nbg1' }}"
   IMAGE: "ubuntu-24.04"
   PLAYGROUND_DIR: "/opt/playground"
 


### PR DESCRIPTION
## Fix

Update workflow defaults to `ccx23` (AMD Dedicated) / `nbg1` after discovery run confirmed it works.

**Discovery chain (6 attempts):**

| Type | Location | Error |
|------|----------|-------|
| cpx31 | fsn1 | deprecated |
| cpx31 | nbg1 | deprecated |
| cx32 | nbg1 | not found (hcloud v1.65.0) |
| cax21 | nbg1 | resource_unavailable |
| cax21 | hel1 | resource_unavailable |
| **ccx23** | **nbg1** | **✅ SUCCESS** — run [27582791403](https://github.com/Dakera-AI/dakera-deploy/actions/runs/27582791403) |

ccx23 = AMD EPYC Dedicated, 4 vCPU / 16 GB. Better than cpx31 (more RAM), dedicated CPU.

Inputs remain overrideable if capacity shifts in the future (no code change needed).

## Test plan

- [x] Run 27582791403 provisioned ccx23/nbg1 successfully (Provision job ✅)
- [ ] Deploy job completes — [DAK-6706](/DAK/issues/DAK-6706) done

🤖 [Agent: CTO] Generated with [Claude Code](https://claude.com/claude-code)