### PR TITLE
fix(playground): increase engine memory limit 3584M→5120M (DAK-6925)

### DIFF
--- a/docker/docker-compose.playground.yml
+++ b/docker/docker-compose.playground.yml
@@ -2,7 +2,7 @@
 # Dakera Playground — Resource-Limited Single-Node Stack (DAK-6706)
 # =============================================================================
 # Playground limits vs production:
-#   Dakera:  3.5 GB RAM / 3 vCPU (vs 8 GB / 4 vCPU)
+#   Dakera:  5 GB RAM / 3 vCPU (vs 8 GB / 4 vCPU)
 #   MinIO:   1.5 GB RAM / 1 vCPU (vs 4 GB / 2 vCPU)
 #   Body:    5 MB max (vs 500 MB)
 #   Timeout: 30 s (vs 600 s)
@@ -50,7 +50,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 3584M
+          memory: 5120M
           cpus: "3.0"
         reservations:
           memory: 512M


### PR DESCRIPTION
## Summary

- Syncs the OOM hotfix already applied on playground server (5.75.177.31) to the deploy repo
- Engine uses ~3.6 GB idle with GLiNER+embedding models, causing 10+ OOM kills today
- `docker/docker-compose.playground.yml` line 53: `3584M` → `5120M`
- Header comment updated: `3.5 GB RAM` → `5 GB RAM`

## Changes

Only `docker/docker-compose.playground.yml` — 2 lines changed, no other modifications.

Closes DAK-6925

## Test plan

- [x] CI green (YAML lint / validate)
- [x] Diff verified: exactly 2 lines changed
- [x] Server already running at 5120M limit — confirms value is correct