### PR TITLE
feat(proxy): add _agent_c to multiagent namespace isolation (DAK-6952)

### DIFF
--- a/docker/playground/proxy/namespace.js
+++ b/docker/playground/proxy/namespace.js
@@ -31,7 +31,7 @@ const NS_PREFIX = 'playground-demo';
 // Frontend agent_ids follow the pattern `pg_XXXXXX_<suffix>` where the suffix
 // identifies the scenario.  We map suffixes to scenario keys so that:
 //   - each scenario gets its own isolated namespace
-//   - _agent_a and _agent_b share a namespace (multi-agent demo feature)
+//   - _agent_a, _agent_b, and _agent_c share a namespace (multi-agent demo feature)
 //   - all _llm_* variants share a namespace (they seed different agent_ids)
 //   - `playground-demo` (API Explorer auto-seed) maps to `default`
 
@@ -47,8 +47,8 @@ function scenarioKey(agentId) {
   // Exact match for the base playground-demo id (API Explorer / auto-seed)
   if (agentId === NS_PREFIX || agentId === 'playground-demo') return 'default';
 
-  // Multi-agent: _agent_a and _agent_b share a namespace
-  if (agentId.endsWith('_agent_a') || agentId.endsWith('_agent_b')) return 'multiagent';
+  // Multi-agent: _agent_a, _agent_b, and _agent_c share a namespace
+  if (agentId.endsWith('_agent_a') || agentId.endsWith('_agent_b') || agentId.endsWith('_agent_c')) return 'multiagent';
 
   // All LLM compare variants share one namespace
   if (/_llm_/.test(agentId)) return 'llm';

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -468,9 +468,10 @@ test('scenarioKey extracts correct keys from agent_ids (DAK-6929)', () => {
   assert.equal(scenarioKey('pg_abcdef_llm_legal'), 'llm');
   assert.equal(scenarioKey('pg_abcdef_llm_devops'), 'llm');
 
-  // Multi-agent: _agent_a and _agent_b both map to 'multiagent'
+  // Multi-agent: _agent_a, _agent_b, and _agent_c all map to 'multiagent'
   assert.equal(scenarioKey('pg_abcdef_agent_a'), 'multiagent');
   assert.equal(scenarioKey('pg_abcdef_agent_b'), 'multiagent');
+  assert.equal(scenarioKey('pg_abcdef_agent_c'), 'multiagent');
 
   // Arbitrary suffix extraction — the regex `pg_[A-Za-z0-9_-]{6,}_(.+)$` is
   // greedy, so `[A-Za-z0-9_-]{6,}` consumes as much as possible including
@@ -501,11 +502,13 @@ test('sessionNamespace produces different namespaces for different scenarios (DA
   }
 });
 
-test('multi-agent _agent_a and _agent_b share the same namespace (DAK-6929)', () => {
+test('multi-agent _agent_a, _agent_b, and _agent_c share the same namespace (DAK-6952)', () => {
   const session = 'pg_multitest';
   const nsA = sessionNamespace(session, 'pg_multitest_agent_a');
   const nsB = sessionNamespace(session, 'pg_multitest_agent_b');
+  const nsC = sessionNamespace(session, 'pg_multitest_agent_c');
   assert.equal(nsA, nsB, '_agent_a and _agent_b must share a namespace for cross-agent demo');
+  assert.equal(nsB, nsC, '_agent_c must also share the same namespace for 3-agent pipeline');
 });
 
 test('LLM variants all share the same namespace (DAK-6929)', () => {


### PR DESCRIPTION
## Summary
- Add `_agent_c` to the multiagent scenario key check in `namespace.js` so all 3 agents (A, B, C) share the same namespace
- Update proxy tests: 60/60 pass including new `_agent_c` namespace sharing assertion

## Context
Companion to website PR — the Multi-Agent Memory Sharing mode now uses 3 agents (Onboarding → Support → Analytics). Agent C needs the same namespace isolation as A and B.

## Test plan
- [x] `node --test docker/playground/proxy/proxy.test.js` — 60/60 pass
- [ ] Founder reviews and approves (public repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)