### PR TITLE
fix(proxy): convert 404 NAMESPACE_NOT_FOUND to 200 empty results (DAK-6950)

### DIFF
--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -1088,3 +1088,42 @@ test('response agent_id is restored to the client original per scenario (DAK-692
 
   await p.close();
 });
+
+// ---------------------------------------------------------------------------
+// DAK-6950: proxy converts 404 NAMESPACE_NOT_FOUND to 200 empty results
+// ---------------------------------------------------------------------------
+
+test('404 NAMESPACE_NOT_FOUND from engine is converted to 200 with empty memories (DAK-6950)', async () => {
+  const p = await startProxy({}, (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Namespace not found', message: 'Namespace not found: sandbox_abc_cmp' }));
+  });
+  const session = 'pg_ns404test';
+  const res = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/recall',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: 'test_cmp', query: 'test', top_k: 5 }),
+  });
+  assert.equal(res.status, 200, 'proxy should convert 404 namespace-not-found to 200');
+  const json = JSON.parse(res.body);
+  assert.deepStrictEqual(json.memories, [], 'memories should be empty array');
+  assert.equal(json.note, 'namespace_initializing', 'note should indicate namespace is initializing');
+  await p.close();
+});
+
+test('404 for non-namespace errors is passed through unchanged (DAK-6950)', async () => {
+  const p = await startProxy({}, (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found', message: 'Route not found' }));
+  });
+  const session = 'pg_404passtest';
+  const res = await request(p.port, {
+    method: 'POST',
+    path: '/v1/memory/recall',
+    headers: { 'content-type': 'application/json', 'x-playground-session': session },
+    body: JSON.stringify({ agent_id: 'test_cmp', query: 'test', top_k: 5 }),
+  });
+  assert.equal(res.status, 404, 'non-namespace 404 should pass through');
+  await p.close();
+});

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -157,20 +157,36 @@ function forward(config, req, res, path, bodyBuf, baseHeaders, rewrite) {
         outHeaders[k] = v;
       }
 
-      // Fast path: no agent_id was injected — stream straight through.
-      if (!rewrite) {
+      // DAK-6950: intercept 404 NAMESPACE_NOT_FOUND from the engine and convert
+      // to 200 with empty results. Avoids exposing engine-internal namespace errors
+      // to playground users whose seed data may not have landed yet.
+      const isNs404 = upRes.statusCode === 404;
+
+      // Fast path: no agent_id was injected — stream straight through (unless 404).
+      if (!rewrite && !isNs404) {
         res.writeHead(upRes.statusCode || 502, outHeaders);
         upRes.pipe(res);
         return;
       }
 
-      // Namespaced request: buffer the response so we can restore the client's
-      // original agent_id before returning it (DAK-6757). Sandbox payloads are
-      // small, so buffering here is cheap.
+      // Namespaced request (or potential 404): buffer the response so we can
+      // restore agent_id and/or intercept namespace-not-found (DAK-6757, DAK-6950).
       const chunks = [];
       upRes.on('data', (c) => chunks.push(c));
       upRes.on('end', () => {
-        const buf = restoreResponseAgentId(Buffer.concat(chunks), rewrite.namespace, rewrite.restoreTo);
+        let buf = Buffer.concat(chunks);
+        if (isNs404) {
+          const bodyStr = buf.toString('utf8');
+          if (bodyStr.indexOf('amespace not found') >= 0 || bodyStr.indexOf('NAMESPACE_NOT_FOUND') >= 0) {
+            const empty = JSON.stringify({ memories: [], note: 'namespace_initializing' });
+            outHeaders['content-length'] = String(Buffer.byteLength(empty));
+            delete outHeaders['transfer-encoding'];
+            res.writeHead(200, outHeaders);
+            res.end(empty);
+            return;
+          }
+        }
+        if (rewrite) buf = restoreResponseAgentId(buf, rewrite.namespace, rewrite.restoreTo);
         outHeaders['content-length'] = String(buf.length);
         delete outHeaders['transfer-encoding'];
         res.writeHead(upRes.statusCode || 502, outHeaders);


### PR DESCRIPTION
## Summary
- **Proxy-level resilience**: Sandbox proxy now intercepts 404 responses containing "Namespace not found" or "NAMESPACE_NOT_FOUND" from the engine and converts to `200 {"memories":[],"note":"namespace_initializing"}`
- Makes ALL playground modes resilient to seed→recall race without engine changes
- Non-namespace 404s pass through unchanged
- **Tests**: 60/60 pass (2 new tests: conversion + passthrough)

## Context
Companion to website PR — fixes the proxy layer so even if the frontend seed fails, the user sees empty results instead of cryptic 404 errors.

## Test plan
- [ ] 60/60 proxy tests pass (verified locally)
- [ ] CI green
- [ ] Companion website PR fixes frontend seed chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)