### PR TITLE
fix(docs): correct SSH user in runbook Step 4

### DIFF
--- a/docs/ssh-key-rotation-runbook.md
+++ b/docs/ssh-key-rotation-runbook.md
@@ -90,7 +90,7 @@ PLAYGROUND_IP="5.75.177.31"
 PROD_IP="178.104.45.161"
 
 ssh -i /tmp/deploy_key -o BatchMode=yes -o ConnectTimeout=5 root@${PLAYGROUND_IP} echo "playground OK"
-ssh -i /tmp/deploy_key -o BatchMode=yes -o ConnectTimeout=5 root@${PROD_IP} echo "production OK"
+ssh -i /tmp/deploy_key -o BatchMode=yes -o ConnectTimeout=5 dakera@${PROD_IP} echo "production OK"
 ```
 
 Both must print `OK`. If either fails with `Permission denied`, re-check Step 2 for that server.


### PR DESCRIPTION
## Summary
- Fixes Step 4 of `docs/ssh-key-rotation-runbook.md`: production SSH test command used `root@` but production deploys as `dakera@178.104.45.161`
- The tl;dr quick-reference was already correct; this aligns the expanded Step 4 command

## Context
Caught during CTO review of PR#225. The whole purpose of this runbook is to prevent the root/dakera user mismatch — having the wrong user in the test command defeats that purpose.

## Test plan
- [ ] CI passes (Kustomize Validate + Docker Configs)
- [ ] One-line diff, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)