### PR TITLE
fix(proxy): per-scenario namespace isolation (DAK-6929)

### DIFF
--- a/docker/playground/proxy/namespace.js
+++ b/docker/playground/proxy/namespace.js
@@ -3,7 +3,8 @@
 const crypto = require('crypto');
 
 // =============================================================================
-// Per-session agent_id namespacing (DAK-6757) — cross-session PII isolation.
+// Per-session + per-scenario agent_id namespacing
+// (DAK-6757 cross-session PII isolation + DAK-6929 scenario isolation).
 // =============================================================================
 // Every playground session shares the public "playground-demo" agent_id when
 // talking to the engine. Without this layer ANY session can recall what ANY
@@ -13,23 +14,74 @@ const crypto = require('crypto');
 //   Session C recalls {"agent_id":"playground-demo","query":"SECRET"}  -> leak
 //
 // We give each session its OWN engine namespace by rewriting `agent_id` in the
-// forwarded request to `playground-demo-<sha256(sessionId)[:12]>`, and we
-// transparently restore the client's original `agent_id` in the engine's
-// response so the isolation is invisible to the frontend (no client-visible
-// change to the agent_id format).
+// forwarded request to `playground-demo-<sha256(sessionId + scenarioKey)[:12]>`,
+// and we transparently restore the client's original `agent_id` in the engine's
+// response so the isolation is invisible to the frontend.
+//
+// DAK-6929: Different playground scenarios (Guided Tour, Graph Explorer,
+// Multi-Agent, etc.) now get SEPARATE namespaces so financial data from the
+// Store scenario cannot leak into Graph Explorer, etc.
 // =============================================================================
 
 const NS_PREFIX = 'playground-demo';
 
+// ---------------------------------------------------------------------------
+// Scenario key extraction (DAK-6929)
+// ---------------------------------------------------------------------------
+// Frontend agent_ids follow the pattern `pg_XXXXXX_<suffix>` where the suffix
+// identifies the scenario.  We map suffixes to scenario keys so that:
+//   - each scenario gets its own isolated namespace
+//   - _agent_a and _agent_b share a namespace (multi-agent demo feature)
+//   - all _llm_* variants share a namespace (they seed different agent_ids)
+//   - `playground-demo` (API Explorer auto-seed) maps to `default`
+
 /**
- * Deterministic per-session engine namespace. The same session id always maps
- * to the same namespace, so a session can always recall its own stores, while
- * two different sessions can never collide.
+ * Extract the scenario key from a client-supplied agent_id.
+ *
+ * @param {string} agentId — the raw agent_id from the client request
+ * @returns {string} scenario key used to salt the namespace hash
+ */
+function scenarioKey(agentId) {
+  if (!agentId || typeof agentId !== 'string') return 'default';
+
+  // Exact match for the base playground-demo id (API Explorer / auto-seed)
+  if (agentId === NS_PREFIX || agentId === 'playground-demo') return 'default';
+
+  // Multi-agent: _agent_a and _agent_b share a namespace
+  if (agentId.endsWith('_agent_a') || agentId.endsWith('_agent_b')) return 'multiagent';
+
+  // All LLM compare variants share one namespace
+  if (/_llm_/.test(agentId)) return 'llm';
+
+  // Graph explorer
+  if (agentId.endsWith('_graphex')) return 'graphex';
+
+  // Try to extract suffix after `pg_XXXXXX_` prefix pattern (8-char session prefix)
+  const m = agentId.match(/^pg_[A-Za-z0-9_-]{6,}_(.+)$/);
+  if (m) return m[1];
+
+  // If the agent_id doesn't match the pg_ pattern, use it as-is (capped for safety)
+  return agentId.length > 64 ? agentId.slice(0, 64) : agentId;
+}
+
+/**
+ * Deterministic per-session, per-scenario engine namespace.
+ *
+ * The same (sessionId, agentId) pair always maps to the same namespace.
+ * Different scenarios within the same session get different namespaces so
+ * data cannot leak across playground modes (DAK-6929).
+ *
+ * For backward compatibility, when called with only sessionId (no agentId),
+ * it falls back to the original DAK-6757 behavior (scenarioKey = 'default').
+ *
  * @param {string} sessionId
+ * @param {string} [agentId] — client agent_id, used to derive the scenario key
  * @returns {string}
  */
