### PR TITLE
security(playground): namespace agent_id per session — fix cross-session PII leak (DAK-6757)

### DIFF
--- a/docker/playground/proxy/README.md
+++ b/docker/playground/proxy/README.md
@@ -45,6 +45,26 @@ and resend. Header-less requests fall back to an IP-keyed bucket, so the caps
 always apply. The per-IP ceiling above bounds header-rotation abuse; Nginx's
 per-IP req/s ceiling remains the first line of defence.
 
+## Per-session isolation (DAK-6757)
+
+Every public session authenticates as the same `playground-demo` agent_id, so
+without isolation any session could recall what any other session stored — a
+cross-session PII leak (QA finding DAK-6753). The proxy fixes this in
+`namespace.js`:
+
+- **Request:** every `agent_id` in the forwarded JSON body (top-level and nested
+  batch items) is rewritten to a private namespace
+  `playground-demo-<sha256(sessionId)[:12]>`. An omitted `agent_id` is forced to
+  the namespace too, so it can never fall back to the shared default. The
+  namespace is deterministic, so a session always recalls its own stores.
+- **Response:** the engine's response is buffered and the namespace is swapped
+  back to the client's original `agent_id`, so the isolation is invisible to the
+  frontend (no client-visible change to the `agent_id` format). `accept-encoding`
+  is dropped on namespaced requests so the response body is plaintext-rewritable.
+
+Header-less clients are isolated by their IP-bucket session key, so the caps and
+namespace still apply.
+
 ## Allowed endpoints
 
 Only the read/store operations the playground scenarios use (store, recall,

--- a/docker/playground/proxy/namespace.js
+++ b/docker/playground/proxy/namespace.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const crypto = require('crypto');
+
+// =============================================================================
+// Per-session agent_id namespacing (DAK-6757) — cross-session PII isolation.
+// =============================================================================
+// Every playground session shares the public "playground-demo" agent_id when
+// talking to the engine. Without this layer ANY session can recall what ANY
+// other session stored — a cross-session PII leak (QA finding DAK-6753):
+//
+//   Session B stores  {"agent_id":"playground-demo","content":"SECRET ..."}
+//   Session C recalls {"agent_id":"playground-demo","query":"SECRET"}  -> leak
+//
+// We give each session its OWN engine namespace by rewriting `agent_id` in the
+// forwarded request to `playground-demo-<sha256(sessionId)[:12]>`, and we
+// transparently restore the client's original `agent_id` in the engine's
+// response so the isolation is invisible to the frontend (no client-visible
+// change to the agent_id format).
+// =============================================================================
+
+const NS_PREFIX = 'playground-demo';
+
+/**
+ * Deterministic per-session engine namespace. The same session id always maps
+ * to the same namespace, so a session can always recall its own stores, while
+ * two different sessions can never collide.
+ * @param {string} sessionId
+ * @returns {string}
+ */
+function sessionNamespace(sessionId) {
+  const digest = crypto.createHash('sha256').update(String(sessionId)).digest('hex');
+  return `${NS_PREFIX}-${digest.slice(0, 12)}`;
+}
+
+// Keys whose array values hold per-item objects that may carry their own
+// agent_id (batch store / batch recall request shapes).
+const ITEM_ARRAY_KEYS = ['memories', 'items', 'queries'];
+
+/**
+ * Rewrite every `agent_id` in a JSON request body to the session namespace.
+ *
+ * The top-level object always gets `agent_id` forced to the namespace — even
+ * when the client omitted it — so an absent agent_id can never fall back to the
+ * shared default namespace. Nested batch items are only rewritten when they
+ * already carry their own agent_id (otherwise they inherit the top-level one).
+ *
+ * @param {Buffer} bodyBuf raw request body
+ * @param {string} namespace session namespace from {@link sessionNamespace}
+ * @returns {{body: Buffer, clientAgentId: (string|null)}}
+ *   body          — rewritten buffer (or the original when not JSON)
+ *   clientAgentId — the original agent_id to restore in the response, or null
+ *                   when the body was not rewritten (not JSON). Defaults to
+ *                   "playground-demo" when the client sent no agent_id.
+ */
+function rewriteRequestAgentId(bodyBuf, namespace) {
+  if (!bodyBuf || bodyBuf.length === 0) return { body: bodyBuf, clientAgentId: null };
+
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyBuf.toString('utf8'));
+  } catch {
+    return { body: bodyBuf, clientAgentId: null }; // not JSON — forward untouched
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { body: bodyBuf, clientAgentId: null };
+  }
+
+  let clientAgentId = null;
+  const applyTo = (obj, force) => {
+    if (!obj || typeof obj !== 'object') return;
+    if (typeof obj.agent_id === 'string') {
+      if (clientAgentId === null) clientAgentId = obj.agent_id;
+      obj.agent_id = namespace;
+    } else if (force) {
+      obj.agent_id = namespace;
+    }
+  };
+
+  const roots = Array.isArray(parsed) ? parsed : [parsed];
+  for (const root of roots) {
+    applyTo(root, true); // force isolation on the request root
+    if (root && typeof root === 'object' && !Array.isArray(root)) {
+      for (const key of ITEM_ARRAY_KEYS) {
+        if (Array.isArray(root[key])) {
+          for (const item of root[key]) applyTo(item, false);
+        }
+      }
+    }
+  }
+
+  return {
+    body: Buffer.from(JSON.stringify(parsed), 'utf8'),
+    clientAgentId: clientAgentId === null ? NS_PREFIX : clientAgentId,
+  };
+}
+
+/**
+ * Restore the client's original agent_id in an engine response body by
+ * replacing every occurrence of the session namespace with the original value.
+ * Returns the (possibly unchanged) buffer.
+ * @param {Buffer} buf raw upstream response body
+ * @param {string} namespace session namespace that was injected
+ * @param {string} restoreTo original client agent_id to restore
+ * @returns {Buffer}
+ */
+function restoreResponseAgentId(buf, namespace, restoreTo) {
+  if (!buf || buf.length === 0 || !buf.includes(namespace)) return buf;
+  const text = buf.toString('utf8').split(namespace).join(restoreTo);
+  return Buffer.from(text, 'utf8');
+}
+
+module.exports = { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId, NS_PREFIX };

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -6,6 +6,7 @@ const http = require('http');
 const { SessionStore } = require('./sessions');
 const { isAllowed, storeKind } = require('./allowlist');
 const { createServer, corsHeaders, countMemories } = require('./server');
