### PR TITLE
fix(docker): exec form for HEALTHCHECK CMD — resolves DL3025 (DAK-7718)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,6 +181,6 @@ EXPOSE 3000 50051
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://127.0.0.1:3000/health || exit 1
+    CMD ["curl", "-f", "http://127.0.0.1:3000/health"]
 
 CMD ["dakera"]


### PR DESCRIPTION
## Summary

- Hadolint v2.15.0 (in hadolint-action 3.4.0, PR#258) extended DL3025 to cover HEALTHCHECK CMD shell-form
- Fixes `HEALTHCHECK ... CMD curl -f ...` → `HEALTHCHECK ... CMD ["curl", "-f", ...]`
- The `|| exit 1` suffix was unnecessary — `curl -f` already returns non-zero on HTTP error

## Root cause

`hadolint/hadolint-action@v3.4.0` bumps hadolint from v2.14.0 to v2.15.0. The new version enforces DL3025 ("Use arguments JSON notation for CMD and ENTRYPOINT arguments") on `HEALTHCHECK CMD` shell form — a new check not present in v2.14.0.

## Test plan
- [ ] CI: `Validate Docker Configs` passes on this PR
- [ ] After merge to main: PR#258 (dependabot hadolint-action bump) CI passes and can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)