### PR TITLE
fix(playground): correct proxy allowlist HTTP methods — scenarios 4 & 5 (DAK-6758)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -35,19 +35,28 @@ const ALLOW = [
   compile('POST', '/v1/memories/recall/batch'),
   compile('POST', '/v1/memory/search'),
   compile('GET', '/v1/memory/get/{seg}'),
-  compile('GET', '/v1/memory/importance'),
+  // Scenario 5 (memory decay): importance update is a POST in the engine
+  // (lib.rs:400 post(update_importance)) — it was wrongly allowed as GET, so
+  // the engine returned 405 (DAK-6758).
+  compile('POST', '/v1/memory/importance'),
 
   // --- routing demo (read-only classifier) ---
   compile('POST', '/v1/route'),
 
   // --- knowledge graph scenario (read-only) ---
-  compile('POST', '/v1/knowledge/query'),
-  compile('GET', '/v1/knowledge/graph'),
+  // KG-2 query + path traversal are GET routes in the engine
+  // (lib.rs:455-456 get(kg_query) / get(kg_path)) — they were wrongly allowed
+  // as POST, so the proxy 403'd query and the engine 405'd path (DAK-6758).
+  compile('GET', '/v1/knowledge/query'),
+  compile('GET', '/v1/knowledge/path'),
+  // /v1/knowledge/graph is POST-only in the engine (lib.rs:483 post). The dead
+  // GET entry was removed (it could only ever 405).
   compile('POST', '/v1/knowledge/graph'),
-  compile('POST', '/v1/knowledge/path'),
   compile('GET', '/v1/memories/{seg}/graph'),
-  compile('GET', '/v1/memories/{seg}/links'),
   compile('GET', '/v1/memories/{seg}/path'),
+  // NOTE: /v1/memories/{seg}/links is POST-only in the engine (link creation,
+  // lib.rs:449). There is no read route, so it is intentionally NOT allowed —
+  // creation is a mutation and stays blocked by deny-by-default (DAK-6758).
 ];
 
 // Endpoints that store one or more memories — used to apply the memory cap.

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -91,8 +91,29 @@ test('allow-list permits sandbox-safe endpoints', () => {
   assert.ok(isAllowed('POST', '/v1/memory/recall'));
   assert.ok(isAllowed('POST', '/v1/memory/search'));
   assert.ok(isAllowed('GET', '/v1/memory/get/mem_123'));
-  assert.ok(isAllowed('POST', '/v1/knowledge/query'));
+  assert.ok(isAllowed('GET', '/v1/knowledge/query'));
   assert.ok(isAllowed('GET', '/v1/memories/mem_9/graph'));
+});
+
+// DAK-6758: the allow-list methods must match the engine route table
+// (crates/api/src/lib.rs), or the proxy 403s (wrong proxy method) or the engine
+// 405s (wrong engine method) — breaking playground scenarios 4 and 5.
+test('allow-list methods match engine routes (DAK-6758)', () => {
+  // Scenario 4 knowledge query + path: engine has GET (lib.rs:455-456).
+  assert.ok(isAllowed('GET', '/v1/knowledge/query'));
+  assert.ok(isAllowed('GET', '/v1/knowledge/path'));
+  assert.ok(!isAllowed('POST', '/v1/knowledge/query')); // old wrong method 403'd
+  assert.ok(!isAllowed('POST', '/v1/knowledge/path'));
+  // Scenario 5 memory decay: engine has POST (lib.rs:400).
+  assert.ok(isAllowed('POST', '/v1/memory/importance'));
+  assert.ok(!isAllowed('GET', '/v1/memory/importance')); // old wrong method 405'd
+  // knowledge/graph is POST-only in the engine (lib.rs:483); GET was dead.
+  assert.ok(isAllowed('POST', '/v1/knowledge/graph'));
+  assert.ok(!isAllowed('GET', '/v1/knowledge/graph'));
+  // {id}/links is POST-only link creation (a mutation) — no read route exists,
+  // so it must stay blocked by deny-by-default.
+  assert.ok(!isAllowed('GET', '/v1/memories/mem_1/links'));
+  assert.ok(!isAllowed('POST', '/v1/memories/mem_1/links'));
 });
 
 test('allow-list denies admin/delete/bulk/forget by default', () => {
@@ -311,6 +332,33 @@ test('non-2xx store response does not consume the memory cap', async () => {
   // cap not consumed → a second (succeeding shape) request still allowed by cap
   const sess = p.store.resolve('pg_failtest', '127.0.0.1').session;
   assert.equal(sess.memoryCount, 0);
+  await p.close();
+});
+
+// DAK-6758: the remaining sandbox memory budget must be surfaced on every store
+// response (success too), not only on the cap-exceeded 403, so the playground UI
+// can show usage during normal stores.
+test('successful store returns X-Sandbox-Memory-Remaining (DAK-6758)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000, memoryCapPerSession: 50 });
+  const headers = { 'content-type': 'application/json', 'x-playground-session': 'pg_remaintest' };
+  const r1 = await request(p.port, { method: 'POST', path: '/v1/memory/store', headers, body: JSON.stringify({ content: 'a' }) });
+  assert.equal(r1.status, 200);
+  assert.equal(r1.headers['x-sandbox-memory-remaining'], '49'); // 50 - 1 committed
+  const r2 = await request(p.port, { method: 'POST', path: '/v1/memories/store/batch', headers, body: JSON.stringify({ memories: [1, 2, 3] }) });
+  assert.equal(r2.status, 200);
+  assert.equal(r2.headers['x-sandbox-memory-remaining'], '46'); // 49 - 3 committed
+  await p.close();
+});
+
+test('failed store reports unchanged X-Sandbox-Memory-Remaining (DAK-6758)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000, memoryCapPerSession: 10 }, (req, res) => {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'bad' }));
+  });
+  const headers = { 'content-type': 'application/json', 'x-playground-session': 'pg_remainfail' };
+  const r = await request(p.port, { method: 'POST', path: '/v1/memory/store', headers, body: '{}' });
+  assert.equal(r.status, 400);
+  assert.equal(r.headers['x-sandbox-memory-remaining'], '10'); // nothing stored → budget intact
   await p.close();
 });
 

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -302,9 +302,11 @@ function createServer(config, store) {
     // req #2: memory cap (pre-check before forwarding so we never store past it).
     const kind = storeKind(method, path);
     let storeCount = 0;
+    let memRemainingBefore = 0; // sandbox memory budget available before this store
     if (kind !== 'none') {
       storeCount = countMemories(kind, bodyBuf);
       const cap = store.checkMemoryCap(resolved.session, storeCount);
+      memRemainingBefore = cap.remaining;
       if (!cap.ok) {
         sendJson(
           res,
@@ -339,11 +341,23 @@ function createServer(config, store) {
       }
     }
 
-    // Commit the memory count when the engine confirms success (2xx).
+    // Commit the memory count when the engine confirms success (2xx) and surface
+    // the remaining sandbox memory budget on EVERY store response (DAK-6758), not
+    // just on cap-exceeded 403s — so the playground UI can show usage during
+    // normal use. On success the budget reflects the just-committed memories; on
+    // a non-2xx response nothing was stored, so the budget is unchanged.
     if (storeCount > 0) {
       const origWriteHead = res.writeHead.bind(res);
       res.writeHead = (status, ...rest) => {
-        if (status >= 200 && status < 300) store.commitMemory(resolved.session, storeCount);
+        let remaining = memRemainingBefore;
+        if (status >= 200 && status < 300) {
+          store.commitMemory(resolved.session, storeCount);
+          remaining = memRemainingBefore - storeCount;
+        }
+        const headers = rest.length && rest[rest.length - 1] && typeof rest[rest.length - 1] === 'object'
+          ? rest[rest.length - 1]
+          : null;
+        if (headers) headers['X-Sandbox-Memory-Remaining'] = String(Math.max(0, remaining));
         return origWriteHead(status, ...rest);
       };
     }


### PR DESCRIPTION
## Summary

QA E2E testing (DAK-6753) found the playground sandbox proxy allowlist (`docker/playground/proxy/allowlist.js`) had HTTP methods that don't match the engine route table (`crates/api/src/lib.rs`), breaking two playground scenarios. Verified each route against lib.rs in this session (anti-hallucination):

| Route | Was | Now | Engine (lib.rs) | Symptom fixed |
|---|---|---|---|---|
| `/v1/knowledge/query` | POST | **GET** | `get(kg_query)` :455 | proxy 403 → 200 |
| `/v1/knowledge/path` | POST | **GET** | `get(kg_path)` :456 | engine 405 → 200 |
| `/v1/memory/importance` | GET | **POST** | `post(update_importance)` :400 | engine 405 → 200 |
| `/v1/knowledge/graph` | GET+POST | **POST** only | `post(knowledge_graph)` :483 | dead GET entry removed (could only 405) |
| `/v1/memories/{id}/links` | GET | **removed** | `post(create_link)` :449 only | no read route exists; stays deny-by-default |

Also: `X-Sandbox-Memory-Remaining` was only returned on the cap-exceeded 403. It now appears on **every** store response (success included) so the playground UI can show remaining budget during normal use. On 2xx the value reflects the just-committed memories; on a non-2xx response nothing was stored so the budget is reported unchanged.

## Classification
`type:fix` — playground deploy/proxy bug fix. No engine recall/ranking touched → **no bench required**.

## Acceptance Criteria
- [x] Scenario 5 (Memory Decay): `POST /v1/memory/importance` now allowed (was GET→405)
- [x] Scenario 4 knowledge query: `GET /v1/knowledge/query` now allowed (was POST→403)
- [x] `X-Sandbox-Memory-Remaining` returned on all store responses
- [x] Proxy CI (`proxy.test.js`) updated to cover these routes

## Local validation
```
node -c allowlist.js server.js proxy.test.js   # OK
node --test                                     # 32/32 pass (was 29; +3)
```
New tests: `allow-list methods match engine routes (DAK-6758)`, `successful store returns X-Sandbox-Memory-Remaining (DAK-6758)`, `failed store reports unchanged X-Sandbox-Memory-Remaining (DAK-6758)`.

## Rollback
`git revert` + redeploy playground proxy container.

---
Created by: 🤖 Core Engine (automated)