### PR TITLE
fix(security): bind Docker published ports to 127.0.0.1 — prevent UFW bypass (DAK-9811)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     image: ${DAKERA_IMAGE:-ghcr.io/dakera-ai/dakera:latest}
     container_name: dakera
     ports:
-      - "${DAKERA_PORT:-3000}:3000"
-      - "${DAKERA_GRPC_PORT:-50051}:50051"
+      - "127.0.0.1:${DAKERA_PORT:-3000}:3000"
+      - "127.0.0.1:${DAKERA_GRPC_PORT:-50051}:50051"
     environment:
       - RUST_LOG=${RUST_LOG:-info}
       - DAKERA_HOST=0.0.0.0
@@ -86,8 +86,8 @@ services:
     container_name: dakera-minio
     command: server /data --console-address ":9001"
     ports:
-      - "${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+      - "127.0.0.1:${MINIO_API_PORT:-9000}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001"
     environment:
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -141,7 +141,7 @@ services:
     container_name: dakera-prometheus
     profiles: ["monitoring", "full"]
     ports:
-      - "${PROMETHEUS_PORT:-9090}:9090"
+      - "127.0.0.1:${PROMETHEUS_PORT:-9090}:9090"
     volumes:
       - ../monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ../monitoring/alerting-rules.yml:/etc/prometheus/alerting-rules.yml:ro
@@ -160,7 +160,7 @@ services:
     container_name: dakera-grafana
     profiles: ["monitoring", "full"]
     ports:
-      - "${GRAFANA_PORT:-3003}:3000"
+      - "127.0.0.1:${GRAFANA_PORT:-3003}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
@@ -184,7 +184,7 @@ services:
     container_name: dakera-dashboard
     profiles: ["dashboard", "full"]
     ports:
-      - "${DASHBOARD_PORT:-3002}:3000"
+      - "127.0.0.1:${DASHBOARD_PORT:-3002}:3000"
     environment:
       - DAKERA_API_UPSTREAM=http://dakera:3000
       - DAKERA_API_KEY=${DAKERA_ROOT_API_KEY:?Set DAKERA_ROOT_API_KEY in .env (see .env.example)}
@@ -210,7 +210,7 @@ services:
     container_name: dakera-ode
     profiles: ["ode", "full"]
     ports:
-      - "${ODE_PORT:-8080}:8080"
+      - "127.0.0.1:${ODE_PORT:-8080}:8080"
     environment:
       - LOG_LEVEL=${ODE_LOG_LEVEL:-info}
     deploy:


### PR DESCRIPTION
## Summary

Docker's iptables DNAT rules bypass UFW's INPUT chain — every `-p 0.0.0.0:PORT:PORT` published port is reachable from the public internet regardless of UFW policy. Discovered via flywheel dogfooding (FW-3c6cc526, DAK-7771 Move 3).

- **Exposed**: dakera 3300 (memory API), 50051 (gRPC), minio 9000/9001, dashboard 3002
- **Auth holds**: 3300 returns 401, minio 9000 returns 403 — NOT a data breach
- **Risk**: unnecessary attack surface for internal memory API, version disclosure via /health, DoS amplification

## Fix

Bind all published ports to `127.0.0.1` instead of `0.0.0.0`. Caddy and local processes retain full access; the public internet cannot reach container ports.

## Immediate mitigation (already applied on prod)

DOCKER-USER iptables rules applied and persisted in `/etc/ufw/after.rules`:
- RETURN for ESTABLISHED/loopback/tailscale (100.64.0.0/10)/docker-nets (172.16/12, 10/8)
- DROP for eth0 (public interface)

Verified: `curl http://127.0.0.1:3300/health` → 200, all containers healthy.

## Test plan

- [ ] CI lint passes
- [ ] After deploy: `docker ps` shows `127.0.0.1:3300->3000/tcp` (not `0.0.0.0`)
- [ ] Caddy proxy (8443) still serves dashboard and API correctly
- [ ] `curl http://127.0.0.1:3300/health` → 200 from prod box

🤖 Generated with [Claude Code](https://claude.com/claude-code)