### PR TITLE
security(playground): mint unique pg_xxx session for ALL clients — fix cross-session PII leak (DAK-6783)

### DIFF
--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -492,19 +492,58 @@ test('agent_id is namespaced per session before forwarding (DAK-6757)', async ()
   await p.close();
 });
 
-test('header-less clients are isolated by IP bucket namespace (DAK-6757)', async () => {
+test('header-less clients get a fresh pg_xxx session and unique namespace (DAK-6757/DAK-6783)', async () => {
   const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
-  // No X-Playground-Session header -> falls back to ip: bucket; still namespaced.
+  // No X-Playground-Session header -> proxy mints a new pg_xxx session ID and
+  // returns it via X-Playground-Session so the client can reuse it.
   const store = await request(p.port, {
     method: 'POST',
     path: '/v1/memory/store',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ agent_id: 'playground-demo', content: 'ip-bucket secret' }),
+    body: JSON.stringify({ agent_id: 'playground-demo', content: 'session-less secret' }),
   });
   assert.equal(store.status, 200);
+  // Proxy should return a pg_xxx session ID in the response header.
+  const mintedSession = store.headers['x-playground-session'];
+  assert.ok(mintedSession, 'proxy must return X-Playground-Session for header-less clients');
+  assert.ok(/^pg_[A-Za-z0-9_-]{8,}$/.test(mintedSession), `minted session must match pg_xxx format, got: ${mintedSession}`);
+  // Forwarded body must use the unique namespace for this session.
   const seen = JSON.parse(p.upstream.captured[0].body).agent_id;
   assert.ok(seen.startsWith('playground-demo-'));
   assert.notEqual(seen, 'playground-demo');
+  await p.close();
+});
+
+test('two clients without session headers get different namespaces (DAK-6783 cross-session isolation)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
+
+  // Client A stores a secret (no session header).
+  const storeA = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent_id: 'playground-demo', content: 'client-A-secret' }),
+  });
+  assert.equal(storeA.status, 200);
+  const sessionA = storeA.headers['x-playground-session'];
+  const nsA = JSON.parse(p.upstream.captured[0].body).agent_id;
+
+  // Client B (no session header either) stores something.
+  const storeB = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent_id: 'playground-demo', content: 'client-B-secret' }),
+  });
+  assert.equal(storeB.status, 200);
+  const sessionB = storeB.headers['x-playground-session'];
+  const nsB = JSON.parse(p.upstream.captured[1].body).agent_id;
+
+  // Each client must have received a DIFFERENT session ID and namespace.
+  assert.notEqual(sessionA, sessionB, 'each client must get a unique session ID');
+  assert.notEqual(nsA, nsB, 'each client must get a unique engine namespace');
+  assert.ok(nsA.startsWith('playground-demo-'));
+  assert.ok(nsB.startsWith('playground-demo-'));
   await p.close();
 });
 

--- a/docker/playground/proxy/sessions.js
+++ b/docker/playground/proxy/sessions.js
@@ -6,9 +6,11 @@ const crypto = require('crypto');
 // Sandbox session store (DAK-6713 req #1, #2, #3) — in-memory, TTL-bounded.
 // =============================================================================
 // A session is identified by the `X-Playground-Session` header. When a client
-// does not present a valid one, requests fall back to an IP-keyed bucket so the
-// caps still apply (a header-less client cannot escape them). A per-IP cap on
-// the number of live sessions bounds header-rotation abuse.
+// does not present a valid one (no header or non-pg_ value), a fresh pg_xxx
+// session is minted and returned via X-Playground-Session so the client can
+// reuse it on subsequent requests. This guarantees every client gets a unique
+// namespace for memory isolation (DAK-6757/DAK-6783). A per-IP cap on the
+// number of live sessions bounds header-rotation abuse.
 //
 // All time is injected via a `now()` clock so the logic is deterministic under
 // test.
