### PR TITLE
security(DAK-6790): remove hardcoded secrets, IPs, and weak defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Validate docker-compose.yml
         env:
           DAKERA_ROOT_API_KEY: ci-validation-placeholder
+          GRAFANA_PASSWORD: ci-validation-placeholder
         run: docker compose -f docker/docker-compose.yml config --quiet
 
       - name: Validate docker-compose.dev.yml

--- a/.github/workflows/hetzner-server-manage.yml
+++ b/.github/workflows/hetzner-server-manage.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: "hetzner-runner-x64"
       target_server_ip:
-        description: "Target server IP (for resize — e.g. 178.104.227.173)"
+        description: "Target server IP (for resize)"
         required: false
         default: ""
       server_type:

--- a/.github/workflows/playground-monitor-deploy.yml
+++ b/.github/workflows/playground-monitor-deploy.yml
@@ -5,7 +5,7 @@ on:
       playground_ip:
         description: "Playground server IP"
         required: false
-        default: "5.75.177.31"
+        default: ""
   push:
     branches: [main]
     paths:
@@ -18,7 +18,7 @@ jobs:
     name: Deploy Monitor to Playground
     runs-on: ubuntu-latest
     env:
-      PLAYGROUND_IP: ${{ github.event.inputs.playground_ip || '5.75.177.31' }}
+      PLAYGROUND_IP: ${{ github.event.inputs.playground_ip || secrets.PLAYGROUND_IP }}
     steps:
       - uses: actions/checkout@v4
 
@@ -74,7 +74,7 @@ jobs:
             ICON="❌"
             MSG="Playground monitor deploy FAILED. Manual installation needed."
           fi
-          printf '{"chat_id":"%s","text":"%s *[Platform] Playground Monitor*\\n\\nIP: %s\\nStatus: %s\\nDAK-6745\\n\\n%s"}' \
-            "1170826474" "$ICON" "$PLAYGROUND_IP" "$STATUS" "$MSG" | \
-          curl -sf -X POST "https://api.telegram.org/bot8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc/sendMessage" \
+          printf '{"chat_id":"%s","text":"%s *[Platform] Playground Monitor*\\n\\nStatus: %s\\n\\n%s"}' \
+            "${{ secrets.TELEGRAM_CHAT_ID }}" "$ICON" "$STATUS" "$MSG" | \
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -H "Content-Type: application/json" -d @- > /dev/null || true

--- a/.github/workflows/playground-ssl.yml
+++ b/.github/workflows/playground-ssl.yml
@@ -1,7 +1,7 @@
 name: Playground - Enable SSL (Let's Encrypt)
 
-# Run after playground.dakera.ai A record is added to Cloudflare DNS
-# pointing to 5.75.177.31. This workflow SSHs to the server and runs certbot.
+# Run after playground.dakera.ai A record is added to Cloudflare DNS.
+# This workflow SSHs to the server and runs certbot.
 # One-shot: safe to re-run if cert expires or needs renewal.
 
 on:
@@ -14,7 +14,7 @@ on:
       server_ip:
         description: "Playground server IP"
         required: false
-        default: "5.75.177.31"
+        default: ""
 
 jobs:
   ssl:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOMAIN: ${{ inputs.domain || 'playground.dakera.ai' }}
-      SERVER_IP: ${{ inputs.server_ip || '5.75.177.31' }}
+      SERVER_IP: ${{ inputs.server_ip || secrets.PLAYGROUND_IP }}
 
     steps:
       - name: Setup SSH

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -313,7 +313,7 @@ services:
       - "${HA_GRAFANA_PORT:-3203}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-dakera}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana-data:/var/lib/grafana

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       - "${GRAFANA_PORT:-3003}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-dakera}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/json/dakera-overview.json

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "${GRAFANA_PORT:-3003}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-dakera}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/json/dakera-overview.json

--- a/scripts/namespace-cleanup/namespace-cleanup.sh
+++ b/scripts/namespace-cleanup/namespace-cleanup.sh
@@ -29,7 +29,7 @@
 
 set -euo pipefail
 
-DAKERA_API_URL="${DAKERA_API_URL:-http://178.104.45.161:3300}"
+DAKERA_API_URL="${DAKERA_API_URL:?DAKERA_API_URL must be set}"
 DAKERA_API_KEY="${DAKERA_API_KEY:?DAKERA_API_KEY must be set}"
 DRY_RUN="${DRY_RUN:-0}"
 

--- a/scripts/playground/install-monitor.sh
+++ b/scripts/playground/install-monitor.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # install-monitor.sh — installs playground-monitor on playground server via SSH
-# Usage: SSH_KEY=~/.ssh/id_ed25519 PLAYGROUND_IP=5.75.177.31 ./install-monitor.sh
+# Usage: SSH_KEY=~/.ssh/id_ed25519 PLAYGROUND_IP=<server-ip> ./install-monitor.sh
 # DAK-6745
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLAYGROUND_IP="${PLAYGROUND_IP:-5.75.177.31}"
+PLAYGROUND_IP="${PLAYGROUND_IP:?PLAYGROUND_IP must be set}"
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_ed25519}"
 SSH="ssh -i ${SSH_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=15 root@${PLAYGROUND_IP}"
 

