### PR TITLE
fix(docker): raise nofile ulimit to prevent EMFILE under concurrent load

### DIFF
--- a/docker/docker-compose.ha.yml
+++ b/docker/docker-compose.ha.yml
@@ -37,6 +37,10 @@ name: dakera-ha
 x-dakera-common: &dakera-common
   image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
   restart: unless-stopped
+  ulimits:
+    nofile:
+      soft: 65536
+      hard: 1048576
   networks:
     - dakera-ha-net
   expose:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,6 +61,10 @@ services:
         reservations:
           memory: 512M
           cpus: "0.5"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 1048576
     depends_on:
       minio-setup:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary

Root cause of recurring EMFILE on prod (178.104.45.161):

- dakera runs **inside a Docker container** (containerd-shim) — not bare systemd
- Docker default soft `nofile` = **1024** (verified via `/proc/PID/limits` this heartbeat)
- systemd `LimitNOFILE=1048576` is irrelevant for containerized processes
- Under concurrent namespace access, OpenDAL fs backend hits EMFILE

## Changes

- `docker/docker-compose.yml` — adds `ulimits.nofile: soft=65536 hard=1048576` to dakera service
- `docker/docker-compose.ha.yml` — adds same to `x-dakera-common` anchor (all 3 HA nodes inherit)

## Validation

Both compose files pass `docker compose config --quiet` ✅

## Deployment Note

Requires `docker compose up -d` on prod to restart the container with new limits.
After restart, verify: `cat /proc/$(docker inspect -f '{{.State.Pid}}' dakera)/limits | grep files`

## Test Plan

- [ ] CI passes (Kustomize Validate + Validate Docker Configs)
- [ ] Post-deploy: soft limit shows 65536 on prod container