### PR TITLE
feat(playground): LLM side-by-side comparison endpoint (DAK-6845)

### DIFF
--- a/docker/docker-compose.playground.yml
+++ b/docker/docker-compose.playground.yml
@@ -154,6 +154,10 @@ services:
       - SANDBOX_MAX_SESSIONS_PER_IP=${SANDBOX_MAX_SESSIONS_PER_IP:-20}
       - SANDBOX_MAX_BODY_BYTES=${SANDBOX_MAX_BODY_BYTES:-262144}
       - SANDBOX_ALLOWED_ORIGINS=${SANDBOX_ALLOWED_ORIGINS:-https://dakera.ai,https://www.dakera.ai,https://playground.dakera.ai}
+      # LLM side-by-side comparison (DAK-6845): OpenRouter free-model API key.
+      # Required for POST /v1/playground/llm-compare to function.
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - SANDBOX_LLM_RATE_LIMIT=${SANDBOX_LLM_RATE_LIMIT:-5}
     deploy:
       resources:
         limits:

--- a/docker/playground/proxy/config.js
+++ b/docker/playground/proxy/config.js
@@ -68,6 +68,11 @@ const config = {
   // How often to sweep expired sessions out of memory.
   sweepIntervalMs: intEnv('SANDBOX_SWEEP_INTERVAL_SEC', 60) * 1000,
 
+  // LLM comparison endpoint (DAK-6845) — OpenRouter free-model side-by-side.
+  openRouterApiKey: process.env.OPENROUTER_API_KEY || '',
+  llmCompareTimeoutMs: intEnv('LLM_COMPARE_TIMEOUT_SEC', 30) * 1000,
+  llmRateLimitPer10Min: intEnv('SANDBOX_LLM_RATE_LIMIT', 5),
+
   version: process.env.PROXY_VERSION || 'dak6713-1',
 };
 

--- a/docker/playground/proxy/index.js
+++ b/docker/playground/proxy/index.js
@@ -22,6 +22,7 @@ function main() {
     memoryCap: config.memoryCapPerSession,
     ttlMs: config.sessionTtlMs,
     maxSessionsPerIp: config.maxSessionsPerIp,
+    llmRateLimit: config.llmRateLimitPer10Min,
   });
 
   const sweep = setInterval(() => {

--- a/docker/playground/proxy/llm-compare.js
+++ b/docker/playground/proxy/llm-compare.js
@@ -1,0 +1,326 @@
+'use strict';
+
+// =============================================================================
+// LLM side-by-side comparison handler (DAK-6845)
+// =============================================================================
+// Implements POST /v1/playground/llm-compare: calls the same free OpenRouter
+// model twice in parallel — once with no context (raw question) and once with
+// relevant Dakera memories injected as a system prompt — so users can see what
+// memory-augmented AI looks like vs. a plain LLM.
+//
+// Internalfunctions are exported individually so unit tests can inject mocks
+// via the opts._callXxx pattern without patching require() globals.
+// =============================================================================
+
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+const { sessionNamespace } = require('./namespace');
+
+// Seed memories covering medical, engineering, legal, and financial domains.
+// Stored into the session namespace on the FIRST llm-compare call so that
+// "with memory" immediately shows a meaningful improvement over "without".
+const SEED_MEMORIES = [
+  // Medical
+  {
+    content:
+      'Patient John Smith (DOB: 1978-03-15) is currently taking Metformin 500mg twice daily and Lisinopril 10mg once daily for Type 2 diabetes and hypertension. Next review: 2026-09-01.',
+    importance: 0.9,
+  },
+  {
+    content:
+      'Patient Sarah Johnson has a documented penicillin allergy causing anaphylaxis. Alternative antibiotics on file: azithromycin or clindamycin. Allergy flagged across all records.',
+    importance: 0.9,
+  },
+  {
+    content:
+      "Dr. Martinez noted that patient Maria Garcia's HbA1c improved from 9.2% to 7.4% after switching to insulin glargine in January 2026. Follow-up: 2026-07-15.",
+    importance: 0.8,
+  },
+  // Engineering
+  {
+    content:
+      'The API gateway uses a Redis cluster with 3 nodes: primary at 10.0.1.50:6379, replicas at 10.0.1.51 and 10.0.1.52. Failover timeout 5 s, max connections per node: 500.',
+    importance: 0.85,
+  },
+  {
+    content:
+      'The deployment pipeline uses blue-green strategy. Health-check window: 10 minutes. Auto-rollback triggers if error rate exceeds 1% in the first 30 minutes post-deploy.',
+    importance: 0.85,
+  },
+  // Legal
+  {
+    content:
+      'Contract #2026-ACME-0042 with ACME Corp expires 2026-12-31. Terms: 90-day termination notice, $50,000 early-exit penalty, auto-renewal unless cancelled 60 days before expiry.',
+    importance: 0.9,
+  },
+  {
+    content:
+      'Rodriguez & Associates signed NDA on 2026-01-15 covering all product roadmap discussions and unreleased pricing. NDA expires 2029-01-15. Liquidated damages: $250,000.',
+    importance: 0.9,
+  },
+  // Financial
+  {
+    content:
+      'Q1 2026 budget: Engineering $2.4M, Marketing $800K, Sales $1.2M, Operations $600K. Total $5.0M approved. YTD burn as of March: $1.1M (22%). Q2 forecast: $1.4M.',
+    importance: 0.85,
+  },
+  {
+    content:
+      'Portfolio rebalancing target: 60% equities (30% US, 20% international, 10% emerging), 30% fixed income, 10% alternatives. Last rebalanced 2026-02-28. Next review: Q3 2026.',
+    importance: 0.8,
+  },
+  {
+    content:
+      'Client ABC Partners wire transfer of $125,000 received 2026-06-01, reference TXN-20260601-0042. Applied to invoice INV-2026-0318. Remaining balance: $0.',
+    importance: 0.85,
+  },
+];
+
+const DEFAULT_MODEL = 'meta-llama/llama-4-maverick:free';
+const SEED_TIMEOUT_MS = 8_000;
+
+// ---------------------------------------------------------------------------
+// Low-level I/O helpers (replaceable in unit tests via opts._callXxx)
+// ---------------------------------------------------------------------------
+
+function _callOpenRouter(apiKey, model, messages, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ model, messages, max_tokens: 512 });
+    const req = https.request(
+      {
+        hostname: 'openrouter.ai',
+        path: '/api/v1/chat/completions',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Length': Buffer.byteLength(body),
+          'HTTP-Referer': 'https://dakera.ai',
+          'X-Title': 'Dakera AI Playground',
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString('utf8') }));
+        res.on('error', reject);
+      },
+    );
+    req.setTimeout(timeoutMs, () => req.destroy(Object.assign(new Error('OpenRouter timeout'), { timedOut: true })));
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function _callDakeraRecall(upstreamUrl, apiKey, agentId, query, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ agent_id: agentId, query, top_k: 5 });
+    const u = new URL(upstreamUrl + '/v1/memory/recall');
+    const req = http.request(
+      {
+        hostname: u.hostname,
+        port: Number(u.port) || 80,
+        path: u.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString('utf8') }));
+        res.on('error', reject);
+      },
+    );
+    req.setTimeout(timeoutMs, () => req.destroy(Object.assign(new Error('recall timeout'), { timedOut: true })));
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function _callDakeraStoreBatch(upstreamUrl, apiKey, agentId, memories, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({
+      agent_id: agentId,
+      memories: memories.map((m) => ({ agent_id: agentId, content: m.content, importance: m.importance || 0.8 })),
+    });
+    const u = new URL(upstreamUrl + '/v1/memories/store/batch');
+    const req = http.request(
+      {
+        hostname: u.hostname,
+        port: Number(u.port) || 80,
+        path: u.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume(); // drain and discard — fire-and-forget caller handles the result
+        res.on('end', () => resolve({ status: res.statusCode }));
+        res.on('error', reject);
+      },
+    );
+    req.setTimeout(timeoutMs, () => req.destroy());
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function _parseOrResponse(rawBody, fallbackModel) {
+  try {
+    const parsed = JSON.parse(rawBody);
+    if (parsed.error) {
+      return { error: 'openrouter_error', message: parsed.error.message || 'OpenRouter error', model: fallbackModel };
+    }
+    const msg = parsed.choices && parsed.choices[0] && parsed.choices[0].message;
+    return { response: (msg && msg.content) || '', model: parsed.model || fallbackModel };
+  } catch {
+    return { error: 'parse_error', message: 'Could not parse OpenRouter response.', model: fallbackModel };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle POST /v1/playground/llm-compare
+ *
+ * Returns:
+ *   { status: 200, without_memory, with_memory, processing_time_ms }
+ *   { status: 4xx|5xx, error, message [, retryAfterSec] }
+ *
+ * opts (for unit tests):
+ *   _callOpenRouter, _callDakeraRecall, _callDakeraStoreBatch
+ */
+async function handleLlmCompare(config, store, resolved, bodyBuf, opts) {
+  const callOR = (opts && opts._callOpenRouter) || _callOpenRouter;
+  const callRecall = (opts && opts._callDakeraRecall) || _callDakeraRecall;
+  const callSeed = (opts && opts._callDakeraStoreBatch) || _callDakeraStoreBatch;
+
+  if (!config.openRouterApiKey) {
+    return { status: 503, error: 'llm_not_configured', message: 'LLM comparison is not available (OpenRouter API key not configured).' };
+  }
+
+  // LLM-specific rate limit: max 5 calls per 10 min per session.
+  const llmRate = store.checkLlmRate(resolved.session);
+  if (!llmRate.ok) {
+    return {
+      status: 429,
+      error: 'llm_rate_limit_exceeded',
+      message: `LLM comparison is limited to 5 calls per 10 minutes per session. Retry in ${llmRate.retryAfterSec}s.`,
+      retryAfterSec: llmRate.retryAfterSec,
+    };
+  }
+
+  // Validate request body.
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyBuf.toString('utf8'));
+  } catch {
+    return { status: 400, error: 'bad_request', message: 'Request body must be valid JSON.' };
+  }
+  const question = typeof parsed.question === 'string' ? parsed.question.trim() : '';
+  if (!question) {
+    return { status: 400, error: 'bad_request', message: 'Field "question" is required and must be a non-empty string.' };
+  }
+  const model = typeof parsed.model === 'string' && parsed.model.trim() ? parsed.model.trim() : DEFAULT_MODEL;
+
+  const ns = sessionNamespace(resolved.id);
+  const timeout = config.llmCompareTimeoutMs || 30_000;
+
+  // Seed demo memories on the FIRST llm-compare call for this session.
+  // Synchronous so memories are available for the recall that immediately follows.
+  if (!resolved.session.llmSeeded) {
+    resolved.session.llmSeeded = true;
+    try {
+      await Promise.race([
+        callSeed(config.upstreamUrl, config.rootApiKey, ns, SEED_MEMORIES, timeout),
+        new Promise((_, rej) => setTimeout(() => rej(new Error('seed timeout')), SEED_TIMEOUT_MS)),
+      ]);
+    } catch {
+      // Seeding failed or timed out — proceed without pre-populated memories.
+    }
+  }
+
+  const startMs = Date.now();
+
+  // Step 1: Recall relevant memories from the session's private Dakera namespace.
+  let memories = [];
+  let recallWarning = null;
+  try {
+    const recallRes = await callRecall(config.upstreamUrl, config.rootApiKey, ns, question, timeout);
+    if (recallRes.status === 200) {
+      const r = JSON.parse(recallRes.body);
+      memories = (r.results || r.memories || [])
+        .map((m) => (typeof m === 'string' ? m : m.content || m.text || ''))
+        .filter(Boolean);
+    }
+  } catch {
+    recallWarning = 'Dakera recall failed; response may not reflect stored memories.';
+  }
+
+  // Steps 2 + 3: OpenRouter calls — without and with memory context (parallel).
+  const withoutMessages = [{ role: 'user', content: question }];
+  const withMessages =
+    memories.length > 0
+      ? [
+          {
+            role: 'system',
+            content:
+              'You have access to the following relevant records and memories:\n\n' +
+              memories.join('\n\n') +
+              '\n\nUse this context to provide an accurate, specific answer.',
+          },
+          { role: 'user', content: question },
+        ]
+      : withoutMessages;
+
+  const [withoutSettled, withSettled] = await Promise.allSettled([
+    callOR(config.openRouterApiKey, model, withoutMessages, timeout),
+    callOR(config.openRouterApiKey, model, withMessages, timeout),
+  ]);
+
+  const processingTimeMs = Date.now() - startMs;
+
+  function resolveResult(settled, includeMemories) {
+    if (settled.status === 'rejected') {
+      const base = { error: 'request_failed', message: 'Failed to call OpenRouter.', model };
+      return includeMemories ? { ...base, memories_used: memories } : base;
+    }
+    const { status: httpStatus, body } = settled.value;
+    if (httpStatus === 402) {
+      const base = { error: 'credits_exhausted', message: 'OpenRouter free-tier credits exhausted. Please try again later.', model };
+      return includeMemories ? { ...base, memories_used: memories } : base;
+    }
+    if (httpStatus >= 400) {
+      let msg = `OpenRouter returned HTTP ${httpStatus}.`;
+      try {
+        const p = JSON.parse(body);
+        if (p.error && p.error.message) msg = p.error.message;
+      } catch { /**/ }
+      const base = { error: 'openrouter_error', message: msg, model };
+      return includeMemories ? { ...base, memories_used: memories } : base;
+    }
+    const base = _parseOrResponse(body, model);
+    return includeMemories ? { ...base, memories_used: memories } : base;
+  }
+
+  const withoutMemory = resolveResult(withoutSettled, false);
+  let withMemory = resolveResult(withSettled, true);
+  if (recallWarning) withMemory = { ...withMemory, recall_warning: recallWarning };
+
+  return { status: 200, without_memory: withoutMemory, with_memory: withMemory, processing_time_ms: processingTimeMs };
+}
+
+module.exports = { handleLlmCompare, SEED_MEMORIES, DEFAULT_MODEL };

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -25,6 +25,10 @@ function baseConfig(over = {}) {
     maxBodyBytes: 256 * 1024,
     allowedOrigins: ['https://dakera.ai', 'https://playground.dakera.ai'],
     upstreamTimeoutMs: 5000,
+    // LLM compare (DAK-6845) — disabled by default in tests (no real key)
+    openRouterApiKey: '',
+    llmCompareTimeoutMs: 5000,
+    llmRateLimitPer10Min: 5,
     version: 'test',
     ...over,
   };
@@ -56,6 +60,7 @@ async function startProxy(over = {}, upstreamHandler) {
     memoryCap: config.memoryCapPerSession,
     ttlMs: config.sessionTtlMs,
     maxSessionsPerIp: config.maxSessionsPerIp,
+    llmRateLimit: config.llmRateLimitPer10Min,
   });
   const server = createServer(config, store);
   await new Promise((r) => server.listen(0, '127.0.0.1', r));