--- a/scripts/playground/playground-monitor.service
+++ b/scripts/playground/playground-monitor.service
@@ -4,6 +4,7 @@ After=network.target docker.service
 
 [Service]
 Type=oneshot
+EnvironmentFile=/etc/dakera/telegram.env
 ExecStart=/usr/local/bin/playground-monitor.sh
 User=root
 StandardOutput=journal

--- a/scripts/playground/playground-monitor.sh
+++ b/scripts/playground/playground-monitor.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # playground-monitor.sh — DAK-6745
 # Monitors Dakera Playground health: HTTP endpoint, Docker containers, disk, memory.
-# Runs every 5min via systemd timer on playground server (5.75.177.31).
+# Runs every 5min via systemd timer on the playground server.
 # Alerts Telegram on failure with 5-min cooldown per check type.
 
 set -euo pipefail
 
-TELEGRAM_BOT_TOKEN="8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc"
-TELEGRAM_CHAT_ID="1170826474"
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}"
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:?TELEGRAM_CHAT_ID must be set}"
 STATE_DIR="/var/lib/playground-health"
-PLAYGROUND_URL="https://5-75-177-31.sslip.io/health"
+PLAYGROUND_URL="${PLAYGROUND_URL:-https://localhost/health}"
 DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Thresholds

--- a/scripts/runner/install.sh
+++ b/scripts/runner/install.sh
@@ -2,7 +2,7 @@
 # install.sh — Deploy runner health monitor and disk cleanup automation
 # DAK-5764: Platform reliability — deploy pipeline hardening + runner health automation
 #
-# Run on each GitHub Actions runner host (ARM: 168.119.60.30, x64: 178.104.227.173)
+# Run on each GitHub Actions runner host.
 # Requires: root, systemd, TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in environment
 
 set -euo pipefail

--- a/scripts/runner/runner-disk-cleanup.sh
+++ b/scripts/runner/runner-disk-cleanup.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-TELEGRAM_BOT_TOKEN="8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc"
-TELEGRAM_CHAT_ID="1170826474"
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}"
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:?TELEGRAM_CHAT_ID must be set}"
 LOG="/var/log/runner-disk-cleanup.log"
 HOSTNAME=$(hostname -s)
 DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/scripts/runner/runner-health-monitor.service
+++ b/scripts/runner/runner-health-monitor.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
+EnvironmentFile=/etc/dakera/telegram.env
 ExecStart=/usr/local/bin/runner-health-monitor.sh
 User=root
 StandardOutput=journal

--- a/scripts/runner/runner-health-monitor.sh
+++ b/scripts/runner/runner-health-monitor.sh
@@ -6,8 +6,8 @@
 
 set -euo pipefail
 
-TELEGRAM_BOT_TOKEN="8559576881:AAHBV3sZHL1KzJ_Lwwij00aalitnRpxP4uc"
-TELEGRAM_CHAT_ID="1170826474"
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}"
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:?TELEGRAM_CHAT_ID must be set}"
 STATE_DIR="/var/lib/runner-health"
 HOSTNAME=$(hostname -s)
 DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Summary
- Remove hardcoded Telegram bot token and chat ID from 3 scripts and 1 workflow (CRITICAL exposure in public repo)
- Replace hardcoded server IPs with GitHub Secrets references in all workflows and scripts
- Add `EnvironmentFile` to systemd services for secure credential injection
- Replace weak Grafana default password (`dakera`) with required env var
- Strip infrastructure IPs from code comments

## Findings (14 files, 9 findings)
| # | Severity | Issue | Files |
|---|----------|-------|-------|
| 1 | CRITICAL | Telegram bot token hardcoded | 3 scripts |
| 2 | CRITICAL | Telegram bot token in GH Actions | 1 workflow |
| 3 | HIGH | Chat ID (PII) exposed | Same 4 files |
| 4 | HIGH | Production server IP as default | namespace-cleanup.sh |
| 5 | HIGH | Playground IP hardcoded in workflows | 3 workflows + 2 scripts |
| 6 | HIGH | Runner IPs in comments | install.sh |
| 7 | MEDIUM | Weak Grafana default password | 3 compose files |

## Post-merge actions (REQUIRED)
1. **Revoke** the exposed Telegram bot token immediately via @BotFather
2. **Create** new bot token
3. **Set GitHub Secrets** on dakera-deploy repo: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `PLAYGROUND_IP`
4. **Create** `/etc/dakera/telegram.env` on each server (playground + both runners):
   ```
   TELEGRAM_BOT_TOKEN=<new-token>
   TELEGRAM_CHAT_ID=<chat-id>
   PLAYGROUND_URL=https://<playground-url>/health
   ```
5. **Set** `GRAFANA_PASSWORD` in production `.env` files
6. **Consider** running `git filter-repo` or BFG Repo-Cleaner to purge old token from git history

## Test plan
- [ ] Verify no hardcoded tokens remain: `grep -rn '8559576881' .`
- [ ] Verify no hardcoded IPs remain in scripts/workflows
- [ ] Verify systemd services reference EnvironmentFile
- [ ] After merge: verify playground-monitor still runs with env file
- [ ] After merge: verify runner-health-monitor still runs with env file