### PR TITLE
fix(playground): security remediations — MinIO fail-loud, CSP, server_tokens, XFF (DAK-6732)

### DIFF
--- a/docker/docker-compose.playground.yml
+++ b/docker/docker-compose.playground.yml
@@ -122,10 +122,11 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
+      set -e;
       mc alias set myminio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       mc mb myminio/$${MINIO_BUCKET:-dakera-playground} --ignore-existing;
-      echo 'Playground bucket ready';
-      exit 0;
+      mc ls myminio/$${MINIO_BUCKET:-dakera-playground} > /dev/null;
+      echo 'Playground bucket verified and ready';
       "
     networks:
       - playground-net

--- a/docker/nginx-playground.conf
+++ b/docker/nginx-playground.conf
@@ -49,11 +49,14 @@ server {
 
     limit_conn playground_conn 20;
 
+    server_tokens off;
+
     add_header X-Content-Type-Options  "nosniff"          always;
     add_header X-Frame-Options         "DENY"             always;
     add_header X-XSS-Protection        "1; mode=block"    always;
     add_header Referrer-Policy         "no-referrer"      always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self' https://dakera.ai https://www.dakera.ai; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" always;
 
     # Health endpoint — higher limit for monitoring checks
     location = /health {
@@ -76,7 +79,7 @@ server {
         proxy_pass            http://127.0.0.1:3100;
         proxy_set_header      Host              $host;
         proxy_set_header      X-Real-IP         $remote_addr;
-        proxy_set_header      X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header      X-Forwarded-For   $remote_addr;
         proxy_set_header      X-Forwarded-Proto $scheme;
         proxy_read_timeout    30s;
         proxy_connect_timeout 5s;


### PR DESCRIPTION
## Summary

Security remediations from DAK-6730 playground audit:

- **CRITICAL — MinIO bucket silent failure**: `minio-setup` entrypoint called `exit 0` unconditionally, masking `mc mb` Access Denied errors. Fixed with `set -e` + `mc ls` verification so the container fails loudly if the bucket isn't created.
- **MEDIUM — Missing CSP header**: Added `Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self' https://dakera.ai https://www.dakera.ai; style-src 'self' 'unsafe-inline'; img-src 'self' data:;`
- **LOW — Server version exposed**: Added `server_tokens off;` to nginx config
- **LOW — XFF spoofing** (DAK-6720): Replaced `$proxy_add_x_forwarded_for` with `$remote_addr` to prevent header injection

### Server-side fixes (applied separately via SSH)
- UFW enabled (ports 22, 80, 443)
- `.env` permissions set to 0600

## Files Changed
- `docker/docker-compose.playground.yml` — MinIO setup entrypoint hardened
- `docker/nginx-playground.conf` — CSP + server_tokens + XFF fix

## Test Plan
- [ ] `docker compose -f docker-compose.playground.yml config` validates ✅ (verified locally)
- [ ] MinIO setup fails on Access Denied instead of silent success
- [ ] `curl -I` shows CSP + no Server version header
- [ ] XFF header contains only direct client IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)