### PR TITLE
fix(ci): repair distribution-freshness YAML startup_failure + add workflow parse gate (DAK-9928)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,30 @@ jobs:
           dockerfile: docker/Dockerfile
           failure-threshold: warning
 
+  validate-workflows:
+    name: Validate Workflow YAML
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Parse all workflow YAML files
+        run: |
+          python3 - <<'EOF'
+          import yaml, glob, sys
+          errors = []
+          for f in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  yaml.safe_load(open(f))
+              except yaml.YAMLError as e:
+                  errors.append(f"{f}: {e}")
+          if errors:
+              print("YAML parse errors found:")
+              for e in errors:
+                  print(f"  {e}")
+              sys.exit(1)
+          print(f"All {len(glob.glob('.github/workflows/*.yml'))} workflow files parse cleanly.")
+          EOF
+
   kustomize-validate:
     name: Kustomize Validate
     runs-on: [self-hosted, linux, arm64]

--- a/.github/workflows/distribution-freshness.yml
+++ b/.github/workflows/distribution-freshness.yml
@@ -230,14 +230,15 @@ jobs:
           SERVER_VERSION: ${{ steps.server.outputs.version }}
           STALE_COUNT: ${{ steps.report.outputs.stale_count }}
         run: |
-          MSG="⚠️ [Platform] Distribution Freshness ALERT
-
-Server: v${SERVER_VERSION}
-Stale channels (${STALE_COUNT}): ${STALE_NAMES}
-
-These distribution channels have not been updated within ${LAG_THRESHOLD_DAYS} days of the server release. Review and cut releases or update formulas/packages.
-
-Full report: https://github.com/dakera-ai/dakera-deploy/actions/runs/${{ github.run_id }}"
+          MSG=$(printf '%s\n' \
+            "⚠️ [Platform] Distribution Freshness ALERT" \
+            "" \
+            "Server: v${SERVER_VERSION}" \
+            "Stale channels (${STALE_COUNT}): ${STALE_NAMES}" \
+            "" \
+            "These distribution channels have not been updated within ${LAG_THRESHOLD_DAYS} days of the server release. Review and cut releases or update formulas/packages." \
+            "" \
+            "Full report: https://github.com/dakera-ai/dakera-deploy/actions/runs/${{ github.run_id }}")
 
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

- **Root cause**: `MSG="..."` multi-line string in the Telegram alert step had continuation lines at column 0 — below the `run: |` block-scalar indent (10 spaces). YAML terminated the block scalar early, raising a mapping-key scan error at ~line 238 → GitHub reported `startup_failure` with 0 jobs, no logs. Both runs since merge (https://github.com/dakera-ai/dakera-deploy/actions/runs/33733654394 and the 08:33 run) failed this way.
- **Fix**: Replace the heredoc-style `MSG="..."` with `printf '%s\n'` — all lines stay inside the indented block scalar.
- **Gate**: Add `validate-workflows` CI job that runs `python3 yaml.safe_load` on every `.github/workflows/*.yml` — a broken workflow can no longer merge past CI undetected.

## Verification

Both files validate cleanly locally:
```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/distribution-freshness.yml'))" → YAML_VALID
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" → CI_YAML_VALID
```

## Test plan

- [ ] CI passes (validate-workflows job should go green on this PR itself)
- [ ] workflow_dispatch run of Distribution Freshness Monitor completes with real jobs/logs (not startup_failure)
- [ ] Monitor correctly reports all channels FRESH (server v0.11.107; helm, cli, mcp, apt/rpm/homebrew all current)

Closes DAK-9928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)