### PR TITLE
fix(proxy): update default LLM model for llm-compare (DAK-6916)

### DIFF
--- a/docker/playground/proxy/llm-compare.js
+++ b/docker/playground/proxy/llm-compare.js
@@ -77,7 +77,7 @@ const SEED_MEMORIES = [
   },
 ];
 
-const DEFAULT_MODEL = 'meta-llama/llama-4-maverick:free';
+const DEFAULT_MODEL = 'google/gemma-4-26b-a4b-it:free';
 const SEED_TIMEOUT_MS = 8_000;
 
 // ---------------------------------------------------------------------------

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -594,7 +594,7 @@ const { handleLlmCompare, SEED_MEMORIES, DEFAULT_MODEL } = require('./llm-compar
 
 // Minimal noop mocks for the internal I/O helpers.
 function makeOrMock(response) {
-  return async () => ({ status: 200, body: JSON.stringify({ model: 'meta-llama/llama-4-maverick:free', choices: [{ message: { content: response } }] }) });
+  return async () => ({ status: 200, body: JSON.stringify({ model: 'google/gemma-4-26b-a4b-it:free', choices: [{ message: { content: response } }] }) });
 }
 const noopSeed = async () => ({ status: 200 });
 const emptyRecall = async () => ({ status: 200, body: JSON.stringify({ results: [] }) });


### PR DESCRIPTION
## Summary
- `meta-llama/llama-4-maverick:free` is no longer available on OpenRouter free tier
- Switch `DEFAULT_MODEL` to `google/gemma-4-26b-a4b-it:free` (verified working)
- Fixes LLM Compare returning `openrouter_error` for every request

## Verification
- Tested `google/gemma-4-26b-a4b-it:free` directly against OpenRouter API: HTTP 200 ✅
- Applied patch on server, end-to-end llm-compare returns real AI responses ✅
- Also fixed: OPENROUTER_API_KEY added to playground server .env (was missing, causing 503)

## Test plan
- [ ] CI green (node --test proxy.test.js)
- [ ] llm-compare endpoint returns AI responses not 503/openrouter_error

🤖 Generated with [Claude Code](https://claude.com/claude-code)