@@ -560,5 +565,214 @@ test('batch store namespaces every item against the session (DAK-6757)', async (
   const body = JSON.parse(p.upstream.captured[0].body);
   assert.equal(body.agent_id, ns);
   assert.equal(body.memories[0].agent_id, ns); // per-item agent_id rewritten too
+  await p.close();
+});
+
+// ---------------------------------------------------------------------------
+// unit + integration: LLM compare (DAK-6845)
+// ---------------------------------------------------------------------------
+
+const { handleLlmCompare, SEED_MEMORIES, DEFAULT_MODEL } = require('./llm-compare');
+
+// Minimal noop mocks for the internal I/O helpers.
+function makeOrMock(response) {
+  return async () => ({ status: 200, body: JSON.stringify({ model: 'meta-llama/llama-4-maverick:free', choices: [{ message: { content: response } }] }) });
+}
+const noopSeed = async () => ({ status: 200 });
+const emptyRecall = async () => ({ status: 200, body: JSON.stringify({ results: [] }) });
+
+function makeStore(overrides = {}) {
+  return new SessionStore({
+    rateLimitPerMin: 1000,
+    memoryCap: 50,
+    ttlMs: 1e9,
+    maxSessionsPerIp: 0,
+    llmRateLimit: 5,
+    ...overrides,
+  });
+}
+
+function makeResolved(store, id = 'pg_llmtest0001') {
+  return store.resolve(id, '1.2.3.4');
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    openRouterApiKey: 'test-key',
+    llmCompareTimeoutMs: 5000,
+    upstreamUrl: 'http://127.0.0.1:0',
+    rootApiKey: 'root-key',
+    ...overrides,
+  };
+}
+
+test('llm-compare returns 503 when OPENROUTER_API_KEY is not set (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig({ openRouterApiKey: '' }), store, resolved, Buffer.from('{"question":"test"}'), {
+    _callOpenRouter: makeOrMock('ok'),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 503);
+  assert.equal(result.error, 'llm_not_configured');
+});
+
+test('llm-compare returns 400 for missing question field (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from('{"model":"foo"}'), {
+    _callOpenRouter: makeOrMock('ok'),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.error, 'bad_request');
+});
+
+test('llm-compare returns 400 for bad JSON body (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from('not json'), {
+    _callOpenRouter: makeOrMock('ok'),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.error, 'bad_request');
+});
+
+test('llm-compare successful call returns correct structure (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'What medication is the patient taking?' })), {
+    _callOpenRouter: makeOrMock('Some medication answer'),
+    _callDakeraRecall: async () => ({ status: 200, body: JSON.stringify({ results: [{ content: 'Patient takes Metformin 500mg' }] }) }),
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 200);
+  assert.ok(result.without_memory);
+  assert.ok(result.with_memory);
+  assert.equal(typeof result.processing_time_ms, 'number');
+  assert.ok(Array.isArray(result.with_memory.memories_used));
+  assert.ok(result.with_memory.memories_used.length > 0);
+  assert.equal(result.without_memory.model, DEFAULT_MODEL);
+  assert.equal(result.without_memory.response, 'Some medication answer');
+});
+
+test('llm-compare passes model override to OpenRouter (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const capturedModels = [];
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'hello', model: 'google/gemma-3-27b-it:free' })), {
+    _callOpenRouter: async (key, model) => {
+      capturedModels.push(model);
+      return { status: 200, body: JSON.stringify({ model, choices: [{ message: { content: 'hi' } }] }) };
+    },
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 200);
+  assert.ok(capturedModels.every((m) => m === 'google/gemma-3-27b-it:free'));
+});
+
+test('llm-compare LLM-specific rate limit blocks after 5 calls per 10 min (DAK-6845)', async () => {
+  let now = 0;
+  const store = new SessionStore({ rateLimitPerMin: 1000, memoryCap: 50, ttlMs: 1e9, maxSessionsPerIp: 0, llmRateLimit: 5, now: () => now });
+  const resolved = store.resolve('pg_llmratetest1', '1.1.1.1');
+  const body = Buffer.from(JSON.stringify({ question: 'hello' }));
+  const cfg = makeConfig();
+  const mocks = { _callOpenRouter: makeOrMock('resp'), _callDakeraRecall: emptyRecall, _callDakeraStoreBatch: noopSeed };
+
+  for (let i = 0; i < 5; i++) {
+    const r = await handleLlmCompare(cfg, store, resolved, body, mocks);
+    assert.equal(r.status, 200, `call ${i + 1} should succeed`);
+  }
+  const blocked = await handleLlmCompare(cfg, store, resolved, body, mocks);
+  assert.equal(blocked.status, 429);
+  assert.equal(blocked.error, 'llm_rate_limit_exceeded');
+  assert.ok(blocked.retryAfterSec >= 1);
+
+  // Window expires — should allow again.
+  now = 10 * 60 * 1000 + 1_000;
+  const allowed = await handleLlmCompare(cfg, store, resolved, body, mocks);
+  assert.equal(allowed.status, 200);
+});
+
+test('llm-compare handles OpenRouter 402 gracefully (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'test' })), {
+    _callOpenRouter: async () => ({ status: 402, body: JSON.stringify({ error: { message: 'Insufficient credits' } }) }),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 200);
+  assert.equal(result.without_memory.error, 'credits_exhausted');
+  assert.equal(result.with_memory.error, 'credits_exhausted');
+});
+
+test('llm-compare proceeds when Dakera recall fails (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store);
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'test' })), {
+    _callOpenRouter: makeOrMock('fallback answer'),
+    _callDakeraRecall: async () => { throw new Error('network error'); },
+    _callDakeraStoreBatch: noopSeed,
+  });
+  assert.equal(result.status, 200);
+  assert.equal(result.with_memory.recall_warning, 'Dakera recall failed; response may not reflect stored memories.');
+  assert.deepEqual(result.with_memory.memories_used, []);
+});
+
+test('llm-compare seeds memories on first call for a session (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store, 'pg_seedtest001');
+  let seedCalled = false;
+  const result = await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'test' })), {
+    _callOpenRouter: makeOrMock('ok'),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: async (url, key, agent, memories) => {
+      seedCalled = true;
+      assert.equal(memories.length, SEED_MEMORIES.length);
+      return { status: 200 };
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.ok(seedCalled, 'seed store should have been called');
+  assert.ok(resolved.session.llmSeeded, 'llmSeeded flag should be set');
+});
+
+test('llm-compare does NOT seed again on second call (DAK-6845)', async () => {
+  const store = makeStore();
+  const resolved = makeResolved(store, 'pg_seedtest002');
+  let seedCallCount = 0;
+  const mocks = {
+    _callOpenRouter: makeOrMock('ok'),
+    _callDakeraRecall: emptyRecall,
+    _callDakeraStoreBatch: async () => { seedCallCount++; return { status: 200 }; },
+  };
+  await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'first' })), mocks);
+  await handleLlmCompare(makeConfig(), store, resolved, Buffer.from(JSON.stringify({ question: 'second' })), mocks);
+  assert.equal(seedCallCount, 1, 'seed should only fire once per session');
+});
+
+test('llm-compare endpoint accessible via HTTP proxy (integration, DAK-6845)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000, openRouterApiKey: 'fake-key', llmRateLimitPer10Min: 5, llmCompareTimeoutMs: 5000 });
+  // The proxy will try to call OpenRouter (fake-key, won't succeed) and Dakera upstream.
+  // We just verify the proxy routes it correctly (not 403 forbidden_endpoint).
+  const res = await request(p.port, {
+    method: 'POST',
+    path: '/v1/playground/llm-compare',
+    headers: { 'content-type': 'application/json', 'x-playground-session': 'pg_integllm1' },
+    body: JSON.stringify({ question: 'test question' }),
+  });
+  // With a real fake key the OpenRouter call will fail or return 4xx — either way
+  // the endpoint should respond (not 403 forbidden) and include the structured fields.
+  assert.notEqual(res.status, 403, 'llm-compare must not be denied by the allow-list');
+  assert.notEqual(res.status, 404, 'route must exist');
+  const json = JSON.parse(res.body);
+  // Status 200 OR an upstream error (503/502) — either is valid here without real creds.
+  assert.ok(json.without_memory !== undefined || json.error, 'response must be structured');
   await p.close();
 });

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -5,6 +5,7 @@ const { URL } = require('url');
 const { isAllowed, storeKind } = require('./allowlist');
 const { SessionStore } = require('./sessions');
 const { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId } = require('./namespace');