+const { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId } = require('./namespace');
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -310,5 +311,167 @@ test('non-2xx store response does not consume the memory cap', async () => {
   // cap not consumed → a second (succeeding shape) request still allowed by cap
   const sess = p.store.resolve('pg_failtest', '127.0.0.1').session;
   assert.equal(sess.memoryCount, 0);
+  await p.close();
+});
+
+// ---------------------------------------------------------------------------
+// unit: per-session agent_id namespacing (DAK-6757)
+// ---------------------------------------------------------------------------
+
+test('sessionNamespace is deterministic, prefixed, and per-session unique (DAK-6757)', () => {
+  const a = sessionNamespace('pg_abcdefgh');
+  const b = sessionNamespace('pg_abcdefgh');
+  const c = sessionNamespace('pg_zzzzzzzz');
+  assert.equal(a, b); // deterministic — a session can recall its own stores
+  assert.notEqual(a, c); // different sessions -> different namespaces
+  assert.match(a, /^playground-demo-[0-9a-f]{12}$/);
+});
+
+test('rewriteRequestAgentId rewrites top-level + nested and captures original (DAK-6757)', () => {
+  const ns = sessionNamespace('pg_session1');
+  const r = rewriteRequestAgentId(
+    Buffer.from(JSON.stringify({ agent_id: 'playground-demo', memories: [{ agent_id: 'playground-demo', content: 'x' }, { content: 'y' }] })),
+    ns,
+  );
+  const parsed = JSON.parse(r.body.toString());
+  assert.equal(parsed.agent_id, ns); // top-level rewritten
+  assert.equal(parsed.memories[0].agent_id, ns); // nested rewritten when present
+  assert.equal(parsed.memories[1].agent_id, undefined); // nested without agent_id inherits top-level
+  assert.equal(r.clientAgentId, 'playground-demo');
+});
+
+test('rewriteRequestAgentId forces namespace when agent_id omitted (DAK-6757)', () => {
+  const ns = sessionNamespace('pg_session2');
+  const r = rewriteRequestAgentId(Buffer.from(JSON.stringify({ query: 'bank account' })), ns);
+  assert.equal(JSON.parse(r.body.toString()).agent_id, ns); // forced — cannot fall back to shared default
+  assert.equal(r.clientAgentId, 'playground-demo'); // restore to public placeholder
+});
+
+test('rewriteRequestAgentId leaves non-JSON and custom agent_id intact (DAK-6757)', () => {
+  const ns = sessionNamespace('pg_session3');
+  const bad = rewriteRequestAgentId(Buffer.from('not json'), ns);
+  assert.equal(bad.body.toString(), 'not json');
+  assert.equal(bad.clientAgentId, null); // not rewritten
+  const custom = rewriteRequestAgentId(Buffer.from(JSON.stringify({ agent_id: 'demo', content: 'z' })), ns);
+  assert.equal(custom.clientAgentId, 'demo'); // original preserved for response restore
+});
+
+test('restoreResponseAgentId swaps the namespace back to the client value (DAK-6757)', () => {
+  const ns = sessionNamespace('pg_session4');
+  const body = Buffer.from(JSON.stringify({ agent_id: ns, results: [`${ns} stored`] }));
+  const restored = JSON.parse(restoreResponseAgentId(body, ns, 'playground-demo').toString());
+  assert.equal(restored.agent_id, 'playground-demo');
+  assert.equal(restored.results[0], 'playground-demo stored'); // every occurrence swapped
+  // unrelated body untouched
+  const plain = Buffer.from('{"ok":true}');
+  assert.equal(restoreResponseAgentId(plain, ns, 'playground-demo').toString(), '{"ok":true}');
+});
+
+// ---------------------------------------------------------------------------
+// integration: cross-session isolation end-to-end (DAK-6757 acceptance)
+// ---------------------------------------------------------------------------
+
+// Stateful mock engine: a per-agent_id memory store, mirroring how the real
+// engine isolates by agent_id. Lets us prove a session cannot read another's.
+function memoryEngine() {
+  const byAgent = new Map();
+  return (req, res, captured) => {
+    let parsed = {};
+    try {
+      parsed = JSON.parse(captured[captured.length - 1].body);
+    } catch {
+      /* ignore */
+    }
+    const agent = parsed.agent_id || 'default';
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    if (req.url.includes('/store')) {
+      const arr = byAgent.get(agent) || [];
+      arr.push(parsed.content);
+      byAgent.set(agent, arr);
+      res.end(JSON.stringify({ ok: true, agent_id: agent }));
+    } else if (req.url.includes('/recall')) {
+      res.end(JSON.stringify({ agent_id: agent, results: byAgent.get(agent) || [] }));
+    } else {
+      res.end(JSON.stringify({ agent_id: agent }));
+    }
+  };
+}
+
+function storeReq(port, session, content) {
+  return request(port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: 'playground-demo', content }),
+  });
+}
+
+function recallReq(port, session, query) {
+  return request(port, {
+    method: 'POST',
+    path: '/v1/memory/recall',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: 'playground-demo', query }),
+  });
+}
+
+test('a fresh session cannot recall another session PII (DAK-6757 AC#1)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
+  await storeReq(p.port, 'pg_sessionAAA1', 'Alice Chen is a software engineer');
+  await storeReq(p.port, 'pg_sessionBBB1', 'SECRET bank account 1234-5678-9012');
+
+  // Session C — brand new — tries to recall the bank account.
+  const c = await recallReq(p.port, 'pg_sessionCCC1', 'bank account');
+  const cj = JSON.parse(c.body);
+  assert.deepEqual(cj.results, []); // isolated — sees nothing from A or B
+  assert.equal(cj.agent_id, 'playground-demo'); // response restored, no namespace leak
+
+  // Session B can still recall its OWN memory (deterministic namespace).
+  const b = await recallReq(p.port, 'pg_sessionBBB1', 'bank account');
+  assert.deepEqual(JSON.parse(b.body).results, ['SECRET bank account 1234-5678-9012']);
+  await p.close();
+});
+
+test('agent_id is namespaced per session before forwarding (DAK-6757)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 });
+  await storeReq(p.port, 'pg_nsOne0001', 'hello one');
+  await storeReq(p.port, 'pg_nsTwo0002', 'hello two');
+  const a1 = JSON.parse(p.upstream.captured[0].body).agent_id;
+  const a2 = JSON.parse(p.upstream.captured[1].body).agent_id;
+  assert.notEqual(a1, 'playground-demo'); // client value never reaches the engine verbatim
+  assert.ok(a1.startsWith('playground-demo-'));
+  assert.notEqual(a1, a2); // distinct sessions -> distinct engine namespaces
+  await p.close();
+});
+
+test('header-less clients are isolated by IP bucket namespace (DAK-6757)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
+  // No X-Playground-Session header -> falls back to ip: bucket; still namespaced.
+  const store = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent_id: 'playground-demo', content: 'ip-bucket secret' }),
+  });
+  assert.equal(store.status, 200);
+  const seen = JSON.parse(p.upstream.captured[0].body).agent_id;
+  assert.ok(seen.startsWith('playground-demo-'));
+  assert.notEqual(seen, 'playground-demo');
+  await p.close();
+});
+
+test('batch store namespaces every item against the session (DAK-6757)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000, memoryCapPerSession: 50 });
+  const ns = sessionNamespace('pg_batchns01');
+  const res = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memories/store/batch',
+    headers: { 'content-type': 'application/json', 'x-playground-session': 'pg_batchns01' },
+    body: JSON.stringify({ agent_id: 'playground-demo', memories: [{ agent_id: 'playground-demo', content: 'a' }, { content: 'b' }] }),
+  });
+  assert.equal(res.status, 200);
+  const body = JSON.parse(p.upstream.captured[0].body);
+  assert.equal(body.agent_id, ns);
+  assert.equal(body.memories[0].agent_id, ns); // per-item agent_id rewritten too
   await p.close();
 });

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -4,6 +4,7 @@ const http = require('http');
 const { URL } = require('url');
 const { isAllowed, storeKind } = require('./allowlist');
 const { SessionStore } = require('./sessions');
