### PR TITLE
fix(ci): add Docker image readiness polling to deploy-production (DAK-6807)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,11 +33,16 @@ jobs:
       - name: Verify Docker image exists
         run: |
           echo "Checking ghcr.io/dakera-ai/dakera:${{ inputs.version }}..."
-          docker manifest inspect ghcr.io/dakera-ai/dakera:${{ inputs.version }} > /dev/null 2>&1 || {
-            echo "❌ Image ghcr.io/dakera-ai/dakera:${{ inputs.version }} not found in registry"
-            exit 1
-          }
-          echo "✅ Image exists"
+          for i in $(seq 1 10); do
+            if docker manifest inspect ghcr.io/dakera-ai/dakera:${{ inputs.version }} > /dev/null 2>&1; then
+              echo "✅ Image exists (attempt $i/10)"
+              exit 0
+            fi
+            echo "⏳ Attempt $i/10: image not yet available, waiting 60s (ARM build lag)..."
+            sleep 60
+          done
+          echo "❌ Image ghcr.io/dakera-ai/dakera:${{ inputs.version }} not found after 10 minutes"
+          exit 1
 
       - name: Checkout deploy config
         uses: actions/checkout@v6


### PR DESCRIPTION
## Root Cause

`deploy-production.yml` is triggered by `release.yml` shortly after tagging. The ARM Docker build takes ~36min to complete and push to GHCR. When the deploy workflow ran at 18:23Z for v0.11.91, the image wasn't available until 18:45Z — causing an immediate failure at the `Verify Docker image exists` step.

Failed run: https://github.com/Dakera-AI/dakera-deploy/actions/runs/27507942223

## Fix

Added a polling retry loop (10 attempts × 60s = 10-minute window) to the `Verify Docker image exists` step. Instead of failing immediately when the image isn't found, the step now waits and retries — covering the ARM build lag between release tag and GHCR push.

## What changed

`.github/workflows/deploy-production.yml` — `Verify Docker image exists` step:
- **Before**: single `docker manifest inspect` → fail immediately if image absent
- **After**: retry loop up to 10× with 60s sleep → fail only after 10 minutes

## Test plan

- [ ] CI green on this PR
- [ ] Next release deploy: `Verify Docker image exists` step should show `⏳ Attempt N/10...` messages if image not yet available, then `✅ Image exists (attempt N/10)` once ready

Parent EPIC: DAK-6587
Closes: DAK-6807

🤖 Generated with [Claude Code](https://claude.com/claude-code)