+const { handleLlmCompare } = require('./llm-compare');
 
 // =============================================================================
 // Dakera Playground Sandbox Proxy (DAK-6713)
@@ -248,6 +249,59 @@ function createServer(config, store) {
       return;
     }
     const sessionHeaders = { ...cors, 'X-Playground-Session': resolved.id };
+
+    // LLM side-by-side comparison (DAK-6845) — handled internally by the proxy,
+    // not forwarded to the engine. Must come before the deny-by-default allow-list
+    // because the endpoint is not a Dakera engine route.
+    if (path === '/v1/playground/llm-compare' && method === 'POST') {
+      // Apply the general per-session rate limit first — LLM calls count toward
+      // the 30/min cap to prevent API-level abuse.
+      const rate = store.checkRate(resolved.session);
+      if (!rate.ok) {
+        sendJson(
+          res,
+          429,
+          { error: 'rate_limit_exceeded', message: `Sandbox limit is ${config.rateLimitPerMin} requests/min per session.`, retry_after: rate.retryAfterSec },
+          { ...sessionHeaders, 'Retry-After': String(rate.retryAfterSec) },
+        );
+        return;
+      }
+
+      let llmBodyBuf = Buffer.alloc(0);
+      try {
+        llmBodyBuf = await readBody(req, config.maxBodyBytes);
+      } catch (err) {
+        if (err && err.tooLarge) {
+          sendJson(res, 413, { error: 'payload_too_large', message: `Request body exceeds the sandbox limit of ${config.maxBodyBytes} bytes.` }, sessionHeaders);
+        } else {
+          sendJson(res, 400, { error: 'bad_request', message: 'Could not read request body.' }, sessionHeaders);
+        }
+        return;
+      }
+
+      let llmResult;
+      try {
+        llmResult = await handleLlmCompare(config, store, resolved, llmBodyBuf);
+      } catch {
+        sendJson(res, 500, { error: 'internal_error', message: 'LLM comparison failed unexpectedly.' }, sessionHeaders);
+        return;
+      }
+
+      const llmHeaders = { ...sessionHeaders, 'X-Sandbox-Rate-Remaining': String(rate.remaining) };
+      if (llmResult.status === 200) {
+        sendJson(
+          res,
+          200,
+          { without_memory: llmResult.without_memory, with_memory: llmResult.with_memory, processing_time_ms: llmResult.processing_time_ms },
+          llmHeaders,
+        );
+      } else if (llmResult.retryAfterSec) {
+        sendJson(res, llmResult.status, { error: llmResult.error, message: llmResult.message }, { ...llmHeaders, 'Retry-After': String(llmResult.retryAfterSec) });
+      } else {
+        sendJson(res, llmResult.status, { error: llmResult.error, message: llmResult.message }, llmHeaders);
+      }
+      return;
+    }
 
     // req #4: deny-by-default endpoint allow-list.
     if (!isAllowed(method, path)) {

--- a/docker/playground/proxy/sessions.js
+++ b/docker/playground/proxy/sessions.js
@@ -29,6 +29,7 @@ class SessionStore {
    * @param {number} opts.memoryCap
    * @param {number} opts.ttlMs
    * @param {number} opts.maxSessionsPerIp
+   * @param {number} [opts.llmRateLimit]  – max LLM compare calls per 10 min (DAK-6845)
    * @param {() => number} [opts.now]
    */
   constructor(opts) {
@@ -36,8 +37,9 @@ class SessionStore {
     this.memoryCap = opts.memoryCap;
     this.ttlMs = opts.ttlMs;
     this.maxSessionsPerIp = opts.maxSessionsPerIp;
+    this.llmRateLimit = opts.llmRateLimit !== undefined ? opts.llmRateLimit : 5;
     this.now = opts.now || Date.now;
-    /** @type {Map<string, {createdAt:number, calls:number[], memoryCount:number, ip:string, generated:boolean}>} */
+    /** @type {Map<string, {createdAt:number, calls:number[], memoryCount:number, ip:string, generated:boolean, llmCalls?:number[], llmSeeded?:boolean}>} */
     this.sessions = new Map();
   }
 
@@ -128,6 +130,25 @@ class SessionStore {
   /** Commit a successful store of `count` memories. */
   commitMemory(session, count) {
     session.memoryCount += count;
+  }
+
+  /**
+   * LLM-specific rate limit (DAK-6845): sliding 10-min window.
+   * Called only on POST /v1/playground/llm-compare requests.
+   * Records the call when allowed.
+   * @returns {{ok:true, remaining:number}|{ok:false, retryAfterSec:number}}
+   */
+  checkLlmRate(session) {
+    const now = this.now();
+    const windowStart = now - 10 * 60_000;
+    session.llmCalls = (session.llmCalls || []).filter((t) => t > windowStart);
+    if (session.llmCalls.length >= this.llmRateLimit) {
+      const oldest = session.llmCalls[0];
+      const retryAfterSec = Math.max(1, Math.ceil((oldest + 10 * 60_000 - now) / 1000));
+      return { ok: false, retryAfterSec };
+    }
+    session.llmCalls.push(now);
+    return { ok: true, remaining: this.llmRateLimit - session.llmCalls.length };
   }
 
   /** Evict expired sessions; returns the number removed. */


### PR DESCRIPTION
## Summary

- **New endpoint**: `POST /v1/playground/llm-compare` — calls the same OpenRouter free model twice in parallel (without memory, and with Dakera memories as system context), returning a side-by-side JSON comparison
- **Seed memories**: 10 rich demo memories across medical/engineering/legal/financial are stored on the first call for each session so the first comparison is immediately compelling
- **Rate limiting**: counts toward the general 30/min cap; separate 5/10min LLM-specific cap via `checkLlmRate()` in sessions.js
- **Graceful degradation**: 402 (credits exhausted) → user-friendly error; Dakera recall failure → still returns without-memory response with `recall_warning`
- **OPENROUTER_API_KEY** added as GitHub secret in dakera-deploy; referenced in docker-compose.playground.yml

## Files changed

| File | Change |
|------|--------|
| `docker/playground/proxy/llm-compare.js` | NEW — handler, seed data, OpenRouter/Dakera I/O helpers |
| `docker/playground/proxy/server.js` | Route for `/v1/playground/llm-compare` before allow-list |
| `docker/playground/proxy/sessions.js` | `checkLlmRate()` — 5/10min LLM rate limit |
| `docker/playground/proxy/config.js` | `openRouterApiKey`, `llmCompareTimeoutMs`, `llmRateLimitPer10Min` |
| `docker/playground/proxy/index.js` | Pass `llmRateLimit` to SessionStore |
| `docker/playground/proxy/proxy.test.js` | 11 new tests (503 no key, 400 validation, 5/10min rate limit, 402 graceful, recall failure, seed once per session) |
| `docker/docker-compose.playground.yml` | `OPENROUTER_API_KEY` + `SANDBOX_LLM_RATE_LIMIT` env vars |

## Test plan

- [x] `node --test` — 44/44 pass (33 existing + 11 new)
- [x] All existing sandbox proxy tests pass unchanged
- [x] `OPENROUTER_API_KEY` set as GitHub secret in dakera-deploy

## Response shape

```json
{
  "without_memory": { "response": "I don't have specific information...", "model": "meta-llama/llama-4-maverick:free" },
  "with_memory": { "response": "Based on the records, the patient is taking Metformin 500mg...", "model": "meta-llama/llama-4-maverick:free", "memories_used": ["..."] },
  "processing_time_ms": 4321
}
```

Follow-on: VP Product to build the frontend UI calling this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)