### PR TITLE
fix(ci): run wedged-runner watchdog on ARM64 not x64 (DAK-7528)

### DIFF
--- a/.github/workflows/runner-wedged-watchdog.yml
+++ b/.github/workflows/runner-wedged-watchdog.yml
@@ -1,11 +1,11 @@
 name: Wedged Runner Auto-Heal (DAK-7528)
 
 # Detects self-hosted runners that are busy=true with no active job (wedged state)
-# and auto-restarts them. Runs on the x64 self-hosted runner (DAK-7665) so it
-# survives GitHub-hosted billing outages. Partial self-reference trade-off: if the
-# x64 runner itself is wedged, this job cannot run — but ARM is still monitored.
-# Full coverage requires an independent monitor; partial coverage beats zero during
-# a GitHub Actions billing lock.
+# and auto-restarts them. Runs on the ARM self-hosted runner (hetzner-arm-deploy)
+# which is the only runner registered for dakera-deploy. The ARM runner has full
+# SSH access to both the ARM and x64 runner hosts via RUNNER_SSH_KEY so it can
+# heal both fleets. Partial self-reference trade-off: if the ARM runner itself is
+# wedged, this job cannot run — but recovery falls to manual or CTO escalation.
 #
 # Wedged signature:
 #   - Runner shows busy=true in GitHub API
@@ -42,7 +42,7 @@ env:
 jobs:
   detect-and-heal:
     name: Detect + auto-heal wedged runners
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Check runner busy state and CI queue
         id: runner-check


### PR DESCRIPTION
## Problem

The `runner-wedged-watchdog.yml` workflow was configured with `runs-on: [self-hosted, linux, x64]` but `dakera-deploy` only has `hetzner-arm-deploy` (ARM64) registered as a self-hosted runner. No x64 runner was ever registered for this repo.

**Impact:** Every scheduled run (*/10 min) queued indefinitely with no runner to pick it up, then got cancelled by the next schedule tick. The watchdog has been completely inactive for 24+ hours — runners were unmonitored.

Verified via `gh api repos/dakera-ai/dakera-deploy/actions/runners` → only `hetzner-arm-deploy (ARM64, online, not busy)`.

## Fix

Change `runs-on` to `[self-hosted, linux, ARM64]` to use the registered `hetzner-arm-deploy` runner.

The ARM runner has `RUNNER_SSH_KEY` access to both the ARM runner host (168.119.60.30) and x64 runner host (178.104.227.173), so healing capability for both fleets is preserved.

## Verification

After merge, the next */10 min schedule should be picked up by `hetzner-arm-deploy` and complete (fleet is currently healthy → expected to exit cleanly at Phase 1 with "No busy runners").

🤖 Platform agent — DAK-7528 self-heal restoration