+const { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId } = require('./namespace');
 
 // =============================================================================
 // Dakera Playground Sandbox Proxy (DAK-6713)
@@ -119,7 +120,7 @@ function countMemories(kind, body) {
   }
 }
 
-function forward(config, req, res, path, bodyBuf, baseHeaders) {
+function forward(config, req, res, path, bodyBuf, baseHeaders, rewrite) {
   const upstream = new URL(config.upstreamUrl + path);
   const headers = {};
   for (const [k, v] of Object.entries(req.headers)) {
@@ -127,6 +128,9 @@ function forward(config, req, res, path, bodyBuf, baseHeaders) {
     if (HOP_BY_HOP.has(lk)) continue;
     if (lk === 'authorization' || lk === 'x-api-key') continue; // strip client creds
     if (lk === 'host' || lk === 'content-length') continue;
+    // When restoring agent_id in the response we must read a plaintext body, so
+    // ask the engine not to compress it (DAK-6757).
+    if (rewrite && lk === 'accept-encoding') continue;
     headers[k] = v;
   }
   headers['host'] = upstream.host;
@@ -151,8 +155,33 @@ function forward(config, req, res, path, bodyBuf, baseHeaders) {
         if (HOP_BY_HOP.has(k.toLowerCase())) continue;
         outHeaders[k] = v;
       }
-      res.writeHead(upRes.statusCode || 502, outHeaders);
-      upRes.pipe(res);
+
+      // Fast path: no agent_id was injected — stream straight through.
+      if (!rewrite) {
+        res.writeHead(upRes.statusCode || 502, outHeaders);
+        upRes.pipe(res);
+        return;
+      }
+
+      // Namespaced request: buffer the response so we can restore the client's
+      // original agent_id before returning it (DAK-6757). Sandbox payloads are
+      // small, so buffering here is cheap.
+      const chunks = [];
+      upRes.on('data', (c) => chunks.push(c));
+      upRes.on('end', () => {
+        const buf = restoreResponseAgentId(Buffer.concat(chunks), rewrite.namespace, rewrite.restoreTo);
+        outHeaders['content-length'] = String(buf.length);
+        delete outHeaders['transfer-encoding'];
+        res.writeHead(upRes.statusCode || 502, outHeaders);
+        res.end(buf);
+      });
+      upRes.on('error', () => {
+        if (!res.headersSent) {
+          sendJson(res, 502, { error: 'upstream_error', message: 'Could not reach the engine.' }, baseHeaders);
+        } else {
+          res.destroy();
+        }
+      });
     },
   );
 
@@ -296,6 +325,20 @@ function createServer(config, store) {
       'X-Sandbox-Rate-Remaining': String(rate.remaining),
     };
 
+    // Per-session namespace isolation (DAK-6757): rewrite the request body's
+    // agent_id to this session's private namespace so no session can recall
+    // another session's memories. The original agent_id is restored in the
+    // response so the client sees no change.
+    let rewrite = null;
+    if (bodyBuf && bodyBuf.length) {
+      const namespace = sessionNamespace(resolved.id);
+      const rewritten = rewriteRequestAgentId(bodyBuf, namespace);
+      if (rewritten.clientAgentId !== null) {
+        bodyBuf = rewritten.body;
+        rewrite = { namespace, restoreTo: rewritten.clientAgentId };
+      }
+    }
+
     // Commit the memory count when the engine confirms success (2xx).
     if (storeCount > 0) {
       const origWriteHead = res.writeHead.bind(res);
@@ -305,7 +348,7 @@ function createServer(config, store) {
       };
     }
 
-    forward(config, req, res, path, bodyBuf, outHeaders);
+    forward(config, req, res, path, bodyBuf, outHeaders, rewrite);
   });
 }
 


