### PR TITLE
fix(monitor): check @dakera-ai/dakera-mcp on npm, not unscoped package (DAK-9942)

### DIFF
--- a/.github/workflows/distribution-freshness.yml
+++ b/.github/workflows/distribution-freshness.yml
@@ -75,15 +75,15 @@ jobs:
           echo "mcp_version=$MCP_VERSION" >> "$GITHUB_OUTPUT"
           echo "Homebrew dk: $DK_VERSION | dakera-mcp: $MCP_VERSION"
 
-      - name: Check npm (dakera-mcp)
+      - name: Check npm (@dakera-ai/dakera-mcp)
         id: npm
         run: |
-          NPM_DATA=$(curl -sf "https://registry.npmjs.org/dakera-mcp/latest" 2>/dev/null || echo '{}')
-          NPM_VERSION=$(echo "$NPM_DATA" | jq -r '.version // "unknown"')
-          NPM_TIME=$(echo "$NPM_DATA" | jq -r '.time.modified // "1970-01-01T00:00:00Z"' 2>/dev/null || echo "1970-01-01T00:00:00Z")
+          NPM_META=$(curl -sf "https://registry.npmjs.org/@dakera-ai%2fdakera-mcp" 2>/dev/null || echo '{}')
+          NPM_VERSION=$(echo "$NPM_META" | jq -r '."dist-tags".latest // "unknown"')
+          NPM_TIME=$(echo "$NPM_META" | jq -r --arg v "$NPM_VERSION" '.time[$v] // .time.modified // "1970-01-01T00:00:00Z"')
           echo "version=$NPM_VERSION" >> "$GITHUB_OUTPUT"
           echo "published=$NPM_TIME" >> "$GITHUB_OUTPUT"
-          echo "npm dakera-mcp: $NPM_VERSION"
+          echo "npm @dakera-ai/dakera-mcp: $NPM_VERSION"
 
       - name: Check Helm chart (dakera-helm)
         id: helm


### PR DESCRIPTION
## Root Cause

The Distribution Freshness Monitor was querying `https://registry.npmjs.org/dakera-mcp/latest` — an **unscoped** package that does not exist on npm (404). The actual published package is `@dakera-ai/dakera-mcp` (scoped).

This caused `npm-mcp` to always report STALE (1970-01-01 fallback date → ~20,000 day lag), keeping the monitor red for 26h even after the v0.10.12 npm publish succeeded at 2026-09-03T16:57Z (run https://github.com/Dakera-AI/dakera-mcp/actions/runs/33781648288).

## Fix

Query the full package metadata endpoint for `@dakera-ai/dakera-mcp` instead:
- URL: `https://registry.npmjs.org/@dakera-ai%2fdakera-mcp` (full metadata, not `/latest`)
- Extract `dist-tags.latest` for version: `"0.10.12"` ✅
- Extract `time[version]` for publish date: `"2026-09-03T16:57:14.632Z"` ✅
- Lag at time of fix: 0 days → **OK** (threshold: 7 days)

## Verification

```bash
curl -sf "https://registry.npmjs.org/@dakera-ai%2fdakera-mcp" | jq '{version: ."dist-tags".latest, published: .time[."dist-tags".latest]}'
# {"version": "0.10.12", "published": "2026-09-03T16:57:14.632Z"}
```

All other channels confirmed fresh (≤1 day lag):
- homebrew-dk: v0.7.1 (2026-09-03) ✅
- homebrew-mcp: v0.10.12 (2026-09-03) ✅  
- helm-chart: appVersion 0.11.107 (2026-09-03) ✅
- apt/deb-cli: v0.7.1 (2026-09-03) ✅

## Test Plan
- [ ] Merge to main
- [ ] Trigger `workflow_dispatch` on Distribution Freshness Monitor
- [ ] Confirm conclusion=success

DAK-9942