### PR TITLE
fix(proxy): add KG endpoint + GET query-param agent_id namespacing (DAK-6899)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -39,6 +39,10 @@ const ALLOW = [
   // (lib.rs:400 post(update_importance)) — it was wrongly allowed as GET, so
   // the engine returned 405 (DAK-6758).
   compile('POST', '/v1/memory/importance'),
+  // Hybrid Search Tuner: vector_weight slider sends POST /v1/memory/hybrid.
+  // Engine route: POST /v1/namespaces/{ns}/hybrid — proxy passes through; 404s from
+  // namespaced route are acceptable (playground uses /memory/search fallback) (DAK-6898).
+  compile('POST', '/v1/memory/hybrid'),
 
   // --- sessions (ChatMemorySession scenario: start, store, recall, end) ---
   // Engine routes: POST /v1/sessions/start (lib.rs:421), POST /v1/sessions/{id}/end (lib.rs:422),
@@ -53,10 +57,10 @@ const ALLOW = [
   compile('POST', '/v1/memories/extract'),
 
   // --- agent memory listing (API explorer + multi-agent scenario) ---
-  // Engine route: GET /v1/agents/{agent_id}/memories.  The playground calls the
-  // singular /v1/agent/memories path which the engine 404s on — allowed here so the
-  // proxy passes it through rather than returning a misleading 403.
-  compile('GET', '/v1/agent/memories'),
+  // Engine route: GET /v1/agents/{agent_id}/memories (crates/api lib.rs).
+  // DAK-6898: fixed from wrong singular /v1/agent/memories (which never matched
+  // the engine route and always 404'd). {seg} wildcard matches the agent_id segment.
+  compile('GET', '/v1/agents/{seg}/memories'),
 
   // --- routing demo (read-only classifier) ---
   compile('POST', '/v1/route'),
@@ -70,6 +74,7 @@ const ALLOW = [
   // /v1/knowledge/graph is POST-only in the engine (lib.rs:483 post). The dead
   // GET entry was removed (it could only ever 405).
   compile('POST', '/v1/knowledge/graph'),
+  compile('POST', '/v1/knowledge/graph/full'),  // DAK-6899: KG Explorer
   compile('GET', '/v1/memories/{seg}/graph'),
   compile('GET', '/v1/memories/{seg}/path'),
   // NOTE: /v1/memories/{seg}/links is POST-only in the engine (link creation,

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -416,7 +416,19 @@ function createServer(config, store) {
       };
     }
 
-    forward(config, req, res, path, bodyBuf, outHeaders, rewrite);
+    // Also rewrite agent_id in URL query params for GET endpoints (DAK-6899)
+    let forwardPath = path;
+    try {
+      const qUrl = new URL(req.url, "http://localhost");
+      if (qUrl.searchParams.has("agent_id")) {
+        const namespace = sessionNamespace(resolved.id);
+        const qAgentId = qUrl.searchParams.get("agent_id");
+        qUrl.searchParams.set("agent_id", namespace);
+        forwardPath = qUrl.pathname + "?" + qUrl.searchParams.toString();
+        if (!rewrite) rewrite = { namespace, restoreTo: qAgentId };
+      }
+    } catch (_) {}
+    forward(config, req, res, forwardPath, bodyBuf, outHeaders, rewrite);
   });
 }
 


### PR DESCRIPTION
Two proxy fixes for playground Mode 9 (DAK-6899). Already deployed + validated. Details in commit message.