### PR TITLE
fix(ci): extend deploy image readiness poll 10→90 min (DAK-6833)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify Docker image exists
         run: |
           echo "Checking ghcr.io/dakera-ai/dakera:${{ inputs.version }}..."
-          for i in $(seq 1 10); do
+          for i in $(seq 1 90); do
             if docker manifest inspect ghcr.io/dakera-ai/dakera:${{ inputs.version }} > /dev/null 2>&1; then
               echo "✅ Image exists (attempt $i/10)"
               exit 0


### PR DESCRIPTION
## Problem

PR#200 added a retry loop to `Verify Docker image exists` but set it to `10×60s = 10 minutes`. ARM Docker builds measured at **30–106 minutes** (avg 49–64 min). A deploy triggered within the first 10 minutes of a release tag still fails.

Evidence from v0.11.91: released 18:09Z, deploy failed 18:23Z (14 min in). The 10-min retry exhausted before ARM build completed.

## Fix

`seq 1 10` → `seq 1 90` (90×60s = **90 minutes** of polling), covering worst-case ARM builds.

No behavior change when image is already available — exits on first iteration.

Related: PR#200 (original race condition fix)