### PR TITLE
fix(docker): mimalloc purge-delay=0 + memory.high=7G slice for Dakera container (DAK-9814)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,12 @@ services:
   dakera:
     image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
     container_name: dakera
+    # FW-b5ad5a7f / DAK-9814: place the container under a systemd slice that
+    # sets memory.high=7G (soft cgroup-v2 backpressure). The kernel throttles &
+    # reclaims before the 8G hard wall (deploy.resources.limits.memory), giving
+    # graceful degradation instead of an OOM kill. Requires dakera-mem.slice on
+    # the host (see scripts/install-dakera-mem-slice.sh). No-op if absent.
+    cgroup_parent: dakera-mem.slice
     ports:
       - "${DAKERA_PORT:-3000}:3000"
       - "${DAKERA_GRPC_PORT:-50051}:50051"
@@ -50,6 +56,10 @@ services:
       - DAKERA_ROOT_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.example)}
       - HF_TOKEN=${HF_TOKEN:-}
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+      # FW-b5ad5a7f / DAK-9814: mimalloc returns freed pages to the OS
+      # immediately (purge delay 0ms) so container RSS returns to baseline
+      # after allocation peaks instead of retaining decommitted heap.
+      - MIMALLOC_PURGE_DELAY=0
     volumes:
       - dakera-cache:/data/cache
       - dakera-rocksdb:/data/rocksdb

--- a/docker/scripts/install-dakera-mem-slice.sh
+++ b/docker/scripts/install-dakera-mem-slice.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# =============================================================================
+# install-dakera-mem-slice.sh  (FW-b5ad5a7f / DAK-9814)
+# -----------------------------------------------------------------------------
+# Installs a systemd slice that applies a cgroup-v2 memory.high (soft limit) to
+# the Dakera container. Referenced by docker-compose.yml via `cgroup_parent`.
+#
+# Why: the Dakera container's RSS did not return to baseline after allocation
+# peaks and pegged the 8G hard cap, exhausting host swap (same precondition as
+# the 2026-07-11 UI-hang). memory.high=7G lets the kernel throttle & reclaim the
+# cgroup gracefully BEFORE the 8G hard wall (memory.max) triggers an OOM kill.
+# The root fix (mimalloc returning pages to the OS) is MIMALLOC_PURGE_DELAY=0 in
+# the compose env; this slice is the safety net.
+#
+# Idempotent. Requires root (systemd unit + daemon-reload). Persists across
+# reboots and CI redeploys (deploys scp only docker-compose.yml, not units).
+# =============================================================================
+set -euo pipefail
+
+MEM_HIGH="${DAKERA_MEM_HIGH:-7G}"
+UNIT=/etc/systemd/system/dakera-mem.slice
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Re-executing under sudo..." >&2
+  exec sudo -E "$0" "$@"
+fi
+
+# cgroup v2 is required for MemoryHigh on a slice.
+if [[ "$(stat -fc %T /sys/fs/cgroup/ 2>/dev/null)" != "cgroup2fs" ]]; then
+  echo "ERROR: host is not on cgroup v2; memory.high slice unsupported." >&2
+  exit 1
+fi
+
+cat > "$UNIT" <<EOF
+# Managed by install-dakera-mem-slice.sh (FW-b5ad5a7f / DAK-9814).
+# Soft memory backpressure for the Dakera container; see docker-compose.yml
+# cgroup_parent: dakera-mem.slice.
+[Unit]
+Description=Dakera container memory slice (soft memory.high backpressure)
+Before=docker.service
+
+[Slice]
+MemoryAccounting=yes
+MemoryHigh=${MEM_HIGH}
+EOF
+
+systemctl daemon-reload
+systemctl start dakera-mem.slice
+
+echo "✅ dakera-mem.slice installed with MemoryHigh=${MEM_HIGH}"
+systemctl show dakera-mem.slice -p MemoryHigh -p MemoryAccounting


### PR DESCRIPTION
## Summary
Operational fix from ENGINE-GAP **FW-b5ad5a7f** triage (DAK-9814). The Dakera container's RSS never returned to baseline after allocation peaks, pegging the 8G hard cap and exhausting host swap — the same precondition as the 2026-07-11 UI-hang.

## Changes
1. **Root fix — `MIMALLOC_PURGE_DELAY=0`** (compose env): mimalloc returns freed pages to the OS immediately instead of retaining decommitted heap. The Dakera binary links mimalloc (verified in `/proc/1/maps`), so this is an effective knob, not a no-op.
2. **Safety net — `memory.high=7G`** via `cgroup_parent: dakera-mem.slice` + `docker/scripts/install-dakera-mem-slice.sh` (host bootstrap, idempotent, cgroup-v2, persists across reboots/redeploys). The kernel throttles + reclaims the cgroup gracefully before the 8G hard wall (`memory.max`) triggers an OOM kill. The 8G hard cap is unchanged.

## Verified on prod (178.104.45.161)
- Container recreated with pinned image `0.11.106`, `healthy`.
- `MIMALLOC_PURGE_DELAY=0` present in container env.
- `dakera-mem.slice` `memory.high=7516192768` (7G) enforced; scope `memory.max=8589934592` (8G) preserved.
- RSS dropped **7.4GB → 6.0GB** (92.6% → 74.7%) on recreate; the ~1.4GB of mimalloc-retained freed pages released.

## Durability
The host slice unit is already installed on prod. This PR codifies the compose change + the bootstrap script so the production deploy (`deploy-production.yml` scp's this compose) preserves both changes on the next release.

## Rollback
Remove the env var + `cgroup_parent` and redeploy; `systemctl stop dakera-mem.slice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)