### PR TITLE
chore(release): bump remaining image tags to :latest + CHANGELOG 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Dakera deployment configurations will be documented i
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-25
+
+### Changed
+
+- **Bump default Dakera image to `:latest` across all deployment configs** — removes the stale pinned tags (`optA-baked-ec6ef91` and `0.11.81`) that were 13–30+ server releases behind. All files now default to `ghcr.io/dakera-ai/dakera:latest` which tracks the current stable release automatically. CTO confirmed: all official images since `v0.11.89+` (DAK-6224) include ONNX embedding files — the cold-boot concern that motivated the original pin is resolved.
+  - `docker/docker-compose.yml`: `optA-baked-ec6ef91` → `:latest` ([#243](https://github.com/Dakera-AI/dakera-deploy/pull/243))
+  - `docker/docker-compose.ha.yml`: `optA-baked-ec6ef91` → `:latest`
+  - `docker/docker-compose.local.yml`: `0.11.81` → `:latest`
+  - `k8s/dakera/deployment.yaml`: `optA-baked-ec6ef91` → `:latest`
+
+  Operators who need a pinned version can still override via `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:v0.11.94` in their `.env` file. The `${DAKERA_IMAGE:-...}` pattern is preserved in all compose files.
+
 ## [0.8.0] - 2026-05-29
 
 ### Changed

--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -35,7 +35,7 @@
 name: dakera-ha
 
 x-dakera-common: &dakera-common
-  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91}
+  image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
   restart: unless-stopped
   networks:
     - dakera-ha-net

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   dakera:
-    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:0.11.81}
+    image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
     ports:
       - "3000:3000"
       - "50051:50051"

--- a/k8s/dakera/deployment.yaml
+++ b/k8s/dakera/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: dakera
-          image: ghcr.io/dakera-ai/dakera:optA-baked-ec6ef91
+          image: ghcr.io/dakera-ai/dakera:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

PR#243 updated `docker/docker-compose.yml` but left three configs still on stale pinned tags. This PR completes the cleanup:

| File | Old tag | New tag |
|---|---|---|
| `docker/docker-compose.ha.yml` | `optA-baked-ec6ef91` (30+ releases behind) | `:latest` |
| `docker/docker-compose.local.yml` | `0.11.81` (13+ releases behind) | `:latest` |
| `k8s/dakera/deployment.yaml` | `optA-baked-ec6ef91` (30+ releases behind) | `:latest` |

Also adds the missing CHANGELOG `[0.9.0]` entry covering all image bumps (both PR#243 and this PR).

**Why safe:** CTO confirmed in room-release that all official images since `v0.11.89+` (DAK-6224) include ONNX embedding files — the cold-boot concern that motivated the original `optA-baked-ec6ef91` pin is fully resolved.

**Operator override:** The `${DAKERA_IMAGE:-...}` pattern is preserved in all compose files. Pin a specific version by setting `DAKERA_IMAGE=ghcr.io/dakera-ai/dakera:v0.11.94` in `.env`.

## Test plan

- [x] All 4 files have no remaining stale tags (`grep -r "optA-baked\|0\.11\.81\|0\.11\.90" docker/ k8s/` returns nothing in these files)
- [x] CHANGELOG 0.9.0 entry covers both PR#243 and this PR
- [x] k8s deployment.yaml uses bare `:latest` tag (no `${...}` env var syntax — consistent with existing k8s style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)