### PR TITLE
fix(playground): add POST /v1/memories/:id/links to proxy allowlist (DAK-6776)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -54,9 +54,10 @@ const ALLOW = [
   compile('POST', '/v1/knowledge/graph'),
   compile('GET', '/v1/memories/{seg}/graph'),
   compile('GET', '/v1/memories/{seg}/path'),
-  // NOTE: /v1/memories/{seg}/links is POST-only in the engine (link creation,
-  // lib.rs:449). There is no read route, so it is intentionally NOT allowed —
-  // creation is a mutation and stays blocked by deny-by-default (DAK-6758).
+  // KG link creation — POST-only in the engine (lib.rs:449 post(memory_link)).
+  // Required by all SDK quickstarts: py client.memory_link(), js memoryLink(),
+  // go MemoryLink(), rs memory_link() (DAK-6776).
+  compile('POST', '/v1/memories/{seg}/links'),
 ];
 
 // Endpoints that store one or more memories — used to apply the memory cap.

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -110,10 +110,10 @@ test('allow-list methods match engine routes (DAK-6758)', () => {
   // knowledge/graph is POST-only in the engine (lib.rs:483); GET was dead.
   assert.ok(isAllowed('POST', '/v1/knowledge/graph'));
   assert.ok(!isAllowed('GET', '/v1/knowledge/graph'));
-  // {id}/links is POST-only link creation (a mutation) — no read route exists,
-  // so it must stay blocked by deny-by-default.
+  // {id}/links: POST-only link creation (lib.rs:449). GET stays blocked (no
+  // read route). POST is now allowed — required by all SDK quickstarts (DAK-6776).
   assert.ok(!isAllowed('GET', '/v1/memories/mem_1/links'));
-  assert.ok(!isAllowed('POST', '/v1/memories/mem_1/links'));
+  assert.ok(isAllowed('POST', '/v1/memories/mem_1/links'));
 });
 
 test('allow-list denies admin/delete/bulk/forget by default', () => {


### PR DESCRIPTION
## Problem

`POST /v1/memories/{id}/links` (KG link creation) was not in the sandbox proxy allowlist. All four SDK quickstarts fail at this step:

```
{"error":"forbidden_endpoint","message":"This endpoint is not available in the public sandbox: POST /v1/memories/mem_test/links"}
```

Affected SDKs (DAK-6774 smoke test):
- **Python**: `client.memory_link()` → 403
- **JS**: `client.memoryLink()` → 403
- **Go**: `client.MemoryLink()` → 403
- **Rust**: `client.memory_link()` → 403

## Root Cause

During the DAK-6758 allowlist method audit, this endpoint was noted as "a mutation — intentionally blocked." That was correct for pure safety auditing but missed that the KG quickstart scenario explicitly calls this endpoint. DAK-6776 overrides that decision.

## Fix

Two files changed:

**`allowlist.js`** — replace the "intentionally NOT allowed" NOTE with an actual `compile('POST', '/v1/memories/{seg}/links')` entry.  
**`proxy.test.js`** — flip the DAK-6758 test assertion for this endpoint from `!isAllowed(POST)` → `isAllowed(POST)`. GET stays blocked (no read route in the engine).

## Verification

```
node --test   # 32/32 pass
```

## Secondary findings from DAK-6776 / DAK-6774

These are tracked separately and do NOT block this PR:

1. **Shared namespace contamination** (DAK-6776 note 1) — already fixed by DAK-6757 (session-scoped namespacing via `namespace.js`). No action needed here.
2. **Python search empty content** (DAK-6776 note 2) — nested-envelope mismatch in the Python client. Separate SDK bug, not a proxy issue.

## Type

`type:fix` — proxy allowlist only, no engine changes, no bench required.