@@ -51,6 +53,9 @@ class SessionStore {
   resolve(headerValue, ip) {
     const hdr = typeof headerValue === 'string' ? headerValue.trim() : '';
     const provided = SESSION_RE.test(hdr);
+    // For clients with a valid pg_xxx header, use it as the key.
+    // For clients without a valid header, look up any existing legacy ip:-keyed
+    // session so in-flight requests aren't orphaned (DAK-6783).
     const key = provided ? hdr : `ip:${ip || 'unknown'}`;
 
     let s = this.sessions.get(key);
@@ -70,10 +75,18 @@ class SessionStore {
           message: `Too many active sandbox sessions from this address (max ${this.maxSessionsPerIp}). Try again later.`,
         };
       }
+      // Mint a fresh pg_xxx session ID for new sessions — both for clients that
+      // provided no header AND for IP-fallback clients. Returning a pg_xxx ID
+      // via X-Playground-Session lets the client reuse it on subsequent requests,
+      // giving every client a unique engine namespace (DAK-6757/DAK-6783).
+      const mintedId = provided ? hdr : newSessionId();
       s = { createdAt: this.now(), calls: [], memoryCount: 0, ip: ip || 'unknown', generated: !provided };
-      this.sessions.set(key, s);
+      this.sessions.set(mintedId, s);
+      return { ok: true, id: mintedId, generated: !provided, session: s };
     }
 
+    // Existing session: for pg_xxx clients return their key; for legacy ip:-keyed
+    // sessions return the key too (they expire within 30 min and get pg_xxx after).
     return { ok: true, id: provided ? hdr : key, generated: !provided, session: s };
   }
 


### PR DESCRIPTION
## Security Fix — Cross-Session PII Leak (DAK-6783)

### Root Cause

The DAK-6757 namespace fix (`namespace.js`) is deployed and working correctly for clients that send valid `pg_xxx` session IDs. **However**, when a client sends no `X-Playground-Session` header (or an invalid format like `iso-A-...`), the proxy fell back to an `ip:<ip>` bucket key — giving **all clients from the same IP the same engine namespace**.

The playground frontend never generates `pg_xxx` IDs itself — it reads `X-Playground-Session` from the **response header** and saves it to `sessionStorage`. Before this fix, the response contained `ip:1.2.3.4` (not a `pg_xxx` value), so all subsequent requests also failed the `SESSION_RE` check and stayed in the shared IP bucket.

**Proof**: Session B (same IP as A, no session header) recalled Session A's exact memory at score 14.5.

### Fix

In `sessions.js`, when creating a NEW session for a header-less client, mint a fresh `pg_xxx` session ID via `newSessionId()` instead of using `ip:<ip>`. The minted ID is returned via `X-Playground-Session` so the client saves it and sends it on subsequent requests — giving every client their own unique engine namespace.

```
Before: first request (no header) → key = "ip:1.2.3.4" → namespace shared across all same-IP clients
After:  first request (no header) → key = "pg_abc123..." → unique namespace per client ✓
```

### Backward Compatibility

- Existing `pg_xxx` sessions: unchanged
- Legacy `ip:<ip>` sessions: continue working until 30-min TTL expiry, then get proper `pg_xxx` on next request
- Per-IP session cap (`maxSessionsPerIp=20`): still enforced via `_liveSessionsForIp`

### Tests

- Updated: `header-less clients` test — now verifies `pg_xxx` format returned in `X-Playground-Session` header
- Added: `two clients without session headers get different namespaces (DAK-6783)` — explicit cross-session isolation test
- All **33 tests pass** (`node --test proxy.test.js`)

### Deploy

This is type:security — fast-track deploy required. After CTO merge, Platform will:
1. SCP updated `sessions.js` to playground server
2. `docker compose up -d --build --no-deps sandbox-proxy`
3. Re-run cross-session isolation test to confirm leak is closed

## Test plan
- [x] `node --test proxy.test.js` → 33/33 pass
- [x] PR #32 (new cross-session test) passes
- [ ] Live cross-session isolation test post-deploy: Session B MUST NOT recall Session A's memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)