### PR DESCRIPTION
## Summary

**SECURITY CRITICAL** — fixes cross-session PII leakage in the playground sandbox proxy, found by QA E2E testing ([DAK-6753](https://github.com/dakera-ai/dakera) → DAK-6757).

All playground sessions authenticate to the engine as the same `playground-demo` agent_id. The proxy enforced per-session rate/memory/TTL limits but **never namespaced agent_id**, so any session could recall every other session's stored memories.

### Reproduction (before this PR)
1. Session A stores `{"agent_id":"playground-demo","content":"Alice Chen is a software engineer"}`
2. Session B stores `{"agent_id":"playground-demo","content":"SECRET: bank account 1234-5678-9012"}`
3. Session C (brand new) recalls `{"agent_id":"playground-demo","query":"bank account"}` → **returns Session B's PII**

## Fix

New `docker/playground/proxy/namespace.js`, wired into `server.js`:

- **Request:** rewrite every `agent_id` in the forwarded JSON body (top-level + nested batch items) to `playground-demo-<sha256(sessionId)[:12]>`. An omitted `agent_id` is *forced* to the namespace so it can never fall back to the shared default. The namespace is deterministic, so a session always recalls its own stores.
- **Response:** the engine response is buffered and the namespace is swapped back to the client's original `agent_id` — isolation is invisible to the frontend. `accept-encoding` is dropped on namespaced requests so the response body is plaintext-rewritable.
- **Header-less clients** are isolated by their IP-bucket session key.

## Acceptance criteria
- [x] Session C cannot see memories stored by Session A or B
- [x] All 5 scenario flows still work with namespaced agent_id (transparent rewrite)
- [x] Proxy tests cover cross-session isolation
- [x] No client-visible change to the agent_id format in responses

## Tests
`node --test` → **29 pass / 0 fail** (was 20; +9 new). Includes an end-to-end test with a stateful mock engine proving a fresh session recalls nothing from A/B while each session still recalls its own data, plus unit coverage for `sessionNamespace` / `rewriteRequestAgentId` / `restoreResponseAgentId`, per-session namespacing on the wire, header-less isolation, and batch-item namespacing.

```
# tests 29
# pass 29
# fail 0
```

## Classification
`type:ci-infra` — Node.js stdlib proxy, **no bench required**. CI runs `node -c` syntax check + `node --test`.

## Rollback
`git revert` + redeploy. Reverting restores the prior (vulnerable) shared-namespace behavior, so revert only with a follow-up fix.

## Note (out of scope, pre-existing)
The proxy currently drops query strings when forwarding (`forward()` rebuilds the URL from pathname only). GET endpoints that carry `agent_id` as a query param therefore don't forward it today — unrelated to this body-based leak. Flagging for a separate follow-up if those GET scenarios need query passthrough.

---
Created by: 🤖 Core Engine (automated)