### PR TITLE
fix(deploy): surface ranking/storage/perf vars in .env.example (DAK-9931)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -54,14 +54,94 @@ MINIO_ROOT_PASSWORD=
 # JAEGER_UI_PORT=16686
 
 # =============================================================================
-# Request Limits (optional)
+# Search & Ranking (optional — defaults are production-tuned)
+# =============================================================================
+
+# Search mode: "hybrid" (vector + BM25 fusion), "vector", or "text"
+# DAKERA_SEARCH_MODE=hybrid
+
+# Hybrid fetch multiplier — controls how many candidates the hybrid pipeline
+# retrieves before ranking. Higher = better recall, slower latency.
+# DAKERA_HYBRID_FETCH_MULT=3.0
+
+# BM25 tuning (only affects hybrid/text modes)
+# DAKERA_BM25_K1=1.2
+# DAKERA_BM25_B=0.75
+# DAKERA_BM25_DELTA=0.0
+
+# RRF fusion constant for hybrid search
+# DAKERA_RRF_K=60
+
+# Temporal rerank gamma — weight of temporal proximity in precision reranking
+# DAKERA_TEMPORAL_RERANK_GAMMA=0.30
+
+# Adaptive word-vector boost (validated CE-147)
+# DAKERA_ADAPTIVE_WVEC_BOOST=0.65
+# DAKERA_ADAPTIVE_WVEC_THRESHOLD=0.3
+
+# PPR (Personalized PageRank) graph proximity fusion
+# DAKERA_PPR_FUSION=1
+
+# Bitemporal validity weight in post-ranking
+# DAKERA_BITEMPORAL_WEIGHT=0.1
+
+# Name-entity boost weight (0.0 = disabled)
+# DAKERA_NAME_BOOST=0.15
+
+# Supersession demotion (ON by default — opt-OUT with 0/false)
+# DAKERA_SUPERSEDE_DEMOTE=1
+
+# =============================================================================
+# Storage & Tiering (optional — defaults to S3 with tiered storage)
+# =============================================================================
+
+# Storage backend: "s3", "filesystem", or "memory"
+# DAKERA_STORAGE=s3
+
+# S3 / MinIO connection (auto-configured when using the bundled MinIO)
+# DAKERA_S3_ENDPOINT=http://minio:9000
+# DAKERA_S3_BUCKET=dakera
+# DAKERA_S3_REGION=us-east-1
+
+# Tiered storage (hot → warm → cold)
+# DAKERA_TIERED=1
+# DAKERA_TIERED_STORAGE=true
+# DAKERA_AUTO_TIER=true
+# DAKERA_HOT_TO_WARM_SECS=3600
+# DAKERA_WARM_TO_COLD_SECS=86400
+# DAKERA_TIER_CHECK_INTERVAL_SECS=300
+
+# L1 in-memory cache size in bytes (default: 512 MB)
+# DAKERA_L1_CACHE_SIZE=536870912
+
+# =============================================================================
+# Performance (optional)
 # =============================================================================
 
 # Request timeout in seconds (default: 120)
 # DAKERA_REQUEST_TIMEOUT=120
 
+# Max request body size in bytes (default: 500 MB)
+# DAKERA_MAX_BODY_SIZE=524288000
+
+# ONNX embedding inference pool size (default: 4)
+# DAKERA_ONNX_POOL_SIZE=4
+
 # gRPC endpoint toggle (default: true)
 # DAKERA_GRPC_ENABLED=true
+
+# =============================================================================
+# Watchdog (optional — monitors container health)
+# =============================================================================
+
+# Health check interval in seconds
+# DAKERA_WATCHDOG_POLL_SECS=30
+
+# Restart after N consecutive health failures
+# DAKERA_WATCHDOG_RESTART_AFTER=5
+
+# Memory alert threshold (percentage of container limit)
+# DAKERA_WATCHDOG_MEM_ALERT_PCT=90
 
 # =============================================================================
 # Docker Images (optional — defaults to latest published images)


### PR DESCRIPTION
## Summary
- Close the 8→32+ var drift between `.env.example` and `docker-compose.yml`
- Added documented sections: Search & Ranking (12 vars), Storage & Tiering (10 vars), Performance (4 vars), Watchdog (3 vars)
- All new vars commented-out with defaults — existing deployments unaffected

## Context
Part of CE-M13 Phase D deploy wiring (DAK-9931). The `.env.example` only documented 8 DAKERA_ vars while `docker-compose.yml` uses 32+. Self-hosters had no visibility into ranking tunables, storage config, or watchdog settings.

## Test plan
- [ ] Verify `docker compose config` still resolves correctly with unchanged `.env`
- [ ] Verify commented defaults match the values in `docker-compose.yml`

---
Created by: 🤖 Core Engine (automated)