-function sessionNamespace(sessionId) {
-  const digest = crypto.createHash('sha256').update(String(sessionId)).digest('hex');
+function sessionNamespace(sessionId, agentId) {
+  const key = scenarioKey(agentId);
+  const material = key === 'default' ? String(sessionId) : `${String(sessionId)}:${key}`;
+  const digest = crypto.createHash('sha256').update(material).digest('hex');
   return `${NS_PREFIX}-${digest.slice(0, 12)}`;
 }
 
@@ -45,39 +97,72 @@ const ITEM_ARRAY_KEYS = ['memories', 'items', 'queries'];
  * shared default namespace. Nested batch items are only rewritten when they
  * already carry their own agent_id (otherwise they inherit the top-level one).
  *
+ * DAK-6929: the namespace now incorporates the scenario key derived from the
+ * client's agent_id, so each playground mode gets its own isolated data.
+ *
  * @param {Buffer} bodyBuf raw request body
- * @param {string} namespace session namespace from {@link sessionNamespace}
- * @returns {{body: Buffer, clientAgentId: (string|null)}}
+ * @param {string} sessionId session identifier (used with agent_id to derive namespace)
+ * @param {string} [namespaceOverride] pre-computed namespace (backward compat for callers
+ *   that already called sessionNamespace themselves). When provided, this value is used
+ *   directly and sessionId is only used as a fallback.
+ * @returns {{body: Buffer, clientAgentId: (string|null), namespace: (string|null)}}
  *   body          — rewritten buffer (or the original when not JSON)
  *   clientAgentId — the original agent_id to restore in the response, or null
  *                   when the body was not rewritten (not JSON). Defaults to
  *                   "playground-demo" when the client sent no agent_id.
+ *   namespace     — the engine namespace that was injected (for response restore)
  */
-function rewriteRequestAgentId(bodyBuf, namespace) {
-  if (!bodyBuf || bodyBuf.length === 0) return { body: bodyBuf, clientAgentId: null };
+function rewriteRequestAgentId(bodyBuf, sessionId, namespaceOverride) {
+  if (!bodyBuf || bodyBuf.length === 0) return { body: bodyBuf, clientAgentId: null, namespace: null };
 
   let parsed;
   try {
     parsed = JSON.parse(bodyBuf.toString('utf8'));
   } catch {
-    return { body: bodyBuf, clientAgentId: null }; // not JSON — forward untouched
+    return { body: bodyBuf, clientAgentId: null, namespace: null }; // not JSON — forward untouched
   }
   if (!parsed || typeof parsed !== 'object') {
-    return { body: bodyBuf, clientAgentId: null };
+    return { body: bodyBuf, clientAgentId: null, namespace: null };
   }
 
+  // Extract the first agent_id we find to derive the scenario-aware namespace.
   let clientAgentId = null;
+  const findFirst = (obj) => {
+    if (!obj || typeof obj !== 'object') return;
+    if (typeof obj.agent_id === 'string' && clientAgentId === null) {
+      clientAgentId = obj.agent_id;
+    }
+  };
+  const roots = Array.isArray(parsed) ? parsed : [parsed];
+  for (const root of roots) {
+    findFirst(root);
+    if (clientAgentId) break;
+    if (root && typeof root === 'object' && !Array.isArray(root)) {
+      for (const key of ITEM_ARRAY_KEYS) {
+        if (Array.isArray(root[key])) {
+          for (const item of root[key]) { findFirst(item); if (clientAgentId) break; }
+        }
+        if (clientAgentId) break;
+      }
+    }
+  }
+
+  // Compute the namespace: if a pre-computed override is provided AND it looks
+  // like a session namespace, use it directly (backward compat). Otherwise
+  // derive from sessionId + agent_id scenario key.
+  const namespace = namespaceOverride && namespaceOverride.startsWith(NS_PREFIX + '-')
+    ? namespaceOverride
+    : sessionNamespace(sessionId, clientAgentId);
+
   const applyTo = (obj, force) => {
     if (!obj || typeof obj !== 'object') return;
     if (typeof obj.agent_id === 'string') {
-      if (clientAgentId === null) clientAgentId = obj.agent_id;
       obj.agent_id = namespace;
     } else if (force) {
       obj.agent_id = namespace;
     }
   };
 
-  const roots = Array.isArray(parsed) ? parsed : [parsed];
   for (const root of roots) {
     applyTo(root, true); // force isolation on the request root
     if (root && typeof root === 'object' && !Array.isArray(root)) {
@@ -92,6 +177,7 @@ function rewriteRequestAgentId(bodyBuf, namespace) {
   return {
     body: Buffer.from(JSON.stringify(parsed), 'utf8'),
     clientAgentId: clientAgentId === null ? NS_PREFIX : clientAgentId,
+    namespace,
   };
 }
 
@@ -110,4 +196,4 @@ function restoreResponseAgentId(buf, namespace, restoreTo) {
   return Buffer.from(text, 'utf8');
 }
 
-module.exports = { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId, NS_PREFIX };
+module.exports = { sessionNamespace, scenarioKey, rewriteRequestAgentId, restoreResponseAgentId, NS_PREFIX };

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -6,7 +6,7 @@ const http = require('http');
 const { SessionStore } = require('./sessions');
 const { isAllowed, storeKind } = require('./allowlist');
 const { createServer, corsHeaders, countMemories } = require('./server');
-const { sessionNamespace, rewriteRequestAgentId, restoreResponseAgentId } = require('./namespace');
+const { sessionNamespace, scenarioKey, rewriteRequestAgentId, restoreResponseAgentId } = require('./namespace');
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -396,39 +396,47 @@ test('sessionNamespace is deterministic, prefixed, and per-session unique (DAK-6
   assert.equal(a, b); // deterministic — a session can recall its own stores
   assert.notEqual(a, c); // different sessions -> different namespaces
   assert.match(a, /^playground-demo-[0-9a-f]{12}$/);
+
+  // DAK-6929: backward compat — no agentId defaults to 'default' scenario,
+  // which produces the same hash as the original DAK-6757 behavior (no salt).
+  const d = sessionNamespace('pg_abcdefgh', undefined);
+  assert.equal(a, d); // undefined agentId = same as no agentId
+  const e = sessionNamespace('pg_abcdefgh', 'playground-demo');
+  assert.equal(a, e); // 'playground-demo' maps to 'default' scenario key = no salt
 });
 
 test('rewriteRequestAgentId rewrites top-level + nested and captures original (DAK-6757)', () => {
-  const ns = sessionNamespace('pg_session1');
+  // With playground-demo agent_id → 'default' scenario → same as sessionNamespace('pg_session1')
+  const ns = sessionNamespace('pg_session1', 'playground-demo');
   const r = rewriteRequestAgentId(
     Buffer.from(JSON.stringify({ agent_id: 'playground-demo', memories: [{ agent_id: 'playground-demo', content: 'x' }, { content: 'y' }] })),
-    ns,
+    'pg_session1',
   );
   const parsed = JSON.parse(r.body.toString());
   assert.equal(parsed.agent_id, ns); // top-level rewritten
   assert.equal(parsed.memories[0].agent_id, ns); // nested rewritten when present
   assert.equal(parsed.memories[1].agent_id, undefined); // nested without agent_id inherits top-level
   assert.equal(r.clientAgentId, 'playground-demo');
+  assert.equal(r.namespace, ns);
 });
 
 test('rewriteRequestAgentId forces namespace when agent_id omitted (DAK-6757)', () => {
-  const ns = sessionNamespace('pg_session2');
-  const r = rewriteRequestAgentId(Buffer.from(JSON.stringify({ query: 'bank account' })), ns);
+  const ns = sessionNamespace('pg_session2'); // no agentId → default scenario
+  const r = rewriteRequestAgentId(Buffer.from(JSON.stringify({ query: 'bank account' })), 'pg_session2');
   assert.equal(JSON.parse(r.body.toString()).agent_id, ns); // forced — cannot fall back to shared default
   assert.equal(r.clientAgentId, 'playground-demo'); // restore to public placeholder
 });
 
 test('rewriteRequestAgentId leaves non-JSON and custom agent_id intact (DAK-6757)', () => {
-  const ns = sessionNamespace('pg_session3');
-  const bad = rewriteRequestAgentId(Buffer.from('not json'), ns);
+  const bad = rewriteRequestAgentId(Buffer.from('not json'), 'pg_session3');
   assert.equal(bad.body.toString(), 'not json');
   assert.equal(bad.clientAgentId, null); // not rewritten
-  const custom = rewriteRequestAgentId(Buffer.from(JSON.stringify({ agent_id: 'demo', content: 'z' })), ns);
+  const custom = rewriteRequestAgentId(Buffer.from(JSON.stringify({ agent_id: 'demo', content: 'z' })), 'pg_session3');
   assert.equal(custom.clientAgentId, 'demo'); // original preserved for response restore
 });
 
 test('restoreResponseAgentId swaps the namespace back to the client value (DAK-6757)', () => {
-  const ns = sessionNamespace('pg_session4');
+  const ns = sessionNamespace('pg_session4'); // default scenario
   const body = Buffer.from(JSON.stringify({ agent_id: ns, results: [`${ns} stored`] }));
   const restored = JSON.parse(restoreResponseAgentId(body, ns, 'playground-demo').toString());
   assert.equal(restored.agent_id, 'playground-demo');
@@ -436,6 +444,111 @@ test('restoreResponseAgentId swaps the namespace back to the client value (DAK-6
   // unrelated body untouched
   const plain = Buffer.from('{"ok":true}');
   assert.equal(restoreResponseAgentId(plain, ns, 'playground-demo').toString(), '{"ok":true}');
+});
+
+// ---------------------------------------------------------------------------
+// unit: scenario key extraction (DAK-6929)
+// ---------------------------------------------------------------------------
+
+test('scenarioKey extracts correct keys from agent_ids (DAK-6929)', () => {
+  // Base playground-demo → default
+  assert.equal(scenarioKey('playground-demo'), 'default');
+  assert.equal(scenarioKey(null), 'default');
+  assert.equal(scenarioKey(undefined), 'default');
+  assert.equal(scenarioKey(''), 'default');
+
+  // Graph explorer
+  assert.equal(scenarioKey('pg_abcdef_graphex'), 'graphex');
+  assert.equal(scenarioKey('pg_12345678_graphex'), 'graphex');
+
+  // LLM compare variants all map to 'llm'
+  assert.equal(scenarioKey('pg_abcdef_llm_fintech'), 'llm');
+  assert.equal(scenarioKey('pg_abcdef_llm_medical'), 'llm');
+  assert.equal(scenarioKey('pg_abcdef_llm_org'), 'llm');
+  assert.equal(scenarioKey('pg_abcdef_llm_legal'), 'llm');
+  assert.equal(scenarioKey('pg_abcdef_llm_devops'), 'llm');
+
+  // Multi-agent: _agent_a and _agent_b both map to 'multiagent'
+  assert.equal(scenarioKey('pg_abcdef_agent_a'), 'multiagent');
+  assert.equal(scenarioKey('pg_abcdef_agent_b'), 'multiagent');
+
+  // Arbitrary suffix extraction — the regex `pg_[A-Za-z0-9_-]{6,}_(.+)$` is
+  // greedy, so `[A-Za-z0-9_-]{6,}` consumes as much as possible including
+  // underscores, leaving only the final segment as the captured suffix.
+  assert.equal(scenarioKey('pg_abcdef_hybrid'), 'hybrid');
+  assert.equal(scenarioKey('pg_abcdef_chat'), 'chat');
+  assert.equal(scenarioKey('pg_abcdef_entity'), 'entity');
+});
+
+test('sessionNamespace produces different namespaces for different scenarios (DAK-6929)', () => {
+  const session = 'pg_testtest';
+  const nsDefault = sessionNamespace(session, 'playground-demo');
+  const nsGraphex = sessionNamespace(session, 'pg_testtest_graphex');
+  const nsLlm = sessionNamespace(session, 'pg_testtest_llm_fintech');
+  const nsMulti = sessionNamespace(session, 'pg_testtest_agent_a');
+
+  // Each scenario has its own namespace
+  assert.notEqual(nsDefault, nsGraphex);
+  assert.notEqual(nsDefault, nsLlm);
+  assert.notEqual(nsDefault, nsMulti);
+  assert.notEqual(nsGraphex, nsLlm);
+  assert.notEqual(nsGraphex, nsMulti);
+  assert.notEqual(nsLlm, nsMulti);
+
+  // All follow the format
+  for (const ns of [nsDefault, nsGraphex, nsLlm, nsMulti]) {
+    assert.match(ns, /^playground-demo-[0-9a-f]{12}$/);
+  }
+});
+
+test('multi-agent _agent_a and _agent_b share the same namespace (DAK-6929)', () => {
+  const session = 'pg_multitest';
+  const nsA = sessionNamespace(session, 'pg_multitest_agent_a');
+  const nsB = sessionNamespace(session, 'pg_multitest_agent_b');
+  assert.equal(nsA, nsB, '_agent_a and _agent_b must share a namespace for cross-agent demo');
+});
+
+test('LLM variants all share the same namespace (DAK-6929)', () => {
+  const session = 'pg_llmshare1';
+  const nsFintech = sessionNamespace(session, 'pg_llmshare1_llm_fintech');
+  const nsMedical = sessionNamespace(session, 'pg_llmshare1_llm_medical');
+  const nsOrg = sessionNamespace(session, 'pg_llmshare1_llm_org');
+  assert.equal(nsFintech, nsMedical);
+  assert.equal(nsMedical, nsOrg);
+});
+
+test('rewriteRequestAgentId derives scenario-aware namespace from agent_id (DAK-6929)', () => {
+  const session = 'pg_scentest1';
+  // graphex scenario
+  const rGraph = rewriteRequestAgentId(
+    Buffer.from(JSON.stringify({ agent_id: 'pg_scentest1_graphex', query: 'find nodes' })),
+    session,
+  );
+  const nsGraph = sessionNamespace(session, 'pg_scentest1_graphex');
+  assert.equal(JSON.parse(rGraph.body.toString()).agent_id, nsGraph);
+  assert.equal(rGraph.clientAgentId, 'pg_scentest1_graphex');
+  assert.equal(rGraph.namespace, nsGraph);
+
+  // llm fintech scenario — different namespace
+  const rLlm = rewriteRequestAgentId(
+    Buffer.from(JSON.stringify({ agent_id: 'pg_scentest1_llm_fintech', content: 'portfolio data' })),
+    session,
+  );
+  const nsLlm = sessionNamespace(session, 'pg_scentest1_llm_fintech');
+  assert.equal(JSON.parse(rLlm.body.toString()).agent_id, nsLlm);
+  assert.notEqual(nsGraph, nsLlm, 'graphex and llm must have different namespaces');
+});
+
+test('rewriteRequestAgentId backward compat: pre-computed namespace override (DAK-6929)', () => {
+  // Callers that already computed a namespace can pass it as the third argument
+  const precomputed = 'playground-demo-aabbccddeeff';
+  const r = rewriteRequestAgentId(
+    Buffer.from(JSON.stringify({ agent_id: 'playground-demo', content: 'test' })),
+    'pg_ignored',
+    precomputed,
+  );
+  assert.equal(JSON.parse(r.body.toString()).agent_id, precomputed);
+  assert.equal(r.namespace, precomputed);
 });
 
 // ---------------------------------------------------------------------------
@@ -572,7 +685,8 @@ test('two clients without session headers get different namespaces (DAK-6783 cro
 
 test('batch store namespaces every item against the session (DAK-6757)', async () => {
   const p = await startProxy({ rateLimitPerMin: 1000, memoryCapPerSession: 50 });
-  const ns = sessionNamespace('pg_batchns01');
+  // DAK-6929: namespace now derived from session + agent_id scenario key
+  const ns = sessionNamespace('pg_batchns01', 'playground-demo');
   const res = await request(p.port, {
     method: 'POST',
     path: '/v1/memories/store/batch',
@@ -780,7 +894,8 @@ test('llm-compare does NOT seed again on second call (DAK-6845)', async () => {
 test('hybrid path is rewritten to namespaced engine route (DAK-6906)', async () => {
   const p = await startProxy({ rateLimitPerMin: 1000 });
   const sessionId = 'pg_hybridtest001';
-  const expectedNs = sessionNamespace(sessionId);
+  // DAK-6929: namespace derived from session + agent_id
+  const expectedNs = sessionNamespace(sessionId, 'playground-demo');
 
   await request(p.port, {
     method: 'POST',
@@ -858,5 +973,118 @@ test('agent_id in URL path segment is namespaced for /v1/agents/{id}/memories (D
     !forwarded.url.includes('/v1/agents/playground-demo/'),
     `raw client agent_id must not reach engine, got: ${forwarded.url}`,
   );
+  await p.close();
+});
+
+// ---------------------------------------------------------------------------
+// integration: cross-SCENARIO isolation end-to-end (DAK-6929 acceptance)
+// ---------------------------------------------------------------------------
+
+function scenarioStoreReq(port, session, agentId, content) {
+  return request(port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: agentId, content }),
+  });
+}
+
+function scenarioRecallReq(port, session, agentId, query) {
+  return request(port, {
+    method: 'POST',
+    path: '/v1/memory/recall',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: agentId, query }),
+  });
+}
+
+test('different scenarios in same session get different engine namespaces (DAK-6929 AC#1)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
+  const session = 'pg_sceniso001';
+
+  // Store data in Graph Explorer scenario
+  await scenarioStoreReq(p.port, session, `${session}_graphex`, 'Graph node: Alice knows Bob');
+  // Store data in LLM Compare scenario
+  await scenarioStoreReq(p.port, session, `${session}_llm_fintech`, 'Portfolio: 60% stocks, 40% bonds');
+
+  // Graph Explorer recall: the mock engine returns ALL memories for the agent_id,
+  // so we get graphex data but NOT LLM data — proving namespace isolation.
+  const graphRecall = await scenarioRecallReq(p.port, session, `${session}_graphex`, 'anything');
+  const graphResults = JSON.parse(graphRecall.body).results;
+  assert.deepEqual(graphResults, ['Graph node: Alice knows Bob'],
+    'Graph Explorer must only see its own data, not LLM data');
+  assert.ok(!graphResults.includes('Portfolio: 60% stocks, 40% bonds'),
+    'LLM data must NOT leak into Graph Explorer');
+
+  // LLM recall should see only its own data
+  const llmRecall = await scenarioRecallReq(p.port, session, `${session}_llm_fintech`, 'anything');
+  const llmResults = JSON.parse(llmRecall.body).results;
+  assert.deepEqual(llmResults, ['Portfolio: 60% stocks, 40% bonds'],
+    'LLM must only see its own data');
+  assert.ok(!llmResults.includes('Graph node: Alice knows Bob'),
+    'Graph data must NOT leak into LLM');
+
+  await p.close();
+});
+
+test('multi-agent _agent_a and _agent_b share data (DAK-6929 AC#2)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, memoryEngine());
+  const session = 'pg_multiiso01';
+
+  // Agent A stores a memory
+  await scenarioStoreReq(p.port, session, `${session}_agent_a`, 'Shared context: project deadline is Friday');
+
+  // Agent B should be able to recall it (same namespace)
+  const bRecall = await scenarioRecallReq(p.port, session, `${session}_agent_b`, 'deadline');
+  const bResults = JSON.parse(bRecall.body).results;
+  assert.deepEqual(bResults, ['Shared context: project deadline is Friday'],
+    '_agent_b must see _agent_a memories (shared multiagent namespace)');
+
+  await p.close();
+});
+
+test('different scenarios use different engine agent_ids in forwarded requests (DAK-6929 AC#3)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 });
+  const session = 'pg_fwdcheck1';
+
+  // Store via graphex scenario
+  await scenarioStoreReq(p.port, session, `${session}_graphex`, 'graph data');
+  // Store via default scenario
+  await scenarioStoreReq(p.port, session, 'playground-demo', 'default data');
+  // Store via llm scenario
+  await scenarioStoreReq(p.port, session, `${session}_llm_medical`, 'medical data');
+
+  const agents = p.upstream.captured.map(c => JSON.parse(c.body).agent_id);
+  // All three should be different namespaces
+  assert.notEqual(agents[0], agents[1], 'graphex vs default must differ');
+  assert.notEqual(agents[0], agents[2], 'graphex vs llm must differ');
+  assert.notEqual(agents[1], agents[2], 'default vs llm must differ');
+  // All should follow the namespace format
+  for (const a of agents) {
+    assert.match(a, /^playground-demo-[0-9a-f]{12}$/, `engine agent_id must be namespaced: ${a}`);
+  }
+
+  await p.close();
+});
+
+test('response agent_id is restored to the client original per scenario (DAK-6929 AC#4)', async () => {
+  const p = await startProxy({ rateLimitPerMin: 1000 }, (req, res, captured) => {
+    const parsed = JSON.parse(captured[captured.length - 1].body);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ agent_id: parsed.agent_id, status: 'ok' }));
+  });
+  const session = 'pg_restoretest';
+
+  const res = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/store',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: `${session}_graphex`, content: 'test' }),
+  });
+  const json = JSON.parse(res.body);
+  // The response should have the original client agent_id restored, not the engine namespace
+  assert.equal(json.agent_id, `${session}_graphex`,
+    'response must restore original client agent_id');
+
   await p.close();
 });

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -381,17 +381,17 @@ function createServer(config, store) {
       'X-Sandbox-Rate-Remaining': String(rate.remaining),
     };
 
-    // Per-session namespace isolation (DAK-6757): rewrite the request body's
-    // agent_id to this session's private namespace so no session can recall
-    // another session's memories. The original agent_id is restored in the
-    // response so the client sees no change.
+    // Per-session + per-scenario namespace isolation (DAK-6757, DAK-6929):
+    // rewrite the request body's agent_id to this session's private namespace
+    // so no session can recall another session's memories, and different
+    // playground scenarios (Graph Explorer, LLM Compare, etc.) are isolated
+    // from each other within the same session.
     let rewrite = null;
     if (bodyBuf && bodyBuf.length) {
-      const namespace = sessionNamespace(resolved.id);
-      const rewritten = rewriteRequestAgentId(bodyBuf, namespace);
+      const rewritten = rewriteRequestAgentId(bodyBuf, resolved.id);
       if (rewritten.clientAgentId !== null) {
         bodyBuf = rewritten.body;
-        rewrite = { namespace, restoreTo: rewritten.clientAgentId };
+        rewrite = { namespace: rewritten.namespace, restoreTo: rewritten.clientAgentId };
       }
     }
 
@@ -419,16 +419,17 @@ function createServer(config, store) {
     // Rewrite agent_id in URL path segments (/v1/agents/{id}/...) and query params.
     // Body rewriting is handled above; path segments and query params need explicit
     // treatment because rewriteRequestAgentId only touches JSON body fields (DAK-6901).
+    // DAK-6929: the namespace now includes the scenario key from the agent_id.
     let forwardPath = path;
     try {
       const fUrl = new URL(req.url, "http://localhost");
-      const namespace = sessionNamespace(resolved.id);
       let modified = false;
 
       // Path-segment rewrite: /v1/agents/{agent_id}/... (DAK-6901)
       const segMatch = fUrl.pathname.match(/^(\/v1\/agents\/)([^/]+)(\/.*)?$/);
       if (segMatch) {
         const clientId = segMatch[2];
+        const namespace = sessionNamespace(resolved.id, clientId);
         fUrl.pathname = segMatch[1] + namespace + (segMatch[3] || '');
         if (!rewrite) rewrite = { namespace, restoreTo: clientId };
         modified = true;
@@ -437,6 +438,7 @@ function createServer(config, store) {
       // Query-param rewrite: ?agent_id=... (DAK-6899)
       if (fUrl.searchParams.has("agent_id")) {
         const qAgentId = fUrl.searchParams.get("agent_id");
+        const namespace = sessionNamespace(resolved.id, qAgentId);
         fUrl.searchParams.set("agent_id", namespace);
         if (!rewrite) rewrite = { namespace, restoreTo: qAgentId };
         modified = true;
@@ -452,6 +454,7 @@ function createServer(config, store) {
     // hybrid search endpoint requires this full internal key in the URL path. The proxy translates
     // the shorthand /v1/memory/hybrid path using the session namespace so the frontend doesn't need
     // to know either the session namespace or the internal _dakera_agent_ prefix.
+    // DAK-6929: the namespace now reflects the scenario key from the body rewrite.
     if (path === '/v1/memory/hybrid') {
       const ns = rewrite ? rewrite.namespace : sessionNamespace(resolved.id);
       forwardPath = `/v1/namespaces/_dakera_agent_${ns}/hybrid`;


### PR DESCRIPTION
## Summary
- **Per-scenario namespace isolation** to prevent data pollution between playground modes
- `scenarioKey()` function extracts scenario from client agent_id suffixes
- `_agent_a`/`_agent_b` share `multiagent` namespace (cross-agent demo requires shared data)
- `_llm_*` variants share `llm` namespace
- `_graphex`, `_hybrid`, `_chat_session` etc. get their own isolated namespaces
- Backward compatible: no agentId = `default` = same hash as before (DAK-6757)

## Root Cause (DAK-6929)
Financial data from Guided Tour appeared in Graph Explorer, medical data from LLM Compare in Hybrid Search. The proxy mapped ALL scenario agent_ids to the same per-session namespace. Now each scenario gets its own namespace via `sha256(sessionId + ':' + scenarioKey)[:12]`.

## Test plan
- [x] 58/58 proxy tests pass (10 new DAK-6929 tests added)
- [x] scenarioKey extraction verified for all known scenario patterns
- [x] Multi-agent `_agent_a`/`_agent_b` share same namespace ✓
- [x] LLM variants `_llm_fintech`/`_llm_medical` share same namespace ✓
- [x] graphex ≠ llm ≠ multiagent ≠ default (all different) ✓
- [x] Backward compat: omitted agentId = same namespace as before ✓
- [ ] Deploy to playground server and verify live

🤖 Generated with [Claude Code](https://claude.com/claude-code)