### PR TITLE
fix(proxy): rewrite agent_id in URL path segments for /v1/agents/{id}/... (DAK-6901)

### DIFF
--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -794,3 +794,27 @@ test('llm-compare endpoint accessible via HTTP proxy (integration, DAK-6845)', a
   assert.ok(json.without_memory !== undefined || json.error, 'response must be structured');
   await p.close();
 });
+
+test('agent_id in URL path segment is namespaced for /v1/agents/{id}/memories (DAK-6901)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 });
+  // GET /v1/agents/playground-demo/memories — agent_id is in the URL path, not body/query
+  const res = await request(p.port, {
+    method: 'GET',
+    path: '/v1/agents/playground-demo/memories',
+    headers: { 'x-playground-session': 'pg_pathtest001' },
+  });
+  // Must reach the upstream (not 403 forbidden_endpoint)
+  assert.notEqual(res.status, 403, 'GET /v1/agents/{id}/memories must pass the allow-list');
+  // The forwarded URL path must have the session-namespaced agent_id, not the raw client value
+  const forwarded = p.upstream.captured[0];
+  assert.ok(forwarded, 'request must be forwarded to upstream');
+  assert.ok(
+    forwarded.url.includes('/v1/agents/playground-demo-'),
+    `agent_id in path must be namespaced, got: ${forwarded.url}`,
+  );
+  assert.ok(
+    !forwarded.url.includes('/v1/agents/playground-demo/'),
+    `raw client agent_id must not reach engine, got: ${forwarded.url}`,
+  );
+  await p.close();
+});

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -416,16 +416,34 @@ function createServer(config, store) {
       };
     }
 
-    // Also rewrite agent_id in URL query params for GET endpoints (DAK-6899)
+    // Rewrite agent_id in URL path segments (/v1/agents/{id}/...) and query params.
+    // Body rewriting is handled above; path segments and query params need explicit
+    // treatment because rewriteRequestAgentId only touches JSON body fields (DAK-6901).
     let forwardPath = path;
     try {
-      const qUrl = new URL(req.url, "http://localhost");
-      if (qUrl.searchParams.has("agent_id")) {
-        const namespace = sessionNamespace(resolved.id);
-        const qAgentId = qUrl.searchParams.get("agent_id");
-        qUrl.searchParams.set("agent_id", namespace);
-        forwardPath = qUrl.pathname + "?" + qUrl.searchParams.toString();
+      const fUrl = new URL(req.url, "http://localhost");
+      const namespace = sessionNamespace(resolved.id);
+      let modified = false;
+
+      // Path-segment rewrite: /v1/agents/{agent_id}/... (DAK-6901)
+      const segMatch = fUrl.pathname.match(/^(\/v1\/agents\/)([^/]+)(\/.*)?$/);
+      if (segMatch) {
+        const clientId = segMatch[2];
+        fUrl.pathname = segMatch[1] + namespace + (segMatch[3] || '');
+        if (!rewrite) rewrite = { namespace, restoreTo: clientId };
+        modified = true;
+      }
+
+      // Query-param rewrite: ?agent_id=... (DAK-6899)
+      if (fUrl.searchParams.has("agent_id")) {
+        const qAgentId = fUrl.searchParams.get("agent_id");
+        fUrl.searchParams.set("agent_id", namespace);
         if (!rewrite) rewrite = { namespace, restoreTo: qAgentId };
+        modified = true;
+      }
+
+      if (modified) {
+        forwardPath = fUrl.pathname + (fUrl.search || '');
       }
     } catch (_) {}
     forward(config, req, res, forwardPath, bodyBuf, outHeaders, rewrite);


### PR DESCRIPTION
## Root Cause (BUG 2)

The proxy's session-namespace isolation (DAK-6757) rewrites `agent_id` in JSON body fields and URL query params (DAK-6899) but NOT URL path segments. A `GET /v1/agents/playground-demo/memories` call forwarded the raw client `playground-demo` value to the engine, bypassing session isolation.

## What Changes

- `server.js`: Consolidates path-segment and query-param rewriting into a single `URL` parse pass that also matches `/v1/agents/{id}/...` pathnames and substitutes the session-namespaced ID. Body rewrite logic is unchanged.
- `proxy.test.js`: New integration test (`test 46`) — verifies `GET /v1/agents/playground-demo/memories` reaches upstream with a session-namespaced path (`playground-demo-{hash}/memories`).

## Test Results

```
# tests 46
# pass 46
# fail 0
```

Part of [DAK-6901](/DAK/issues/DAK-6901) — Fix CF Worker LLM Compare + validate all 9 playground modes