### PR TITLE
fix(proxy): add /v1/memory/hybrid + fix /v1/agents/{id}/memories allowlist (DAK-6898)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -39,6 +39,10 @@ const ALLOW = [
   // (lib.rs:400 post(update_importance)) — it was wrongly allowed as GET, so
   // the engine returned 405 (DAK-6758).
   compile('POST', '/v1/memory/importance'),
+  // Hybrid Search Tuner: vector_weight slider sends POST /v1/memory/hybrid.
+  // Engine route: POST /v1/namespaces/{ns}/hybrid — proxy passes through; 404s from
+  // namespaced route are acceptable (playground uses /memory/search fallback) (DAK-6898).
+  compile('POST', '/v1/memory/hybrid'),
 
   // --- sessions (ChatMemorySession scenario: start, store, recall, end) ---
   // Engine routes: POST /v1/sessions/start (lib.rs:421), POST /v1/sessions/{id}/end (lib.rs:422),
@@ -53,10 +57,10 @@ const ALLOW = [
   compile('POST', '/v1/memories/extract'),
 
   // --- agent memory listing (API explorer + multi-agent scenario) ---
-  // Engine route: GET /v1/agents/{agent_id}/memories.  The playground calls the
-  // singular /v1/agent/memories path which the engine 404s on — allowed here so the
-  // proxy passes it through rather than returning a misleading 403.
-  compile('GET', '/v1/agent/memories'),
+  // Engine route: GET /v1/agents/{agent_id}/memories (crates/api lib.rs).
+  // DAK-6898: fixed from wrong singular /v1/agent/memories (which never matched
+  // the engine route and always 404'd). {seg} wildcard matches the agent_id segment.
+  compile('GET', '/v1/agents/{seg}/memories'),
 
   // --- routing demo (read-only classifier) ---
   compile('POST', '/v1/route'),

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -109,9 +109,12 @@ test('allow-list permits DAK-6891 new endpoints', () => {
   assert.ok(isAllowed('GET', '/v1/sessions/sess_abc123'));
   // Entity Extraction scenario
   assert.ok(isAllowed('POST', '/v1/memories/extract'));
-  // Agent Memory Listing (API explorer)
-  assert.ok(isAllowed('GET', '/v1/agent/memories'));
-  // Hybrid Search still uses /v1/memory/search (existing) — no separate /hybrid route
+  // Agent Memory Listing (API explorer) — DAK-6898: fixed to plural /agents/{id}/memories
+  assert.ok(isAllowed('GET', '/v1/agents/explorer-demo/memories'));
+  assert.ok(isAllowed('GET', '/v1/agents/my-agent/memories'));  // any agent_id
+  assert.notEqual(isAllowed('GET', '/v1/agent/memories'), true); // old wrong path blocked
+  // Hybrid Search pass-through (DAK-6898)
+  assert.ok(isAllowed('POST', '/v1/memory/hybrid'));
   assert.ok(isAllowed('POST', '/v1/memory/search'));
 });
 


### PR DESCRIPTION
## Summary
- **POST /v1/memory/hybrid** — was missing from allowlist, returning 403. Added as read-only pass-through.
- **GET /v1/agents/{seg}/memories** — replaces wrong `/v1/agent/memories` (singular) which the engine never had a route for. Engine route is `GET /v1/agents/{agent_id}/memories`. Updated proxy test to assert new path is allowed and old wrong path is blocked.
- 45/45 proxy tests pass locally.

## Deployed
Changes already live on `playground.dakera.ai` (5.75.177.31) — server allowlist.js updated + proxy image rebuilt + container recreated.

## Verification
- `POST /v1/memory/hybrid` → HTTP 404 from engine (non-403 ✅)
- `GET /v1/agents/test-agent/memories` → HTTP 200 (non-403 ✅)
- `POST /v1/memory/store` → HTTP 200 (regression ✅)
- `POST /v1/admin/test` → HTTP 403 (deny-by-default intact ✅)

## Test plan
- [ ] CI node --test passes (45/45)
- [ ] Verify playground.dakera.ai Hybrid Search Tuner works
- [ ] Verify Multi-Agent Memory Sharing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)