### PR TITLE
fix(playground): increase Nginx burst 20→50 (DAK-6961)

### DIFF
--- a/docker/nginx-playground.conf
+++ b/docker/nginx-playground.conf
@@ -2,7 +2,7 @@
 # Nginx — Dakera Playground Rate Limiting + TLS (DAK-6706)
 # =============================================================================
 # Rate zones:
-#   playground_api    10 req/min per IP, burst 20 — coarse DDoS ceiling (DAK-6710 AC8)
+#   playground_api    10 req/min per IP, burst 50 — coarse DDoS ceiling (DAK-6710/6961)
 #   playground_health 60 req/s per IP, burst 20 — /health (monitoring)
 #   playground_conn   20 concurrent connections per IP
 #
@@ -72,7 +72,7 @@ server {
     # server-side root-key injection (DAK-6713). The proxy forwards to the
     # engine on :3000.
     location / {
-        limit_req        zone=playground_api burst=20 nodelay;
+        limit_req        zone=playground_api burst=50 nodelay;
         limit_req_status 429;
 
         proxy_pass            http://127.0.0.1:3100;


### PR DESCRIPTION
## Summary
- Increase `burst=20` → `burst=50` on the playground API rate limit zone (nginx-playground.conf line 75)
- Root cause: `autoSeedDemoData` consumes ~10 burst tokens on page load. When users visit multiple lazy-seeded modes before Compare, burst is exhausted and `seedCmp` gets 429 errors
- Playground-only change — sandbox proxy still enforces per-session limits (10 req/min, 50 memory cap)

## Test plan
- [ ] Deploy to playground server
- [ ] Open incognito tab → visit Graph Explorer → switch to Compare → click Compare → verify data seeds
- [ ] Verify all 6 playground modes still work after burst increase
- [ ] Founder verifies on playground.dakera.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)