### PR TITLE
fix(ci): fix YAML indentation in playground-uptime-check.yml (DAK-7032)

### DIFF
--- a/.github/workflows/playground-uptime-check.yml
+++ b/.github/workflows/playground-uptime-check.yml
@@ -37,20 +37,14 @@ jobs:
           DAKERA_STATUS="${{ steps.health.outputs.dakera_status }}"
           VERSION="${{ steps.health.outputs.version }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          MSG="🔴 *[Platform] Playground DOWN*
-
-URL: \`https://playground.dakera.ai/health\`
-HTTP: \`${HTTP_STATUS}\`
-Dakera status: \`${DAKERA_STATUS}\`
-Version: \`${VERSION}\`
-Run: ${RUN_URL}
-
-Check playground server containers and proxy."
-
+          CHAT_ID="${{ secrets.TELEGRAM_CHAT_ID }}"
+          MSG=$(printf "🔴 *[Platform] Playground DOWN*\n\nURL: \`https://playground.dakera.ai/health\`\nHTTP: \`%s\`\nDakera status: \`%s\`\nVersion: \`%s\`\nRun: %s\n\nCheck playground server containers and proxy." \
+            "$HTTP_STATUS" "$DAKERA_STATUS" "$VERSION" "$RUN_URL")
+          BODY=$(jq -n --arg chat_id "$CHAT_ID" --arg text "$MSG" \
+            '{chat_id: $chat_id, text: $text, parse_mode: "Markdown"}')
           curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -H "Content-Type: application/json" \
-            -d "{\"chat_id\":\"${{ secrets.TELEGRAM_CHAT_ID }}\",\"text\":\"$(echo "$MSG" | sed 's/"/\\"/g')\",\"parse_mode\":\"Markdown\"}" \
+            -d "$BODY" \
             > /dev/null || true
           echo "Telegram alert sent"
           exit 1


### PR DESCRIPTION
## Summary

Fixes playground uptime check workflow failing with "workflow file issue" on every run ([main run 27920225606](https://github.com/Dakera-AI/dakera-deploy/actions/runs/27920225606)).

## Root Cause

The multi-line `MSG=` assignment in the `Alert on failure` step had content lines starting at **column 0** inside a `run: |` block that requires **10-space indentation**. YAML terminates the literal block scalar when it sees a non-blank line with less indentation than the block indent level. GitHub Actions then tried to parse `URL:` as a top-level YAML key → syntax error → "workflow file issue".

## Fix

- Replace multi-line bash string with `printf` on a single properly-indented line
- Use `jq` for proper JSON encoding of the Telegram payload (handles newlines and special chars correctly)
- All lines remain within the 10-space indentation block

## Verification

After merge, the `schedule` trigger fires every 15 min. Can also use `workflow_dispatch` to manually test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)