### PR TITLE
fix(monitor): use GH_PAT_PACKAGES to fetch private dakera release

### DIFF
--- a/.github/workflows/distribution-freshness.yml
+++ b/.github/workflows/distribution-freshness.yml
@@ -24,7 +24,7 @@ jobs:
         id: server
         run: |
           RESPONSE=$(curl -sf https://api.github.com/repos/dakera-ai/dakera/releases/latest \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}")
+            -H "Authorization: Bearer ${{ secrets.GH_PAT_PACKAGES }}")
           TAG=$(echo "$RESPONSE" | jq -r '.tag_name')
           VERSION="${TAG#v}"
           PUBLISHED=$(echo "$RESPONSE" | jq -r '.published_at')


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` in `dakera-deploy` workflows only has permission for the `dakera-deploy` repo itself
- `dakera` is a private repo — fetching its releases requires a cross-repo PAT
- `GH_PAT_PACKAGES` already has cross-org `repo` scope (used in `server-ops.yml` to sync secrets to `dakera-bench`)
- Changes line 27: `${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.GH_PAT_PACKAGES }}`

## Failure pattern

`Distribution Freshness Monitor` was failing on every scheduled run (09:30 UTC daily) with exit code 22 (`curl -sf` HTTP 404 on the private dakera releases API).

Affected runs:
- https://github.com/Dakera-AI/dakera-deploy/actions/runs/33762531860
- https://github.com/Dakera-AI/dakera-deploy/actions/runs/33739900163
- https://github.com/Dakera-AI/dakera-deploy/actions/runs/33733974499

## Test plan
- [ ] CI passes (workflow YAML change only)
- [ ] Next scheduled run at 09:30 UTC resolves the `dakera` server release without exit code 22