### PR TITLE
fix(runner): guard Phase-1 grep exit-1 on all-idle runner fleet (DAK-7574)

### DIFF
--- a/.github/workflows/runner-wedged-watchdog.yml
+++ b/.github/workflows/runner-wedged-watchdog.yml
@@ -61,7 +61,9 @@ jobs:
               BUSY_RUNNERS="${BUSY_RUNNERS} ${RUNNERS}"
             fi
           done
-          BUSY_RUNNERS=$(echo "$BUSY_RUNNERS" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
+          # (grep -v '^$' || true) guards against exit-1 when all runners are idle and
+          # grep has no non-empty lines to match — set -euo pipefail would otherwise kill the script
+          BUSY_RUNNERS=$(echo "$BUSY_RUNNERS" | tr ' ' '\n' | sort -u | (grep -v '^$' || true) | tr '\n' ' ')
 
           if [ -z "$BUSY_RUNNERS" ]; then
             echo "No busy runners — fleet healthy"


### PR DESCRIPTION
## Root Cause

The wedged-runner watchdog (`runner-wedged-watchdog.yml`) was failing every scheduled run since runners went idle.

**Failing line (Phase 1 dedup):**
```bash
BUSY_RUNNERS=$(echo "$BUSY_RUNNERS" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
```

When all runners are idle, `BUSY_RUNNERS=""`. The pipeline fed a single empty line to `grep -v '^$'`, which filtered it out and exited 1 (no lines matched). With `set -euo pipefail`, this exit-1 propagated through the command substitution to the assignment, killing the script before it could reach the healthy-fleet early-exit check at line 66.

**Timeline match:** Fails ~2s into the step — consistent with 4x `gh api` calls (~0.5s each) completing, then hitting the dedup line.

## Fix

Wrap `grep` in a subshell with `|| true` so the dedup pipeline always exits 0:
```bash
BUSY_RUNNERS=$(echo "$BUSY_RUNNERS" | tr ' ' '\n' | sort -u | (grep -v '^$' || true) | tr '\n' ' ')
```

The all-idle path still reaches the `[ -z "$BUSY_RUNNERS" ]` guard and exits cleanly with "No busy runners — fleet healthy".

## Verified

Local smoke test under `set -euo pipefail`:
- **All-idle case:** `BUSY_RUNNERS=""` → pipeline exits 0, guard fires correctly ✓
- **Busy case:** deduped runner names preserved correctly ✓

## Impact

- Restores the wedged-runner auto-heal safety net (was down since 2026-07-26 17:10Z)
- Eliminates hourly false-failure noise on the scheduled workflow

Closes DAK-7574