### PR TITLE
fix(proxy): rewrite /v1/memory/hybrid to namespaced engine route (DAK-6906)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -40,8 +40,8 @@ const ALLOW = [
   // the engine returned 405 (DAK-6758).
   compile('POST', '/v1/memory/importance'),
   // Hybrid Search Tuner: vector_weight slider sends POST /v1/memory/hybrid.
-  // Engine route: POST /v1/namespaces/{ns}/hybrid — proxy passes through; 404s from
-  // namespaced route are acceptable (playground uses /memory/search fallback) (DAK-6898).
+  // Engine route: POST /v1/namespaces/{ns}/hybrid — server.js rewrites the path
+  // to the session-namespaced route before forwarding (DAK-6906).
   compile('POST', '/v1/memory/hybrid'),
 
   // --- sessions (ChatMemorySession scenario: start, store, recall, end) ---

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -775,6 +775,48 @@ test('llm-compare does NOT seed again on second call (DAK-6845)', async () => {
   assert.equal(seedCallCount, 1, 'seed should only fire once per session');
 });
 
+// DAK-6906: /v1/memory/hybrid must be rewritten to /v1/namespaces/{ns}/hybrid before forwarding.
+// The engine only exposes hybrid search under the namespaced route.
+test('hybrid path is rewritten to namespaced engine route (DAK-6906)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 });
+  const sessionId = 'pg_hybridtest001';
+  const expectedNs = sessionNamespace(sessionId);
+
+  await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/hybrid',
+    headers: { 'content-type': 'application/json', 'x-playground-session': sessionId },
+    body: JSON.stringify({ agent_id: 'playground-demo', query: 'test', vector_weight: 0.7 }),
+  });
+
+  const seen = p.upstream.captured[0];
+  // Proxy must rewrite the path to the internal _dakera_agent_ namespaced engine route.
+  assert.equal(seen.url, `/v1/namespaces/_dakera_agent_${expectedNs}/hybrid`, 'path must use _dakera_agent_ internal namespace key');
+  // Body agent_id must also be rewritten to the session namespace.
+  const body = JSON.parse(seen.body);
+  assert.equal(body.agent_id, expectedNs, 'agent_id in body must be the session namespace');
+  await p.close();
+});
+
+test('hybrid path rewrite uses session namespace deterministically (DAK-6906)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 });
+  const sessionId = 'pg_hybridtest002';
+
+  // Two requests with the same session should target the same namespace.
+  await request(p.port, { method: 'POST', path: '/v1/memory/hybrid',
+    headers: { 'content-type': 'application/json', 'x-playground-session': sessionId },
+    body: JSON.stringify({ agent_id: 'playground-demo', query: 'first' }) });
+  await request(p.port, { method: 'POST', path: '/v1/memory/hybrid',
+    headers: { 'content-type': 'application/json', 'x-playground-session': sessionId },
+    body: JSON.stringify({ agent_id: 'playground-demo', query: 'second' }) });
+
+  const url1 = p.upstream.captured[0].url;
+  const url2 = p.upstream.captured[1].url;
+  assert.equal(url1, url2, 'same session always maps to same namespace path');
+  assert.ok(url1.startsWith('/v1/namespaces/_dakera_agent_playground-demo-'), 'path must use _dakera_agent_ prefix with session namespace');
+  await p.close();
+});
+
 test('llm-compare endpoint accessible via HTTP proxy (integration, DAK-6845)', async () => {
   const p = await startProxy({ rateLimitPerMin: 1000, openRouterApiKey: 'fake-key', llmRateLimitPer10Min: 5, llmCompareTimeoutMs: 5000 });
   // The proxy will try to call OpenRouter (fake-key, won't succeed) and Dakera upstream.

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -428,6 +428,17 @@ function createServer(config, store) {
         if (!rewrite) rewrite = { namespace, restoreTo: qAgentId };
       }
     } catch (_) {}
+
+    // Path rewrite: POST /v1/memory/hybrid → POST /v1/namespaces/_dakera_agent_{session-ns}/hybrid (DAK-6906).
+    // The engine stores memories under the internal namespace key _dakera_agent_{agent_id} and the
+    // hybrid search endpoint requires this full internal key in the URL path. The proxy translates
+    // the shorthand /v1/memory/hybrid path using the session namespace so the frontend doesn't need
+    // to know either the session namespace or the internal _dakera_agent_ prefix.
+    if (path === '/v1/memory/hybrid') {
+      const ns = rewrite ? rewrite.namespace : sessionNamespace(resolved.id);
+      forwardPath = `/v1/namespaces/_dakera_agent_${ns}/hybrid`;
+    }
+
     forward(config, req, res, forwardPath, bodyBuf, outHeaders, rewrite);
   });
 }


### PR DESCRIPTION
## Summary

- **Problem**: `POST /v1/memory/hybrid` returned 404 from the engine because the engine only registers hybrid search under `POST /v1/namespaces/{ns}/hybrid`. The proxy forwarded the raw path unchanged.
- **Fix**: Added path rewrite in `server.js`: when path is `/v1/memory/hybrid`, proxy rewrites `forwardPath` to `/v1/namespaces/{session-ns}/hybrid` before calling `forward()`. Uses the session namespace already computed by the body agent_id rewrite when present.
- **Tests**: 47/47 pass. Added 2 new tests: `hybrid path is rewritten to namespaced engine route` and `hybrid path rewrite uses session namespace deterministically`.

## Changes

- `server.js`: Add 7-line path rewrite block before `forward()` call
- `allowlist.js`: Update comment to reflect that the proxy now rewrites (not just passes through)
- `proxy.test.js`: +42 lines — 2 new integration tests for hybrid path rewrite

## Test Plan

- [x] `node --test` → 47/47 pass
- [ ] Deploy proxy rebuild after Docker image lands (DAK-6906 engine rebuild in progress)
- [ ] Verify `POST /v1/memory/hybrid` returns 200 (not 404) on playground server

🤖 Generated with [Claude Code](https://claude.com/claude-code)