### PR TITLE
fix: update docker-compose.yml image tag from stale pin to :latest

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Dakera - AI Agent Memory Platform
   # ==========================================================================
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
     container_name: dakera
     ports:
       - "${DAKERA_PORT:-3000}:3000"
@@ -41,7 +41,7 @@ services:
       - DAKERA_WARM_TO_COLD_SECS=86400
       - DAKERA_AUTO_TIER=true
       - DAKERA_TIER_CHECK_INTERVAL_SECS=300
-      # DAK-6209/DAK-6284: TIERED ON — optA-baked-ec6ef91 has ONNX baked in (DAK-6272 cold-boot guard).
+      # Tiered storage: L1 hot memory → L2 warm RocksDB → L3 cold S3.
       - DAKERA_TIERED=1
       - DAKERA_SEARCH_MODE=hybrid
       - DAKERA_MAX_BODY_SIZE=524288000


### PR DESCRIPTION
## Summary

- Updates default `DAKERA_IMAGE` from a custom build (`optA-baked-ec6ef91`) that was 30+ releases behind to `ghcr.io/dakera-ai/dakera:latest` which tracks the current stable release (currently v0.11.93, updated automatically on each release)
- Removes internal references from a public-facing comment
- The `${DAKERA_IMAGE:-...}` pattern is preserved — operators can still pin a specific tag by setting `DAKERA_IMAGE` in their `.env` file

## Why the old tag existed

The `optA-baked-ec6ef91` tag included ONNX embedding model files baked into the image for cold-boot environments without HuggingFace access. The standard `:latest` image downloads the ONNX model from HuggingFace on first run (public access, no `HF_TOKEN` required for the default `bge-large-en-v1.5` model). The `HF_TOKEN` env var in this compose file allows authenticated access for rate-limited environments.

## Test plan

- [ ] `docker compose pull` succeeds with `:latest` tag
- [ ] `docker compose up -d` starts cleanly
- [ ] `/health` returns `200 OK` after startup
- [ ] For air-gapped environments: set `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:v0.11.93` in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)