### PR TITLE
fix(watchdog): remove chmod from :ro mount to stop crash-loop (DAK-9918)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       - DAKERA_WATCHDOG_RESTART_AFTER=${DAKERA_WATCHDOG_RESTART_AFTER:-5}
       - DAKERA_WATCHDOG_MEM_ALERT_PCT=${DAKERA_WATCHDOG_MEM_ALERT_PCT:-90}
       - DAKERA_WATCHDOG_POLL_SECS=${DAKERA_WATCHDOG_POLL_SECS:-30}
-    command: ["sh", "-c", "chmod +x /usr/local/bin/dakera-watchdog.sh && /usr/local/bin/dakera-watchdog.sh"]
+    command: ["sh", "/usr/local/bin/dakera-watchdog.sh"]
     depends_on:
       - dakera
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Removes `chmod +x` from the watchdog container `command` in docker-compose.yml
- The script is mounted `:ro` — `chmod +x` on a read-only bind mount always fails with "Read-only file system" (exit 1)
- With `restart: unless-stopped`, this produced an endless crash-loop consuming system resources
- `sh script` invocation never needs an executable bit — the fix is a one-liner

## Context

This was applied live on prod during the DAK-9918 incident investigation, but was mistakenly omitted from PR#278 (which only committed the `distribution-freshness.yml` GH_PAT_PACKAGES fix). Without this commit, the next git-based deploy would revert the production container to the crashing state.

## Test plan

- [ ] Verify `docker compose up -d` starts `dakera-watchdog` without crash-loop
- [ ] Confirm `docker logs dakera-watchdog` shows `[watchdog] Starting.` instead of immediate exit
- [ ] Confirm no `chmod: Read-only file system` errors in watchdog logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)