### PR TITLE
ci(DAK-6938): add SSH connectivity pre-check to playground deploy workflows

### DIFF
--- a/.github/workflows/playground-monitor-deploy.yml
+++ b/.github/workflows/playground-monitor-deploy.yml
@@ -29,6 +29,24 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$PLAYGROUND_IP" >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      # KEY ROTATION: if this step fails with "Permission denied (publickey)":
+      #   1. ssh-keygen -t ed25519 -C 'deploy-playground' -f /tmp/pg_deploy
+      #   2. ssh root@<PLAYGROUND_IP> 'cat >> ~/.ssh/authorized_keys' < /tmp/pg_deploy.pub
+      #   3. gh secret set DEPLOY_SSH_KEY --repo dakera-ai/dakera-deploy < /tmp/pg_deploy
+      #   4. rm /tmp/pg_deploy /tmp/pg_deploy.pub
+      - name: Verify SSH connectivity
+        run: |
+          if ! ssh -i ~/.ssh/deploy_key \
+               -o StrictHostKeyChecking=no \
+               -o ConnectTimeout=5 \
+               -o BatchMode=yes \
+               root@${PLAYGROUND_IP} echo ok 2>&1; then
+            echo "❌ SSH check failed — DEPLOY_SSH_KEY does not match playground server authorized_keys."
+            echo "Follow the KEY ROTATION procedure in the comments above this step."
+            exit 1
+          fi
+          echo "✅ SSH connectivity verified"
+
       - name: Upload monitor script
         run: |
           scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \

--- a/.github/workflows/playground-proxy-deploy.yml
+++ b/.github/workflows/playground-proxy-deploy.yml
@@ -38,6 +38,24 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$PLAYGROUND_IP" >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      # KEY ROTATION: if this step fails with "Permission denied (publickey)":
+      #   1. ssh-keygen -t ed25519 -C 'deploy-playground' -f /tmp/pg_deploy
+      #   2. ssh root@<PLAYGROUND_IP> 'cat >> ~/.ssh/authorized_keys' < /tmp/pg_deploy.pub
+      #   3. gh secret set DEPLOY_SSH_KEY --repo dakera-ai/dakera-deploy < /tmp/pg_deploy
+      #   4. rm /tmp/pg_deploy /tmp/pg_deploy.pub
+      - name: Verify SSH connectivity
+        run: |
+          if ! ssh -i ~/.ssh/deploy_key \
+               -o StrictHostKeyChecking=no \
+               -o ConnectTimeout=5 \
+               -o BatchMode=yes \
+               root@${{ env.PLAYGROUND_IP }} echo ok 2>&1; then
+            echo "❌ SSH check failed — DEPLOY_SSH_KEY does not match playground server authorized_keys."
+            echo "Follow the KEY ROTATION procedure in the comments above this step."
+            exit 1
+          fi
+          echo "✅ SSH connectivity verified"
+
       - name: Copy proxy source to server
         run: |
           scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \


### PR DESCRIPTION
## Problem

Deploy Playground Proxy failed 3 consecutive times (runs [27693023892](https://github.com/Dakera-AI/dakera-deploy/actions/runs/27693023892), [27693131184](https://github.com/Dakera-AI/dakera-deploy/actions/runs/27693131184), [27704122654](https://github.com/Dakera-AI/dakera-deploy/actions/runs/27704122654)) because `DEPLOY_SSH_KEY` didn't match the playground server's `authorized_keys`. The failure was buried inside SCP output — not immediately obvious. CEO had to self-fix in <5 min.

## Fix

Adds a **Verify SSH connectivity** step immediately after SSH setup and before any SCP/SSH deploy steps in:
- `playground-proxy-deploy.yml`
- `playground-monitor-deploy.yml` (same vulnerability)

The step runs:
```
ssh -o ConnectTimeout=5 -o BatchMode=yes root@<PLAYGROUND_IP> echo ok
```

On failure it prints a clear error message and the 4-step key rotation procedure as comments on the step — surfaced at the exact point of failure.

## Acceptance Criteria (DAK-6938)

- [x] "Verify SSH" step added BEFORE SCP/SSH deploy steps
- [x] Step runs `ssh -o ConnectTimeout=5 -o BatchMode=yes root@${PLAYGROUND_IP} echo ok`
- [x] Failure prints clear error (not buried in SCP output), exits 1
- [x] Key rotation procedure documented as comments on the failing step

## Key Rotation Procedure (documented in workflow)

```bash
ssh-keygen -t ed25519 -C 'deploy-playground' -f /tmp/pg_deploy
ssh root@<PLAYGROUND_IP> 'cat >> ~/.ssh/authorized_keys' < /tmp/pg_deploy.pub
gh secret set DEPLOY_SSH_KEY --repo dakera-ai/dakera-deploy < /tmp/pg_deploy
rm /tmp/pg_deploy /tmp/pg_deploy.pub
```

Closes DAK-6938.