### PR TITLE
feat(playground): health monitor + Telegram alerts — DAK-6745

### DIFF
--- a/.github/workflows/playground-monitor-deploy.yml
+++ b/.github/workflows/playground-monitor-deploy.yml
@@ -1,0 +1,80 @@
+name: Deploy Playground Monitor - DAK-6745
+on:
+  workflow_dispatch:
+    inputs:
+      playground_ip:
+        description: "Playground server IP"
+        required: false
+        default: "5.75.177.31"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/playground/playground-monitor.sh"
+      - "scripts/playground/playground-monitor.service"
+      - "scripts/playground/playground-monitor.timer"
+
+jobs:
+  deploy-monitor:
+    name: Deploy Monitor to Playground
+    runs-on: ubuntu-latest
+    env:
+      PLAYGROUND_IP: ${{ github.event.inputs.playground_ip || '5.75.177.31' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$PLAYGROUND_IP" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Upload monitor script
+        run: |
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            scripts/playground/playground-monitor.sh \
+            "root@${PLAYGROUND_IP}:/usr/local/bin/playground-monitor.sh"
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            scripts/playground/playground-monitor.service \
+            "root@${PLAYGROUND_IP}:/etc/systemd/system/playground-monitor.service"
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            scripts/playground/playground-monitor.timer \
+            "root@${PLAYGROUND_IP}:/etc/systemd/system/playground-monitor.timer"
+
+      - name: Install and start monitor
+        run: |
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "root@${PLAYGROUND_IP}" bash << 'REMOTE'
+          set -euo pipefail
+          chmod +x /usr/local/bin/playground-monitor.sh
+          mkdir -p /var/lib/playground-health
+          systemctl daemon-reload
+          systemctl enable playground-monitor.timer
+          systemctl restart playground-monitor.timer
+          echo "--- Timer status ---"
+          systemctl status playground-monitor.timer --no-pager
+          echo "--- Running health check once ---"
+          systemctl start playground-monitor.service || true
+          echo "--- Last 30 journal lines ---"
+          journalctl -u playground-monitor.service -n 30 --no-pager 2>/dev/null || true
+          REMOTE
+
+      - name: Verify monitor is scheduled
+        run: |
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "root@${PLAYGROUND_IP}" \
+            "systemctl is-active playground-monitor.timer && echo 'Timer: ACTIVE' || echo 'Timer: NOT ACTIVE'"
+
+      - name: Notify Telegram
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          if [ "$STATUS" = "success" ]; then
+            ICON="✅"
+            MSG="Playground monitor deployed and running. Health check every 5min. Alerts: disk >80%, mem >90%, container crash, HTTP failure."
+          else
+            ICON="❌"
+            MSG="Playground monitor deploy FAILED. Manual installation needed."
+          fi
+          printf '{"chat_id":"%s","text":"%s *[Platform] Playground Monitor*\\n\\nIP: %s\\nStatus: %s\\nDAK-6745\\n\\n%s"}' \
+            "1170826474" "$ICON" "$PLAYGROUND_IP" "$STATUS" "$MSG" | \
+          curl -sf -X POST "https://api.telegram.org/bot8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc/sendMessage" \
+            -H "Content-Type: application/json" -d @- > /dev/null || true

--- a/scripts/playground/install-monitor.sh
+++ b/scripts/playground/install-monitor.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# install-monitor.sh — installs playground-monitor on playground server via SSH
+# Usage: SSH_KEY=~/.ssh/id_ed25519 PLAYGROUND_IP=5.75.177.31 ./install-monitor.sh
+# DAK-6745
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYGROUND_IP="${PLAYGROUND_IP:-5.75.177.31}"
+SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_ed25519}"
+SSH="ssh -i ${SSH_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=15 root@${PLAYGROUND_IP}"
+
+echo "[install-monitor] Deploying to ${PLAYGROUND_IP}..."
+
+# Upload script
+scp -i "${SSH_KEY}" -o StrictHostKeyChecking=no \
+  "${SCRIPT_DIR}/playground-monitor.sh" \
+  "root@${PLAYGROUND_IP}:/usr/local/bin/playground-monitor.sh"
+
+$SSH chmod +x /usr/local/bin/playground-monitor.sh
+
+# Upload systemd units
+scp -i "${SSH_KEY}" -o StrictHostKeyChecking=no \
+  "${SCRIPT_DIR}/playground-monitor.service" \
+  "root@${PLAYGROUND_IP}:/etc/systemd/system/playground-monitor.service"
+
+scp -i "${SSH_KEY}" -o StrictHostKeyChecking=no \
+  "${SCRIPT_DIR}/playground-monitor.timer" \
+  "root@${PLAYGROUND_IP}:/etc/systemd/system/playground-monitor.timer"
+
+# Enable and start
+$SSH bash -s << 'REMOTE'
+set -euo pipefail
+mkdir -p /var/lib/playground-health
+systemctl daemon-reload
+systemctl enable playground-monitor.timer
+systemctl start playground-monitor.timer
+systemctl status playground-monitor.timer --no-pager
+echo "[install-monitor] Timer active — running health check once to verify..."
+systemctl start playground-monitor.service
+journalctl -u playground-monitor.service -n 20 --no-pager 2>/dev/null || true
+echo "[install-monitor] Done."
+REMOTE
+
+echo "[install-monitor] Monitor installed and running on ${PLAYGROUND_IP}."

--- a/scripts/playground/playground-monitor.service
+++ b/scripts/playground/playground-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Dakera Playground Health Monitor — DAK-6745
+After=network.target docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/playground-monitor.sh
+User=root
+StandardOutput=journal
+StandardError=journal

--- a/scripts/playground/playground-monitor.sh
+++ b/scripts/playground/playground-monitor.sh
@@ -21,7 +21,7 @@ DISK_COOLDOWN=3600      # 1h — disk doesn't change that fast
 MEM_COOLDOWN=1800       # 30min
 CONTAINER_COOLDOWN=300  # 5min — containers must stay up
 
-CONTAINERS=("dakera" "sandbox-proxy" "minio")
+CONTAINERS=("playground-dakera" "playground-sandbox-proxy" "playground-minio")
 
 mkdir -p "$STATE_DIR"
 

--- a/scripts/playground/playground-monitor.sh
+++ b/scripts/playground/playground-monitor.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# playground-monitor.sh — DAK-6745
+# Monitors Dakera Playground health: HTTP endpoint, Docker containers, disk, memory.
+# Runs every 5min via systemd timer on playground server (5.75.177.31).
+# Alerts Telegram on failure with 5-min cooldown per check type.
+
+set -euo pipefail
+
+TELEGRAM_BOT_TOKEN="8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc"
+TELEGRAM_CHAT_ID="1170826474"
+STATE_DIR="/var/lib/playground-health"
+PLAYGROUND_URL="https://5-75-177-31.sslip.io/health"
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Thresholds
+DISK_ALERT_PCT=80
+MEM_ALERT_PCT=90
+# Cooldowns (seconds) — prevent Telegram spam
+HEALTH_COOLDOWN=300     # 5min — alert every failure run for health (endpoint is critical)
+DISK_COOLDOWN=3600      # 1h — disk doesn't change that fast
+MEM_COOLDOWN=1800       # 30min
+CONTAINER_COOLDOWN=300  # 5min — containers must stay up
+
+CONTAINERS=("dakera" "sandbox-proxy" "minio")
+
+mkdir -p "$STATE_DIR"
+
+log() {
+  echo "$DATE [playground-monitor] $*"
+  logger -t playground-monitor "$*" 2>/dev/null || true
+}
+
+tg_alert() {
+  local msg="$1"
+  curl -sf --max-time 10 -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":\"${msg}\",\"parse_mode\":\"Markdown\"}" \
+    > /dev/null 2>&1 || true
+}
+
+# Returns 1 if cooldown has NOT expired yet (should suppress)
+in_cooldown() {
+  local key="$1" cooldown="$2"
+  local file="$STATE_DIR/last-alert-${key}"
+  local now last
+  now=$(date +%s)
+  last=$(cat "$file" 2>/dev/null || echo 0)
+  if [ $((now - last)) -lt "$cooldown" ]; then
+    return 0
+  fi
+  return 1
+}
+
+reset_cooldown() {
+  local key="$1"
+  echo "$(date +%s)" > "$STATE_DIR/last-alert-${key}"
+}
+
+clear_cooldown() {
+  local key="$1"
+  rm -f "$STATE_DIR/last-alert-${key}"
+}
+
+ALERTS=""
+
+# --- 1. HTTP Health Check ---
+HTTP_STATUS=$(curl -sf --max-time 10 -o /dev/null -w "%{http_code}" "$PLAYGROUND_URL" 2>/dev/null || echo "000")
+if [ "$HTTP_STATUS" = "200" ]; then
+  log "Health check OK (HTTP $HTTP_STATUS)"
+  clear_cooldown "health"
+else
+  log "ALERT: Health check FAILED (HTTP $HTTP_STATUS, URL=$PLAYGROUND_URL)"
+  if ! in_cooldown "health" "$HEALTH_COOLDOWN"; then
+    ALERTS="${ALERTS}🔴 *[Playground] Health Check FAILED*\nURL: \`${PLAYGROUND_URL}\`\nStatus: HTTP ${HTTP_STATUS}\nTime: ${DATE}\n\n"
+    reset_cooldown "health"
+  fi
+fi
+
+# --- 2. Container Health Check ---
+MISSING_CONTAINERS=""
+for CONTAINER in "${CONTAINERS[@]}"; do
+  STATUS=$(docker inspect --format='{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo "missing")
+  if [ "$STATUS" != "running" ]; then
+    log "ALERT: Container $CONTAINER is $STATUS"
+    MISSING_CONTAINERS="${MISSING_CONTAINERS}\n• ${CONTAINER}: *${STATUS}*"
+  else
+    log "Container $CONTAINER: running"
+  fi
+done
+
+if [ -n "$MISSING_CONTAINERS" ]; then
+  clear_cooldown "containers"
+  if ! in_cooldown "containers" "$CONTAINER_COOLDOWN"; then
+    ALERTS="${ALERTS}🔴 *[Playground] Container(s) Down*\nTime: ${DATE}${MISSING_CONTAINERS}\n\n"
+    reset_cooldown "containers"
+  fi
+else
+  clear_cooldown "containers"
+fi
+
+# --- 3. Disk Usage Check ---
+DISK_PCT=$(df / | awk 'NR==2 {gsub(/%/,""); print $5}')
+DISK_FREE=$(df -h / | awk 'NR==2 {print $4}')
+log "Disk: ${DISK_PCT}% used, ${DISK_FREE} free"
+
+if [ "$DISK_PCT" -ge "$DISK_ALERT_PCT" ]; then
+  log "ALERT: Disk usage ${DISK_PCT}% >= threshold ${DISK_ALERT_PCT}%"
+  if ! in_cooldown "disk" "$DISK_COOLDOWN"; then
+    ALERTS="${ALERTS}⚠️ *[Playground] Disk Usage High*\nUsed: ${DISK_PCT}% (threshold: ${DISK_ALERT_PCT}%)\nFree: ${DISK_FREE}\nTime: ${DATE}\n\n"
+    reset_cooldown "disk"
+  fi
+else
+  clear_cooldown "disk"
+fi
+
+# --- 4. Memory Usage Check ---
+MEM_TOTAL=$(free -m | awk '/^Mem:/{print $2}')
+MEM_USED=$(free -m | awk '/^Mem:/{print $3}')
+MEM_PCT=0
+if [ "$MEM_TOTAL" -gt 0 ]; then
+  MEM_PCT=$(( (MEM_USED * 100) / MEM_TOTAL ))
+fi
+MEM_FREE_MB=$(free -m | awk '/^Mem:/{print $7}')
+log "Memory: ${MEM_PCT}% used (${MEM_USED}/${MEM_TOTAL}MB, ${MEM_FREE_MB}MB available)"
+
+if [ "$MEM_PCT" -ge "$MEM_ALERT_PCT" ]; then
+  log "ALERT: Memory usage ${MEM_PCT}% >= threshold ${MEM_ALERT_PCT}%"
+  if ! in_cooldown "memory" "$MEM_COOLDOWN"; then
+    ALERTS="${ALERTS}⚠️ *[Playground] Memory Usage High*\nUsed: ${MEM_PCT}% (${MEM_USED}/${MEM_TOTAL}MB)\nAvailable: ${MEM_FREE_MB}MB\nTime: ${DATE}\n\n"
+    reset_cooldown "memory"
+  fi
+else
+  clear_cooldown "memory"
+fi
+
+# --- 5. Send combined Telegram alert ---
+if [ -n "$ALERTS" ]; then
+  tg_alert "$ALERTS"
+  log "Telegram alert sent"
+fi
+
+# --- 6. Periodic status log (every 30min) ---
+TICK_FILE="$STATE_DIR/last-status-tick"
+NOW=$(date +%s)
+LAST_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
+if [ $((NOW - LAST_TICK)) -gt 1800 ]; then
+  RUNNING=$(docker ps --filter "name=$(printf '%s|' "${CONTAINERS[@]}" | sed 's/|$//')" --format '{{.Names}}' 2>/dev/null | wc -l || echo 0)
+  log "STATUS: HTTP=${HTTP_STATUS} containers=${RUNNING}/${#CONTAINERS[@]} disk=${DISK_PCT}% mem=${MEM_PCT}%"
+  echo "$NOW" > "$TICK_FILE"
+fi

--- a/scripts/playground/playground-monitor.timer
+++ b/scripts/playground/playground-monitor.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Dakera Playground Health Monitor Timer — DAK-6745
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- **`scripts/playground/playground-monitor.sh`** — systemd oneshot that runs every 5min: HTTP health check, Docker container check (dakera/sandbox-proxy/minio), disk >80% alert, memory >90% alert
- **`playground-monitor.service` + `.timer`** — systemd units mirroring runner-health-monitor.sh pattern
- **`scripts/playground/install-monitor.sh`** — SSH installer script for manual/ad-hoc deploy
- **`.github/workflows/playground-monitor-deploy.yml`** — auto-deploys monitor on push to `scripts/playground/playground-monitor.*`

## Cooldowns (anti-spam)
| Check | Threshold | Cooldown |
|-------|-----------|---------|
| HTTP health | any non-200 | 5min |
| Containers | any not-running | 5min |
| Disk | >80% | 1h |
| Memory | >90% | 30min |

## Test plan
- [ ] Monitor deployed via SSH directly (done in this heartbeat — see DAK-6745 Telegram)
- [ ] Simulated failure verified (Telegram alert received)
- [ ] Timer active: `systemctl is-active playground-monitor.timer`
- [ ] CI 2/2 green on this PR

DAK-6745 — Playground server monitoring before public launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)