### PR TITLE
fix(dashboard): bump to v0.3.30 — fixes monitoring tiers parse error (DAK-7710)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -180,7 +180,7 @@ services:
   # Dakera Dashboard (optional)
   # ==========================================================================
   dashboard:
-    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.29}
+    image: ${DASHBOARD_IMAGE:-ghcr.io/dakera-ai/dakera-dashboard:0.3.30}
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:


### PR DESCRIPTION
## Summary

- Bumps dashboard default image `0.3.29` → `0.3.30`
- Fixes **DAK-7710**: Monitoring page showed 'Failed to load: tiers' on every load

## Root Cause

`hot_tier_capacity` in `TierConfig` was typed as `usize` in dashboard v0.3.29. WASM is 32-bit, so `usize = u32`. The server returns `hot_tier_capacity: 18446744073709551615` (u64::MAX for "unlimited"). This value overflows u32 → `serde_json` parse error → `ApiError::Parse` → error banner.

**Fix**: PR#74 in dakera-dashboard changed the type from `usize` to `u64`. Deployed as v0.3.30 (already published to GHCR).

## Verification

- Deployed `0.3.30` directly to production (178.104.45.161)
- Took screenshots at 375px and 1280px viewports — no error banner, HEALTHY status, real data loading
- All 9 monitoring sections load successfully

## Test plan
- [x] Monitoring page loads without 'Failed to load: tiers' at 1280px
- [x] Monitoring page loads without 'Failed to load: tiers' at 375px mobile
- [x] HEALTHY status confirmed, real metrics displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)