### PR TITLE
fix(proxy): allow POST /v1/knowledge/query + convert to GET (DAK-6919)

### DIFF
--- a/docker/playground/proxy/allowlist.js
+++ b/docker/playground/proxy/allowlist.js
@@ -70,6 +70,10 @@ const ALLOW = [
   // (lib.rs:455-456 get(kg_query) / get(kg_path)) — they were wrongly allowed
   // as POST, so the proxy 403'd query and the engine 405'd path (DAK-6758).
   compile('GET', '/v1/knowledge/query'),
+  // POST /v1/knowledge/query is a convenience alias (DAK-6919): server.js converts
+  // the POST body (KgQueryParams as JSON) → GET query string before forwarding so
+  // clients that send a JSON body (QA E2E, direct fetch) work without engine changes.
+  compile('POST', '/v1/knowledge/query'),
   compile('GET', '/v1/knowledge/path'),
   // /v1/knowledge/graph is POST-only in the engine (lib.rs:483 post). The dead
   // GET entry was removed (it could only ever 405).

--- a/docker/playground/proxy/proxy.test.js
+++ b/docker/playground/proxy/proxy.test.js
@@ -125,7 +125,9 @@ test('allow-list methods match engine routes (DAK-6758)', () => {
   // Scenario 4 knowledge query + path: engine has GET (lib.rs:455-456).
   assert.ok(isAllowed('GET', '/v1/knowledge/query'));
   assert.ok(isAllowed('GET', '/v1/knowledge/path'));
-  assert.ok(!isAllowed('POST', '/v1/knowledge/query')); // old wrong method 403'd
+  // DAK-6919: POST is now a convenience alias — server.js converts POST body →
+  // GET query string before forwarding (engine only has GET for this route).
+  assert.ok(isAllowed('POST', '/v1/knowledge/query'));
   assert.ok(!isAllowed('POST', '/v1/knowledge/path'));
   // Scenario 5 memory decay: engine has POST (lib.rs:400).
   assert.ok(isAllowed('POST', '/v1/memory/importance'));

--- a/docker/playground/proxy/server.js
+++ b/docker/playground/proxy/server.js
@@ -477,6 +477,24 @@ function createServer(config, store) {
       forwardPath = `/v1/namespaces/_dakera_agent_${ns}/hybrid`;
     }
 
+    // Method rewrite: POST /v1/knowledge/query → GET with query-string params (DAK-6919).
+    // The engine only registers GET for this route (lib.rs:455 get(kg_query)). Some clients
+    // (QA E2E, direct fetch) POST a JSON body with KgQueryParams instead of using GET query
+    // params. We convert: parse the already-namespaced body, build URL query string, forward
+    // as GET with an empty body. Agent_id has already been namespaced by the body-rewrite step.
+    if (path === '/v1/knowledge/query' && method === 'POST' && bodyBuf.length) {
+      try {
+        const parsed = JSON.parse(bodyBuf.toString('utf8'));
+        const qs = Object.entries(parsed)
+          .filter(([, v]) => v !== undefined && v !== null)
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+          .join('&');
+        forwardPath = qs ? `/v1/knowledge/query?${qs}` : '/v1/knowledge/query';
+        bodyBuf = Buffer.alloc(0);
+        req.method = 'GET';
+      } catch (_) { /* malformed body — fall through, engine will reject with 400 */ }
+    }
+
     forward(config, req, res, forwardPath, bodyBuf, outHeaders, rewrite);
   });
 }


### PR DESCRIPTION
## Summary

- **allowlist.js**: add `POST /v1/knowledge/query` (convenience alias for QA E2E + direct-fetch clients)
- **server.js**: convert `POST` body (`KgQueryParams` JSON) → `GET` query string before forwarding to engine (same pattern as DAK-6906 hybrid rewrite). Agent_id is already session-namespaced by the existing body-rewrite step.
- **proxy.test.js**: update the DAK-6758 `!isAllowed('POST',...)` assertion; add DAK-6919 comment explaining the conversion

The engine only has `GET /v1/knowledge/query` (lib.rs:455). Adding POST to the allowlist alone would change 403→405; the server.js conversion ensures the engine actually receives GET with correct query params.

**Verification**: `node --test` → 64/64 pass

Fixes: DAK-6894 / DAK-6919
Unblocks: DAK-6714 (QA E2E 20/20)

## Test plan
- [x] `node --test` 64/64 pass locally
- [ ] Deploy via `playground-proxy-deploy.yml` to playground server
- [ ] QA E2E re-run: POST /v1/knowledge/query returns 200 (not 403)
- [ ] GET /v1/knowledge/query still works (regression: existing scenario 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)